### PR TITLE
Refresh file list on upload completion

### DIFF
--- a/src/app/core/services/upload/upload.session.ts
+++ b/src/app/core/services/upload/upload.session.ts
@@ -111,8 +111,13 @@ export class UploadSession {
 
     try {
       this.statistics.current++;
+
       await this.uploader.uploadFile(item, progressHandler);
+
       this.statistics.completed++;
+      item.uploadStatus = UploadStatus.Done;
+      this.emitProgress(item);
+
       setTimeout(this.uploadNextInQueue, 0);
     } catch (err: unknown) {
       item.uploadStatus = UploadStatus.Cancelled;


### PR DESCRIPTION
When addressing the multiple-uploads issue by adding upload sessions in PR #2, we missed a bit of accounting, and stopped sending upload complete messages for individual items in the queue. The upload progress UI worked fine, because it is not watching for those messages, but the upload services triggers a refresh of the file list on that message.

Emit a progress event for completing an upload, so that the file list refresh is triggered correctly.

PER-8029 Mdot changes to call the new API end points