### PR TITLE
PER-8435: Ignore Sentry's ResizeObserver error

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,9 @@ declare var ga: any;
 if (environment.environment !== 'local') {
   Sentry.init({
     dsn: 'https://5cb2f4943c954624913c336eb10da4c5@o360597.ingest.sentry.io/5285675"',
+    ignoreErrors: [
+      'ResizeObserver loop limit exceeded',
+    ],
     integrations: [new Sentry.Integrations.TryCatch({
       XMLHttpRequest: false,
     })],
@@ -215,4 +218,3 @@ export class AppModule {
       });
   }
 }
-


### PR DESCRIPTION
## Description
This PR configures Sentry to ignore the following error: `ResizeObserver loop limit exceeded`. After doing some research, it seems like this is an error in Sentry's monitoring system where lag can interrupt monitoring for viewport resize events. I'm not sure how to actually recreate this issue since it seems to be tied to very specific browser events. This is not fixable on our side (it's an error with Sentry and the tools it uses) and also a completely harmless error which just means that some data was not able to be recorded by Sentry for a bit of time. As such, I think it's best to ignore it, and specifically configure Sentry to ignore it so the error data isn't ever sent in the first place.

If this PR is approved and merged, I will also mark the error as ignored/resolved on our Sentry page as well.

Resolves Jira#PER-8435 and Sentry#MDOT-6A.

## Steps to Test
- Compare the error message on Sentry to the error message being ignored in the config?
