### PR TITLE
PER-8248: Show navigation style sooner in process

### DIFF
--- a/src/app/core/components/main/main.component.ts
+++ b/src/app/core/components/main/main.component.ts
@@ -62,7 +62,13 @@ export class MainComponent implements OnInit, AfterViewInit, OnDestroy, Draggabl
         } else if (event instanceof NavigationEnd) {
           this.isNavigating = false;
         }
+        this.setDocumentCursor();
       });
+
+    this.data.events.subscribe((event) => {
+      this.isNavigating = event;
+      this.setDocumentCursor();
+    });
 
     this.upload.progressVisible.subscribe((visible: boolean) => {
       this.uploadProgressVisible = visible;
@@ -327,5 +333,9 @@ export class MainComponent implements OnInit, AfterViewInit, OnDestroy, Draggabl
       this.upload.uploadFiles(targetFolder, Array.from(files));
     }
 
+  }
+
+  protected setDocumentCursor(): void {
+    document.body.style.cursor = this.isNavigating ? 'wait' : 'auto';
   }
 }

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -441,6 +441,7 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
     }
 
     if (this.item.dataStatus < DataStatus.Lean) {
+      this.dataService.beginPreparingForNavigate();
       if (!this.item.isFetching) {
         this.dataService.fetchLeanItems([this.item]);
       }

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -7,7 +7,7 @@ import { FolderVO, RecordVO, ItemVO, FolderVOData, RecordVOData, SortType } from
 import { DataStatus } from '@models/data-status.enum';
 import { FolderResponse, RecordResponse } from '@shared/services/api/index.repo';
 import { EventEmitter } from '@angular/core';
-import { Subject, BehaviorSubject } from 'rxjs';
+import { Subject, BehaviorSubject, Observable } from 'rxjs';
 import debug from 'debug';
 import { debugSubscribable } from '@shared/utilities/debug';
 import { TagsService } from '@core/services/tags/tags.service';
@@ -62,6 +62,9 @@ export class DataService {
   private currentHiddenItems: ItemVO[] = [];
 
   private unsharedItemSubject = new Subject<ItemVO>();
+
+  private eventSubject: Subject<boolean> = new Subject<boolean>();
+  public events: Observable<boolean> = this.eventSubject.asObservable();
 
   private debug = debug('service:dataService');
 
@@ -615,5 +618,9 @@ export class DataService {
     const item = this.itemToShowAfterNavigate;
     this.itemToShowAfterNavigate = null;
     return item;
+  }
+
+  public beginPreparingForNavigate() {
+    this.eventSubject.next(true);
   }
 }


### PR DESCRIPTION
## Description
(The bug fix here is a bit more abstract than usual... apologies if it's harder to follow.)

This PR fixes a bug where the UI sometimes does not immediately indicate its navigating to another folder when clicking into one. This bug is caused by the front end needing to fetch more information on that folder before being able to navigate to it, and until that information is actually fully fetched the UI does not actually indicate is loading or navigating. The code additions here trigger the UI to enter the greyed out "loading" state right when it fetches that additional information.

In more detail, an Item can have 3 different data statuses: Placeholder, Lean, and Full. A folder needs at least Lean status to be able to navigate to it without this bug triggering. If we try to navigate to a folder with the Placeholder status, we need to fetch a Lean version of it to actually even begin navigating to it (I'm assuming because we're missing data values to even construct the proper URL to navigate to). Sending and waiting for this API request does not trigger the greyed out loading state that navigation does, so it appears that nothing is happening in the UI for a moment. Check out the video in the Jira ticket for an example.

This PR also adds a slight UX change while loading: the user's mouse cursor is set to a waiting icon if the operating system supports it.

Resolves PER-8248.

## Steps to Test
- To test this properly, you need to try navigating to a folder that is still a "placeholder" in memory. This causes the UI to fetch more data on the folder before actually navigating to it. I'm not actually sure how to properly reproduce this, and for my own testing I simulated this by forcing folders into this state.
- Verify that the UI enters the greyed out loading state while loading the prerequisite data prior to actually entering the navigation state.
- Verify that the mouse cursor changes while loading.