### PR TITLE
PER-8332: Properly redirect to MFA page when logging in from share preview

### DIFF
--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -426,7 +426,7 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
             this.accountService.setRedirect(['/share', 'invite' , this.sharePreviewVO.token, 'view']);
           }
 
-          this.router.navigate(['/auth', 'mfa'], { queryParamsHandling: 'preserve' })
+          this.router.navigate(['/app', 'auth', 'mfa'], { queryParamsHandling: 'preserve' })
             .then(() => {
               this.message.showMessage(`Verify to continue as ${this.accountService.getAccount().primaryEmail}.`, 'warning');
             });


### PR DESCRIPTION
## Description
This PR fixes a bug with the log in process on the share preview page where the MFA page isn't properly redirected to.

Resolves PER-8332.

## Steps to Test
- When logged into an account, create a share link for an item in your archive. 
- Copy the share link. I recommend opening up a text editor window and pasting the link in there so you don't lose the link when you copy MFA codes. Also, make sure to change the domain of the link to the local front end dev server's domain if necessary (from `local.permanent.org` to `ng.permanent.org:4200`).
- Open up an incognito/private browsing window (or log out and clear all cookies/session variables for the local domain) and navigate to the share link.
- Log in to an account. Without this PR the login process will break and ask you to log in two times (and send 2 verification codes), with this PR you will be redirected immediately to the MFA page.

Extra fix to test:
- In a new incognito/private browsing window (or with freshly cleared cookies), begin the login process from the normal login page of the app, but *don't* enter in your MFA code.
- When the MFA prompt comes up, navigate to the share link you got earlier.
- You should be redirected *back* to the MFA page when you put in this share link. Before this PR, you would instead be shown a general error page.
- After logging in from here you will be redirected to the share page.