### PR TITLE
Make new archive type labels clickable

### DIFF
--- a/src/app/core/components/my-archives-dialog/my-archives-dialog.component.html
+++ b/src/app/core/components/my-archives-dialog/my-archives-dialog.component.html
@@ -53,7 +53,7 @@
         <ng-container *ngSwitchCase="'new'">
           <form [formGroup]="newArchiveForm" class="dialog-form" (submit)="onNewArchiveFormSubmit(newArchiveForm.value)">
             <div class="dialog-form-field">
-              <label for="name">Archive Name</label>
+              <label class="row-label" for="name">Archive Name</label>
               <div class="dialog-inline-field">
                 <span>The</span>
                 <input type="text" class="form-control" id="newArchiveName" name="name"
@@ -63,14 +63,16 @@
               </div>
             </div>
             <div class="dialog-form-field">
-              <label for="email">Archive Type</label>
+              <label class="row-label" for="email">Archive Type</label>
               <div class="form-check" *ngFor="let typeOption of archiveTypes">
-                <input type="radio" class="form-check-input" formControlName="type" [value]="typeOption.value">
-                <div class="form-check-label">{{typeOption.text}}</div>
+                <label class="form-check-label">
+                  <input type="radio" class="form-check-input" formControlName="type" [value]="typeOption.value">
+                  {{typeOption.text}}
+                </label>
               </div>
             </div>
             <div class="dialog-form-field" *ngIf="newArchiveForm.value.type === 'type.archive.person'">
-              <label for="relation">Connection</label>
+              <label class="row-label" for="relation">Connection</label>
               <select name="relation" class="form-control" formControlName="relationType">
                 <option value="" disabled selected>Choose connection (optional)</option>
                 <option [value]="relation.value" *ngFor="let relation of relationTypes">{{relation.text}}</option>

--- a/src/styles/_dialog.scss
+++ b/src/styles/_dialog.scss
@@ -155,7 +155,7 @@ $header-height: 3 * $grid-unit;
     display: flex;
     align-items: center;
 
-    label {
+    .row-label {
       flex: 0 0 $labelWidth;
       font-weight: $font-weight-bold;
       margin: 0;


### PR DESCRIPTION
## Description

While going through the upload test plan, I noticed a small UI bug: I couldn't click on the archive type labels! It turns out they weren't actually `<label>`s.

Improve the accessibility and usability of the new archive page by connecting the names of each different archive type to their radio buttons via labels.

To prevent them from becoming bold, give the label-element rule a name and apply it to the labels that need it.

![Clickable labels](https://user-images.githubusercontent.com/1494855/106532838-d7553880-64a5-11eb-9910-2e0827c5b4ba.gif)


## Steps to Test

Open the user menu in the top right, click archives, switch to the new archive tab, and click on the newly clickable labels!