### PR TITLE
Create Google API Keys for each environment

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_DEV }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_DEV }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
         run: npm run build:dev
@@ -47,7 +47,7 @@ jobs:
           token: ${{ secrets.SENTRY_TOKEN }}
           organization: permanentorg
           project: mdot
-      
+
       - name: Download dist
         uses: actions/download-artifact@v2
         with:
@@ -63,7 +63,7 @@ jobs:
           declare -x VERSION=mdot@$(jq -r '.version' package.json)
           sentry-cli releases set-commits $VERSION --auto
           sentry-cli releases files $VERSION upload-sourcemaps --rewrite --validate --verbose --strip-common-prefix ./dist/ --ignore mdot
-  
+
   upload-code:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm install
       - name: Build
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_PROD }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_PROD }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_LIVE_KEY }}
         run: npm run build

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm install
       - name: Build
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_STAGING }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_STAGING }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
         run: npm run build:staging

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run unit tests
         env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_DEV }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_DEV }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
         run: npm run test:build


### PR DESCRIPTION
Previously we only had one secret for the Google API Key. We want to use a separate API key for each environment, and so the actual workflows need to use the correct Github secret for each environment.

Part of work for PER-8279.