### PR TITLE
PER-8261: Make tags case sensitive

### DIFF
--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -17,7 +17,8 @@ export class SearchService {
 
   private tagsFuseOptions: Fuse.IFuseOptions<ItemVO> = {
     keys: ['name'],
-    threshold: 0.1
+    threshold: 0.1,
+    isCaseSensitive: true
   };
   private tagsFuse = new Fuse([], this.tagsFuseOptions);
 


### PR DESCRIPTION
## Description
Tags need to be case sensitive to match Library of Congress standards, and specifically for a partner of ours.  

This PR adds case-sensitive search for tags.  The tag search by default was case insensitive, but "Fuse" has an option for case sensitivity, so this turns that on.  See https://fusejs.io/api/options.html if you're interested.

Resolves PER-8261, with https://bitbucket.org/permanent-org/api/pull-requests/325/per-8261-make-tags-case-sensitive.


## Steps to Test
- Create a tag, e.g. "dog"
- Create a tag with different capitalization, e.g. "Dog"
- Both should be created.  This is specifically a change in the search, so you shouldn't see "dog" as an option to autofill for "Dog."

