### PR TITLE
Disable Angular CLI Analytics

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -206,6 +206,6 @@
     }
   },
   "cli": {
-    "analytics": "0f7fbf7e-c8eb-4198-b099-2c1d5308c974"
+    "analytics": false
   }
 }


### PR DESCRIPTION
Our Angular configuration file had a string ID for it's `cli.analytics` property. I believe this means that analytics is enabled on this project and we might be sending anonymous usage data to Google every time we run the Angular CLI within this project. This PR makes sure we're not doing that, since it seems against the philosophy of Permanent... and is also just creepy.