### PR TITLE
PER-8378: Pass invite code from url param

### DIFF
--- a/src/app/auth/components/signup/signup.component.spec.ts
+++ b/src/app/auth/components/signup/signup.component.spec.ts
@@ -42,7 +42,7 @@ describe('SignupComponent', () => {
               queryParams: {
                 fullName: window.btoa(TEST_DATA.user.name),
                 primaryEmail: window.btoa(TEST_DATA.user.email),
-                inviteCode: window.btoa('invite')
+                inviteCode: 'invite'
               }
             }
           }

--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -59,7 +59,7 @@ export class SignupComponent implements OnInit {
     }
 
     if (params.inviteCode) {
-      inviteCode = window.atob(params.inviteCode);
+      inviteCode = params.inviteCode;
     }
 
     if (params.shid && params.tp) {


### PR DESCRIPTION
## Description

This PR fixes PER-8378.

We want to link to the signup form from various pages on the new
marketing site.  Many of these will have different signup codes so
that we can easily tell where new signups come from.  This change
makes the signup code in the url param persist through existing code
until it is stored in the database (in the `invite` table).  It also
makes the invitation code *appear* in the form, where it could be
altered by the new user.  That change requires some QA, since I'm not
sure if it's desired or not (or if it matters).

## Steps to Test
Create a url like https://ng.permanent.org:4200/app/auth/signup?inviteCode={CODE}, where "CODE" is replaced by a value in the `codeName` field of the `invite_codes` table in your local database.  See that the code appears in the signup form "Invitation code" field.  Continue through the signup process.  Once you're done, you should see the code in the `token` field of the `invite` table of the database for the entry corresponding to this new account.