### PR TITLE
PER-8405: Change helptext for deletion

### DIFF
--- a/src/app/core/components/settings-dialog/settings-dialog.component.html
+++ b/src/app/core/components/settings-dialog/settings-dialog.component.html
@@ -36,10 +36,13 @@
             Please note: deleting your account will remove all reference to personally identifiable and contact information as well as payment options you have provided to us in your account settings.
           </p>
           <p>
-            The account deletion action will not delete any archives that you own or personally identifiable information in the records stored in those archives.You must delete archives using the delete archive action in the Profile section of each archive you own.
+            The account deletion action will not delete any archives that you own or personally identifiable information in the records stored in those archives. You must delete archives using the delete archive function under the Archives account menu item.
           </p>
           <p>
             Any archives you own that are not deleted prior to deleting your account will become orphaned archives.
+          </p>
+          <p>
+            <a href="https://desk.zoho.com/portal/permanent/en/kb/articles/how-to-delete-an-archive">Learn more here.</a>
           </p>
           <p>
             When you are ready, type ‘DELETE’ in all caps and press confirm below to confirm account deletion.


### PR DESCRIPTION
Note that we don't have a good solution for making links obvious in
CSS (I don't think?).  @meisekimiu if we do please enlighten me!

The KB article does not yet exist, which is a prereq for
merging/deploying this.

Also, is there no way to delete a default archive?

 Resolves PER-8405.

## Steps to Test
Click into Account from the top right menu and then choose the Delete Account option in the modal.  You should see the new text, including a link to a Knowledge Base article.

Pending QA.
