### PR TITLE
Log claim storage errors to Sentry

### DIFF
--- a/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts
+++ b/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts
@@ -129,16 +129,13 @@ export class ClaimStorageLoginComponent implements OnInit {
     try {
       await this.pledgeService.linkAccount(account);
       const billingResponse = await this.api.billing.claimPledge(payment, pledgeId);
-      this.waiting = false;
       if (billingResponse.isSuccessful) {
         this.router.navigate(['..', 'done'], {relativeTo: this.route});
       } else {
-        console.error(billingResponse);
+        throw billingResponse;
       }
-    } catch (err) {
+    } finally {
       this.waiting = false;
-      console.error(err);
     }
   }
-
 }


### PR DESCRIPTION
Rather than dump error messages in the browser console, where users are unlikely to see them and developers are unable to see them, instead use our global Sentry unhandled-exception-handler to report issues during the claim storage workflow.

# Testing

It took a bit to test this. First I had to enable Sentry in local:

```diff
diff --git a/src/app/app.module.ts b/src/app/app.module.ts
index 7ffe0a95..c58e049f 100644
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,7 +33,6 @@ import { RouteHistoryService } from 'ngx-route-history';
 import { InViewportModule } from 'ng-in-viewport';
 declare var ga: any;
 
-if (environment.environment !== 'local') {
   Sentry.init({
     dsn: 'https://5cb2f4943c954624913c336eb10da4c5@o360597.ingest.sentry.io/5285675"',
     ignoreErrors: [
@@ -45,7 +44,6 @@ if (environment.environment !== 'local') {
     release: `mdot@${environment.release}`,
     environment: environment.environment
   });
-}
 
 
```

Then, I had to intentionally introduce some errors. On the front end, I added a call to an known invalid function:

```diff
diff --git a/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts b/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts
index 9ba2b803..c68035b6 100644
--- a/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts
+++ b/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts
@@ -127,6 +127,7 @@ export class ClaimStorageLoginComponent implements OnInit {
     const payment = this.pledgeService.createBillingPaymentVo(account);
 
     try {
+      console.err('not a function');
       await this.pledgeService.linkAccount(account);
       const billingResponse = await this.api.billing.claimPledge(payment, pledgeId);
       if (billingResponse.isSuccessful) {
```

On the back end, I caused the claim storage API call to fail:

```diff
diff --git a/api/controller/billing/billing.controller.php b/api/controller/billing/billing.controller.php
index 37de6be13..aab4ce03b 100644
--- a/api/controller/billing/billing.controller.php
+++ b/api/controller/billing/billing.controller.php
@@ -167,7 +167,7 @@ class BillingController extends BaseController
         core\SessionBO::CheckCSRF($this->getRequestVO()->getCsrf());
         core\SessionBO::CheckHasAccess(ACCESS_ACTION_CREATE);
 
-        if(core\SessionBO::CheckIsARoleMinor())
+        if(!core\SessionBO::CheckIsARoleMinor())
         {
             throw new core\ApiException(definition\PermConstants::WARNING_AUTH_RESTRICTION_YOU_ARE_A_MINOR, 0, null, "Space can't be bought by minors");
         }
```

To test, you need an unclaimed pledge; you can either create one by pledging normally, or look through the [Firebase dev database](https://console.firebase.google.com/u/1/project/prpledgedev/database/prpledgedev/data) for pledges with `"claimed": true`. Then, in a browser session where you're logged in to Permanent, go to `https://ng.permanent.org:4200/app/pledge/pledge/claim?pledgeId=${pledgeId}` (or `https://local.permanent.org/app/pledge/pledge/claim?pledgeId=${pledgeId}`, depending on how your environment is set up), click "Already logged in?", click the claim storage button, and verify that the expected error is sent to Sentry.

[PER-8476 Report more errors to Sentry](https://permanent.atlassian.net/browse/PER-8476)