### PR TITLE
Remove commented out HTML from component templates.

### DIFF
--- a/src/app/core/components/archive-switcher/archive-switcher.component.html
+++ b/src/app/core/components/archive-switcher/archive-switcher.component.html
@@ -1,7 +1,4 @@
 <div class="archive-list-wrapper">
-  <!-- <div class="current-archive">
-    <pr-archive-small [archive]="currentArchive"></pr-archive-small>
-  </div> -->
   <div class="archive-list">
     <div class="archive-list-title">Select archive to switch to:</div>
     <pr-archive-small *ngFor="let archive of archives"

--- a/src/app/embed/components/newsletter-signup/newsletter-signup.component.html
+++ b/src/app/embed/components/newsletter-signup/newsletter-signup.component.html
@@ -17,13 +17,6 @@
     <pr-form-input type="password" fieldName="password" placeholder="Password (min. 8 chars)" [control]="signupForm.controls['password']"
       [config]="{autocomplete: 'new-password', autocorrect: 'off', autocapitalize: 'off', spellcheck: 'off'}"></pr-form-input>
   </div>
-  <!-- <div class="form-check">
-      <input class="form-check-input" type="checkbox" id="terms"
-        formControlName="agreed">
-      <label class="form-check-label" for="terms">
-        I agree with the (required)</strong>
-      </label>
-    </div> -->
   <button type="submit" class="btn btn-alternate" [disabled]="waiting || signupForm.invalid" (click)="onSignupSubmit(signupForm.value)">
     Create Account
   </button>

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.html
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.html
@@ -19,11 +19,6 @@
       </div>
     </div>
   </div>
-  <!-- <div class="inline-value-controls" *ngIf="isEditing" @ngIfScaleAnimation>
-    <button class="btn btn-primary btn-sm" (click)="endEditing()">
-      Done
-    </button>
-  </div> -->
 </ng-container>
 <ng-container *ngIf="isDialog">
   <div class="dialog-content">

--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.html
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.html
@@ -48,7 +48,6 @@
         <span class="save-sort" (click)="saveSort()" *ngIf="canSaveSort"
           [ngbTooltip]="'fileList.sort.save' | prTooltip">Save</span>
       </div>
-      <!-- <div class="shared-icon" *ngIf="!showAccess"></div> -->
       <div class="type" *ngIf="!showAccess" [class.active-sort]="currentSort === 'type'" [class.sort-desc]="sortDesc">
         <span class="col-title" (click)="onSortClick('type')"
           [ngbTooltip]="getTooltipConstantForSort('type') | prTooltip">Type</span>

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.html
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.html
@@ -55,12 +55,4 @@
       <span class="right-menu-toggler-icon right-menu-toggler-icon-dark"></span>
     </button>
   </div>
-  <!-- <div class="multi-select" *ngIf="allowActions && multiSelect">
-    <div class="select" (click)="$event.stopPropagation()">
-      <label>
-        <input type="checkbox" [(ngModel)]="isMultiSelected" (ngModelChange)="onMultiSelectChange()">
-        <div class="select-active" *ngIf="isMultiSelected"></div>
-      </label>
-    </div>
-  </div> -->
 </div>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -1,8 +1,5 @@
 <div class="file-viewer" [ngClass]="{'minimal': useMinimalView}">
   <div class="file-viewer-close">
-    <!-- <button type="button" class="close" aria-label="Close" (click)="close()">
-      <span aria-hidden="true">&times;</span>
-    </button> -->
     <a (click)="close()">
       <i class="ion-md-arrow-dropleft"></i> Back
     </a>

--- a/src/app/file-browser/components/folder-view/folder-view.component.html
+++ b/src/app/file-browser/components/folder-view/folder-view.component.html
@@ -1,4 +1,3 @@
 <ng-container [ngSwitch]="currentView" *ngIf="currentView">
-  <!-- <pr-timeline-view *ngSwitchCase="'folder.view.timeline'"></pr-timeline-view> -->
   <pr-file-list *ngSwitchDefault></pr-file-list>
 </ng-container>

--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -1,7 +1,5 @@
 <div class="sidebar-tabs">
   <div class="sidebar-tab" [class.active]="currentTab === 'info'" (click)="setCurrentTab('info')">Info</div>
-  <!-- <div class="sidebar-tab" [class.active]="currentTab === 'details'" (click)="setCurrentTab('details')"
-    [class.disabled]="isRootFolder">Details</div> -->
   <div class="sidebar-tab" [class.active]="currentTab === 'sharing'" (click)="setCurrentTab('sharing')"
     [class.disabled]="isRootFolder || isPublicItem"
     [ngbTooltip]="isPublicItem ? ('sidebar.share.disabled.public' | prTooltip) : null">
@@ -155,7 +153,6 @@
       </button>
     </div>
     <div class="sidebar-item">
-      <!-- <label>Shared with</label> -->
       <div class="sidebar-item-content" *ngIf="selectedItem.ShareVOs?.length">
         <div class="shared-with-archive" *ngFor="let share of selectedItem.ShareVOs">
           <div class="archive-thumb" prBgImage [bgSrc]="share.ArchiveVO.thumbURL200" [cover]="true"></div>
@@ -165,9 +162,6 @@
           </div>
         </div>
       </div>
-      <!-- <div class="sidebar-item-content" *ngIf="!selectedItem.ShareVOs?.length">
-        This item is not shared
-      </div> -->
     </div>
   </ng-container>
 </div>

--- a/src/app/search/components/global-search-results/global-search-results.component.html
+++ b/src/app/search/components/global-search-results/global-search-results.component.html
@@ -4,9 +4,6 @@
   <div class="fade-ring-loader" *ngIf="waiting" @ngIfFadeInAnimation></div>
 </div>
 <div class="results">
-  <!-- <div class="results-title">
-    Results for "{{formControl.value}}"
-  </div> -->
   <div class="result-group" *ngIf="tagResults?.length">
     <label>Tags</label>
     <div class="tag-results">

--- a/src/app/share-preview/components/share-preview/share-preview.component.html
+++ b/src/app/share-preview/components/share-preview/share-preview.component.html
@@ -89,7 +89,6 @@
       </div>
     </div>
     <div class="share-preview-cover-buttons" (click)="stopPropagation($event)" *ngIf="isLoggedIn" >
-      <!-- <button class="btn btn-wordpress" *ngIf="!isLoggedIn" (click)="showForm = true;">Sign Up</button> -->
       <button class="btn btn-wordpress" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access Requested' : 'Request Access' }}</button>
       <button class="btn btn-wordpress" (click)="onArchiveThumbClick()" *ngIf="isRelationshipShare">Switch Archive</button>
     </div>
@@ -110,9 +109,9 @@
         </div>
         <button class="btn btn-alternate" *ngIf="isRelationshipShare">Log in</button>
       </strong>
-      <strong *ngIf="isLinkShare && isLoggedIn && !hasRequested">Request full access from {{shareAccount.fullName}}.</strong> 
-      <strong *ngIf="isLinkShare && isLoggedIn && hasRequested">Your request is awaiting approval from {{shareAccount.fullName}}.</strong> 
-      <strong *ngIf="isRelationshipShare && isLoggedIn">Your current archive does not have access to this content. Switch to view or edit.</strong> 
+      <strong *ngIf="isLinkShare && isLoggedIn && !hasRequested">Request full access from {{shareAccount.fullName}}.</strong>
+      <strong *ngIf="isLinkShare && isLoggedIn && hasRequested">Your request is awaiting approval from {{shareAccount.fullName}}.</strong>
+      <strong *ngIf="isRelationshipShare && isLoggedIn">Your current archive does not have access to this content. Switch to view or edit.</strong>
       <div *ngIf="isLinkShare && isLoggedIn">
         <button class="btn btn-alternate" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access requested' : 'Request access' }}</button>
       </div>

--- a/src/app/shared/components/archive-switcher-dialog/archive-switcher-dialog.component.html
+++ b/src/app/shared/components/archive-switcher-dialog/archive-switcher-dialog.component.html
@@ -1,8 +1,4 @@
 <div class="archive-switcher-wrapper">
-  <!-- <div class="current-archive">
-    <pr-archive-small [archive]="currentArchive" (click)="close()"></pr-archive-small>
-    <div class="archive-list-title"><strong>{{promptText}}</strong></div>
-  </div> -->
   <div class="archive-list-wrapper">
     <div class="archive-list" *ngIf="!loadingArchives" [ngClass]="{'switching': waiting}">
       <pr-archive-small *ngFor="let archive of archives"
@@ -18,7 +14,6 @@
     </div>
   </div>
   <div class="archive-list-button">
-    <!-- <button class="btn btn-primary" (click)="createArchiveClick()">Create new archive</button> -->
     <button class="btn btn-wordpress" [disabled]="waiting" (click)="close()">Use Current Archive</button>
     <button class="btn btn-wordpress-alternate" [disabled]="waiting" (click)="logOut()">Log Out</button>
   </div>

--- a/src/app/shared/components/message/message.component.html
+++ b/src/app/shared/components/message/message.component.html
@@ -1,8 +1,5 @@
 <div class="alert-wrapper" [ngClass]="{'visible': visible, 'fade': useFade}" (click)="onClick()">
   <div class="alert alert-primary" [ngClass]="style">
     {{displayText}}
-    <!-- <button type="button" class="close" aria-label="Close" (click)="dismiss()">
-      <span aria-hidden="true">&times;</span>
-    </button> -->
   </div>
 </div>

--- a/src/app/views/components/timeline-view/timeline-view.component.html
+++ b/src/app/views/components/timeline-view/timeline-view.component.html
@@ -30,8 +30,3 @@
   </div>
 </div>
 <ng-container [ngTemplateOutlet]="outletTemplate"></ng-container>
-<!-- <div [@slideUpAnimation]="o.isActivated ? o.activatedRoute : ''">
-  <router-outlet #o="outlet"></router-outlet>
-</div> -->
-
-


### PR DESCRIPTION
## Description
Requested by Jason as part of an extension of refactoring work I did in #54 

This PR removes commented out code from our Angular component templates. If we ever need these code snippets again, they are in version control. Some of these snippets are remnants from earlier in development and aren't even relevant to the current state of the codebase anymore. Get rid of them.

Also includes some autoformatting my IDE did to strip extra whitespace from lines in these files and adding newlines to the end of files where that was absent.