### PR TITLE
PER-8323: Handle null items in share list

### DIFF
--- a/src/app/models/archive-vo.ts
+++ b/src/app/models/archive-vo.ts
@@ -41,12 +41,8 @@ export class ArchiveVO extends BaseVO implements DynamicListChild  {
 
     if (this.ItemVOs && this.ItemVOs.length) {
       // remove null items
-      this.ItemVOs = this.ItemVOs.filter((item) => {
-        if (item.type === null) {
-          return false;
-        }
-        return true;
-      }).map((item) => {
+      this.ItemVOs = this.ItemVOs.filter((item) => item.type !== null)
+        .map((item) => {
         if (item.type.includes('folder')) {
           return new FolderVO(item, false, DataStatus.Lean);
         } else {


### PR DESCRIPTION
Previously, any null items (caused at least once by improper manual
deletion, but possible in general) in an archive's share list would
cause the share tab to freeze.  Remove these null items before mapping
shares so that any existing shares will still load.

Resolves PER-8323.

## Steps to Test
This is easiest to do locally:

- Choose a record in an archive (Archive 1) and share it with another archive (Archive 2).
- Verify that it appears in the "Shares" folder of Archive 2.
- Find the record in the database and make note of its recordId.
- Run `update record set record.status = 'status.generic.deleted', record.updatedDT = NOW() where recordId = $RECORDID;`
- Try to load the "Shares" folder of Archive 2.  Before this PR it will freeze and after it will load properly.

It's best to verify this with other, valid, records still in the Shares folder.  If this is working correctly then those will still appear.