### PR TITLE
Re-add deleted public download button code.

### DIFF
--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -33,6 +33,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   public isAudio = false;
   public isDocument = false;
   public showThumbnail = true;
+  public isPublicArchive: boolean = false;
 
   public documentUrl = null;
 
@@ -83,6 +84,11 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
       this.loadQueuedItems();
     }
+
+    if (route.snapshot.data?.isPublicArchive) {
+      this.isPublicArchive = route.snapshot.data.isPublicArchive;
+    }
+
     this.canEdit = this.accountService.checkMinimumAccess(this.currentRecord.accessRole, AccessRole.Editor) && !route.snapshot.data?.isPublicArchive;
   }
 
@@ -316,5 +322,9 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
   public onDateToggle(active: boolean): void {
     this.editingDate = active;
+  }
+
+  public onDownloadClick(): void {
+    this.dataService.downloadFile(this.currentRecord);
   }
 }


### PR DESCRIPTION
For some reason this code in this typescript file got deleted, and we didn't notice during the code review on #54. I'm not sure why, but for obvious reasons deleting this code caused build errors as these properties and methods were suddenly undefined. I'm creating a new PR for this because I'm not sure I know how to most elegantly revert #54, rewrite its history to remove those deletions, and merge it again. 

(Sorry for what seems like PR spam lol)