### PR TITLE
Use get instead of getByArchiveNbr

### DIFF
--- a/src/app/public/resolves/public-archive-resolve.service.ts
+++ b/src/app/public/resolves/public-archive-resolve.service.ts
@@ -3,6 +3,7 @@ import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@a
 
 import { ApiService } from '@shared/services/api/api.service';
 import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
+import { ArchiveVO } from '@models';
 
 @Injectable()
 export class PublicArchiveResolveService implements Resolve<any> {
@@ -13,7 +14,7 @@ export class PublicArchiveResolveService implements Resolve<any> {
 
   async resolve( route: ActivatedRouteSnapshot, state: RouterStateSnapshot ) {
     const archiveNbr = route.params.publicArchiveNbr;
-    const response = await this.api.archive.getByArchiveNbr([archiveNbr]);
+    const response = await this.api.archive.get([new ArchiveVO({archiveNbr})]);
     this.publicProfile.setArchive(response.getArchiveVO());
   }
 }


### PR DESCRIPTION
I removed getByArchiveNbr as part of the Etherpad work, thinking that
it was never used and was a duplicate of archive/get.  It was used,
though, by web-app, to resolve public archives.  After pushing out the
back-end change, public archives broke.  This fixes them by changing
the call to use archive/get instead.  There will be some followup
cleanup.

## Steps to Test
Go to your Public folder, choose an item, click "get link," and "view on web."  Without this change, it will hang.  With it, you'll get to the item in your public gallery.
