### PR TITLE
PER-8416: Make links more obvious

### DIFF
--- a/src/app/core/components/left-menu/left-menu.component.scss
+++ b/src/app/core/components/left-menu/left-menu.component.scss
@@ -44,6 +44,7 @@ $archive-options-shadow-offset: 0.5rem;
     user-select: none;
     color: white;
     font-weight: 700;
+    text-decoration: none;
 
     transition: background-color $transition-length / 4 ease-in;
 
@@ -109,6 +110,7 @@ $archive-options-shadow-offset: 0.5rem;
     align-items: center;
     justify-content: flex-end;
     color: white;
+    text-decoration: none;
 
     &:hover {
       background: darken($PR-blue-light, 7%);
@@ -225,6 +227,7 @@ $archive-options-shadow-offset: 0.5rem;
       font-size: $font-size-sm;
       user-select: none;
       color: white;
+      text-decoration: none;
 
       &:hover:not(.active) {
         text-decoration: none;

--- a/src/app/shared/components/account-dropdown/account-dropdown.component.scss
+++ b/src/app/shared/components/account-dropdown/account-dropdown.component.scss
@@ -68,6 +68,7 @@ i.badge {
     text-align: right;
     align-items: center;
     justify-content: flex-end;
+    text-decoration: none;
 
     &:hover {
       background-color: darken(white, 4%);

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.scss
@@ -27,6 +27,7 @@ pr-breadcrumb {
 
   a {
     color: white;
+    text-decoration: none;
   }
 
   .current {

--- a/src/styles/_ui.scss
+++ b/src/styles/_ui.scss
@@ -3,6 +3,7 @@ button.btn, a.btn {
   margin: 10px auto;
   width: 100%;
   max-width: $max-form-width;
+  text-decoration: none;
 }
 
 .input-group {
@@ -163,8 +164,9 @@ nav .btn {
   word-break: break-all;
 }
 
-a {
+a:link {
   cursor: pointer;
+  transition: color 0.3s;
 }
 
 .btn-wordpress, .btn-wordpress-alternate {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -161,5 +161,11 @@ $ionicons-font-path: 'https://unpkg.com/ionicons@4.6.3/dist/fonts';
 @import 'vendor/bootstrap/variables';
 @import 'utilities';
 
+// Customizations to Bootstrap Variables
+$link-color:                lighten(theme-color("primary"), 20%);
+$link-decoration:           underline;
+$link-hover-color:          lighten($link-color, 20%);
+$link-hover-decoration:     none;
+
 @import 'dialog';
 @import 'profile';


### PR DESCRIPTION
## Description
This PR updates the default style for links to make them <span title="read: actually noticeable">more obvious</span> and updates CSS for various components like buttons where we probably don't want them to be affected by these changes.

This is waiting on QA, but we should also verify that this doesn't change any other UI elements in the meantime.

Resolves PER-8416.

## Steps to Test
- Check that links are updated and noticeable.
- Verify that any other UI elements that use `<a>` tags are unchanged, and that this only affects links in text.