### PR TITLE
PER-8591: Remove user context from Sentry events

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -71,7 +71,7 @@ export class AccountService {
 
     // set account data on Sentry scope
     Sentry.configureScope(scope => {
-      scope.setUser({id: this.account.accountId, email: this.account.primaryEmail});
+      scope.setUser({id: this.account.accountId});
     });
   }
 


### PR DESCRIPTION
## Description
This PR removes the code that adds user information (e-mail, account/archive numbers) to Sentry events. This means that no more personally identifying information is being attached to these events.

## Steps to Test
Since Sentry is disabled in local, the only way to test this is to deploy to another environment. This is a pretty simple code change so I'm confident that once it's reviewed we can merge it and check Sentry in the coming weeks to see that new events don't have user tags on them anymore.

(Otherwise we can deploy to dev and force an error there to test.)