### PR TITLE
Change cannotCopyToFolder from protected to public

### DIFF
--- a/src/app/core/components/folder-picker/folder-picker.component.ts
+++ b/src/app/core/components/folder-picker/folder-picker.component.ts
@@ -197,6 +197,10 @@ export class FolderPickerComponent implements OnInit, OnDestroy {
     this.folderPickerService.unregisterComponent();
   }
 
+  public cannotCopyToFolder(): boolean {
+    return this.isRootFolder || (this.currentFolder?.type.includes('root.app'));
+  }
+
   protected setChosenFolder(): void {
     if (this.selectedRecord) {
       this.chooseFolderDeferred.resolve(this.selectedRecord);
@@ -221,9 +225,5 @@ export class FolderPickerComponent implements OnInit, OnDestroy {
 
   protected shouldConfirmFolderSelection(): boolean {
     return this.currentFolder.type.endsWith('public');
-  }
-
-  protected cannotCopyToFolder(): boolean {
-    return this.isRootFolder || (this.currentFolder?.type.includes('root.app'));
   }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue introduced in #25 that breaks the build.

## Steps to Test
- Run `npm run build` and see that it builds without errors.