### PR TITLE
PER-8493: Call renamed /tag/deleteTagLink endpoint

### DIFF
--- a/src/app/shared/services/api/tag.repo.ts
+++ b/src/app/shared/services/api/tag.repo.ts
@@ -19,7 +19,7 @@ export class TagRepo extends BaseRepo {
       TagLinkVO: tagLink
     }];
 
-    return this.http.sendRequestPromise<TagResponse>('/tag/delete', data, TagResponse);
+    return this.http.sendRequestPromise<TagResponse>('/tag/deleteTagLink', data, TagResponse);
   }
 
   public getTagsByArchive(archive: ArchiveVO): Promise<TagResponse> {


### PR DESCRIPTION
## Description
This PR features the front end change related to PER-8492, renaming the `/tag/delete` endpoint to `/tag/deleteTagLink`.

Resolves subtask PER-8493.

## Steps to Test
- Switch the back-end to the branch for PER-8492, `feature/PER-8492-renaming-the-endpoint-to-tag-de`.
- Verify that without this change, removing a tag from a record doesn't work with the renamed endpoint.
- Verify that with this change removing a tag works again.

These changes should be merged around the same time as PER-8492 is so they can be deployed together.