### PR TITLE
PER-8378: Hide invitation code from users

### DIFF
--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -26,7 +26,7 @@ export class SignupComponent implements OnInit {
   signupForm: FormGroup;
   waiting: boolean;
 
-  showInviteCode = true;
+  showInviteCode = false;
   isForShareInvite = false;
 
   shareArchiveNbr: string;
@@ -64,13 +64,11 @@ export class SignupComponent implements OnInit {
 
     if (params.shid && params.tp) {
       this.isForShareInvite = true;
-      this.showInviteCode = false;
 
       const responseData = this.route.snapshot.data.shareInviteData;
 
       if (!responseData) {
         this.isForShareInvite = false;
-        this.showInviteCode = true;
       } else {
         const itemData: RecordVOData | FolderVOData = {
           archiveNbr: responseData.recArchiveNbr,


### PR DESCRIPTION
When I showed this to the team, we decided that hiding the invitation
code field altogether was less likely to cause confusion for users.

## Steps to Test
Construct a url like https://ng.permanent.org:4200/app/auth/signup?inviteCode=[CODE] where the CODE exists in the `invite_codes` table on your local machine.  The "invitation code" field should not appear on the signup form, but when the user is created it should have the appropriate code in the `invite` table in the database.

One thing I'm a little concerned about is that if you make a url with an invalid code the user will get an error about the code not working but will have no way to fix it.  Ideas?
