### PR TITLE
Upload next in queue regardless of success

### DIFF
--- a/src/app/core/services/upload/upload.session.ts
+++ b/src/app/core/services/upload/upload.session.ts
@@ -117,8 +117,6 @@ export class UploadSession {
       this.statistics.completed++;
       item.uploadStatus = UploadStatus.Done;
       this.emitProgress(item);
-
-      setTimeout(this.uploadNextInQueue, 0);
     } catch (err: unknown) {
       item.uploadStatus = UploadStatus.Cancelled;
       this.statistics.error++;
@@ -135,5 +133,6 @@ export class UploadSession {
         );
       }
     }
+    setTimeout(this.uploadNextInQueue, 0);
   };
 }


### PR DESCRIPTION
This fixes one oversight that's to blame for disappearing upload sessions. As written, when an item successfully uploads, the queue is triggered to continue. If it fails, however, nothing happens, and the session is left in an `inProgress` state with the queue abandoned. Future attempted uploads fail even though they are added to the queue because nothing is triggered the next upload from the queue. So uploads remain broken until refresh. Not great!

This change makes sure that the next upload in the queue is always attempted, regardless of success or failure, which will continue until there are no more items in the queue, at which point the session resets, and any future uploads are free to start a new session.

A zero-byte file always triggers an error currently, so to test, upload a few files with a zero-byte file somewhere in the middle of the list. All files that are not empty/zero-byte should succeed despite the empty file failing.
