### PR TITLE
PER-8360: Remove Apps/Vault from dialog for now

### DIFF
--- a/src/app/core/components/folder-picker/folder-picker.component.ts
+++ b/src/app/core/components/folder-picker/folder-picker.component.ts
@@ -136,6 +136,8 @@ export class FolderPickerComponent implements OnInit, OnDestroy {
     if (this.filterFolderLinkIds && this.filterFolderLinkIds.length) {
       remove(this.currentFolder.ChildItemVOs, (f: ItemVO) => this.filterFolderLinkIds.includes(f.folder_linkId));
     }
+    remove(this.currentFolder.ChildItemVOs, (item) => item.type.includes('type.folder.root.app'));
+    remove(this.currentFolder.ChildItemVOs, (item) => item.type.includes('type.folder.root.vault'));
 
     } catch (err) {
       if (err instanceof FolderResponse) {


### PR DESCRIPTION
## Description
This PR removes the Apps/Vaults folder from the move/copy dialog.

## Steps to Test
- Try to move/copy a file.
- Note that Apps/Vaults folder do not show up at the archive root anymore.