### PR TITLE
PER-8305: Show thumbnails on folders on public

### DIFF
--- a/src/app/file-browser/components/file-list-item/file-list-item.component.html
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.html
@@ -5,17 +5,17 @@
   (mouseenter)="onItemMouseEnterLeave($event)" (mouseleave)="onItemMouseEnterLeave($event, false)"
   (dragenter)="onItemMouseEnterLeave($event)" (dragleave)="onItemMouseEnterLeave($event, false)"
   inViewport (inViewportAction)="onIntersection($event)" [inViewportOptions]="{ threshold: [0], rootMargin: '100px' }">
-  <ng-container *ngIf="!isInPublicArchive; else public_view" [ngSwitch]="item.isFolder">
-    <div [ngClass]="{'file-list-item-folder-icon': item.isFolder, 'public-view': isInPublicArchive}" *ngSwitchCase="true">
-      <i class="material-icons">folder</i>
-    </div>
+  <ng-container [ngSwitch]="item.isFolder">
+    <ng-container *ngSwitchCase="true">
+      <div class="file-list-item-folder-icon" *ngIf="!inGridView">
+        <i class="material-icons">folder</i>
+      </div>
+      <div prBgImage [bgSrc]="!showFolderIcon() && getThumbnailPath()" [cover]="inGridView" class="file-list-item-folder-icon" *ngIf="inGridView">
+        <i *ngIf="showFolderIcon()" class="material-icons">{{ folderContentsType }}</i>
+      </div>
+    </ng-container>
     <div *ngSwitchDefault prBgImage [bgSrc]="!inGridView ? item.thumbURL200 : item.thumbURL500" [cover]="inGridView"></div>
   </ng-container>
-  <ng-template #public_view>
-    <div prBgImage [bgSrc]="getThumbnailPath()" [cover]="inGridView" [ngClass]="{'file-list-item-folder-icon': item.isFolder, 'public-view': isInPublicArchive}">
-      <i *ngIf="showFolderIcon()" class="material-icons">{{ folderContentsType }}</i>
-    </div>
-  </ng-template>
   <div class="grid-item-type-icon" @ngIfFadeInAnimation
     *ngIf="inGridView && item.isFolder ? item.view : true">
     <i class="material-icons">{{item | itemTypeIcon:item.view}}</i>

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.scss
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.scss
@@ -271,14 +271,12 @@ $bg-transition-length: 0.075s;
     position: relative;
     font-size: 8rem;
     > i {
+      font-size: 7rem;
       position: absolute;
       top: 0;
       bottom: 0;
       display: flex;
       align-items: center;
-    }
-    &.public-view > i {
-      font-size: 7rem;
     }
   }
 }

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -206,6 +206,10 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
       this.isInMyPublic = true;
     }
 
+    if (this.item.isFolder) {
+      this.getFolderThumbnail();
+    }
+
     const data = this.route.snapshot.data as RouteData;
 
     if (data.isPublic) {
@@ -213,9 +217,6 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
     }
 
     if (data.isPublicArchive) {
-      if (this.item.isFolder) {
-        this.getFolderThumbnail();
-      }
       this.isInPublicArchive = true;
     }
 
@@ -844,9 +845,11 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
       if (resp.isSuccessful) {
         const newFolderVO = resp.Results[0].data[0].FolderVO as FolderVO;
         const allChildren = newFolderVO.ChildItemVOs;
-        const [thumbnailItem] = newFolderVO.ChildItemVOs.filter(item => item.type.includes('type.record')).sort((a, b) => {
+        const sortedItems = newFolderVO.ChildItemVOs.filter(item => item.type.includes('type.record'));
+        sortedItems.sort((a, b) => {
           return calculateSortPriority(a) - calculateSortPriority(b);
         });
+        const thumbnailItem = sortedItems.shift();
         if (thumbnailItem) {
           if (sortPriorities.includes(thumbnailItem.type)) {
             if (thumbnailItem.thumbURL200 && thumbnailItem.thumbURL500) {
@@ -877,7 +880,7 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
     if (this.showFolderIcon()) {
       return '';
     }
-    if (this.item.isFolder && this.isInPublicArchive && (this.folderThumb200 || this.folderThumb500)) {
+    if (this.item.isFolder && (this.folderThumb200 || this.folderThumb500)) {
       return this.inGridView ? this.folderThumb500 : this.folderThumb200;
     } else {
       return this.inGridView ? this.item.thumbURL500 : this.item.thumbURL200;
@@ -885,6 +888,6 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
   }
 
   private showFolderIcon(): boolean {
-    return this.folderContentsType !== FolderContentsType.NORMAL;
+    return this.item.isFolder && this.folderContentsType !== FolderContentsType.NORMAL;
   }
 }


### PR DESCRIPTION
## Description
This PR adds thumbnails to the folders on public gallery pages. In the normal file browser, folders should still not have thumbnails, this should only have an effect on the actual public archive view. Currently this implementation just takes the first item in the folder (or rather whatever the API gets first) and uses its thumbnail.

The folder icon that used to be the only thing displayed on folders has also been increased in size and given a slight drop shadow effect to make the item more distinguishable as a folder when a thumbnail is being displayed.

Empty folders on public gallery pages should display almost exactly the same as before, although with the increased icon size and drop shadow also applied.

Resolves PER-8305.

## Steps to Test
- Make sure you have a public gallery set up with folders.
- Go to the public link for your archive and look at the folders.
- Test empty folders, and maybe folders that have children with broken thumbnails. The application shouldn't throw any exceptions... hopefully!
- Also test to make sure no other folder views have changed elsewhere in the app.