### PR TITLE
PER-8399: Cache folder thumbnails

### DIFF
--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -32,7 +32,7 @@ import { ngIfFadeInAnimation } from '@shared/animations';
 import { InViewportTrigger } from 'ng-in-viewport';
 import { RouteData } from '@root/app/app.routes';
 
-import { ThumbnailCache } from './thumbnail-cache/thumbnail-cache';
+import { ThumbnailCache } from '@shared/utilities/thumbnail-cache/thumbnail-cache';
 
 export const ItemActions: {[key: string]: PromptButton} = {
   Rename: {

--- a/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
+++ b/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
@@ -67,6 +67,10 @@ describe('ThumbnailCache', () => {
       expect(folderContentsType).toBe(icon);
     }
   });
+  it('should be able to clear the cache for a specific folder', () => {
+    cache.invalidateFolder(1234);
+    expect(cache.hasThumbnail(folder)).toBeFalse();
+  });
   describe('malformed session storage', () => {
     it('handles completely invalid session storage value', () => {
       storage.session.set('folderThumbnailCache', 'potato');

--- a/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.ts
+++ b/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.ts
@@ -59,6 +59,13 @@ export class ThumbnailCache {
     return this.cache.has(item.folder_linkId);
   }
 
+  public invalidateFolder(folderLinkId: number): void {
+    if(this.cache.has(folderLinkId)) {
+      this.cache.delete(folderLinkId);
+      this.saveMapToStorage();
+    }
+  }
+
   private fetchCacheMapFromStorage(): void {
     const cacheData = this.storage.session.get(this.STORAGE_KEY);
     if (cacheData && Array.isArray(cacheData)) {


### PR DESCRIPTION
## Description
This PR fixes some performance issues with folder thumbnails in grid view (including public galleries). Default folder thumbnails are now no longer the default placeholder image while we're waiting for the "real" thumbnail to load. In addition, thumbnails are now cached in session storage.

## Steps to Test
- Clear your cache and session storage.
- Go to a public gallery or enable grid view in web app.
- Check that the `getWithChildren` endpoint is called for each folder on the first load.
- Refresh the page.
- Check that the `getWithChildren` endpoint is no longer called for these cached folders, and thumbnails load quickly.

This PR now makes folder thumbnails load before record thumbnails if they're cached, which might be a bit jarring but... yay performance?