### PR TITLE
Remove getByArchiveNbr (hotfix cleanup)

### DIFF
--- a/src/app/shared/services/api/archive.repo.ts
+++ b/src/app/shared/services/api/archive.repo.ts
@@ -17,18 +17,6 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>('/archive/get', data, ArchiveResponse);
   }
 
-  public getByArchiveNbr(archiveNbrs: string[]): Promise<ArchiveResponse> {
-    const data = archiveNbrs.map((archiveNbr) => {
-      return {
-        ArchiveVO: new ArchiveVO({
-          archiveNbr
-        })
-      };
-    });
-
-    return this.http.sendRequestPromise<ArchiveResponse>('/archive/getByArchiveNbr', data, ArchiveResponse);
-  }
-
   public getAllArchives(accountVO: AccountVO): Promise<ArchiveResponse> {
     const data = [{
       AccountVO: {


### PR DESCRIPTION
The back-end endpoint for this function no longer exists and I removed
the only call to it in 67b6222, so remove the function altogether.

