### PR TITLE
Add loading status to UploadSession

### DIFF
--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -110,6 +110,8 @@ export class UploadService implements HasSubscriptions, OnDestroy {
   async uploadFolders(parentFolder: FolderVO, items: DataTransferItem[]) {
     this.debug('uploadFolders %d items to folder %o', items.length, parentFolder);
 
+    this.uploadSession.startSession();
+
     const self = this;
     const foldersByPath: Map<string, FileSystemFolder> = new Map();
     const filesByPath: Map<string, FileWithPath[]> = new Map();


### PR DESCRIPTION
When dragging and dropping, the first UploadSessionStatus event isn't emitted until the very first file actually begins uploading. For a flat list of files, this doesn't cause any issues, but when dragging any number of folders or subfolders, there would be a period of zero UI feedback while the API call to create the needed folders was executing before there was any indication that the upload was about to begin.

This adds a new `Loading` status which gets triggered immediately after releasing the dragged-and-dropped files and folders. This ensures that regardless of how long the folder creation (or any other async actions) take to complete, the UI will have responded in some capacity and the user isn't left wondering if things froze.

To test, drag and drop any combination of folders and subfolders onto the file list, and the "Connecting..." message in the right-hand corner should immediately display.