### PR TITLE
Unit test fixes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - uses: actions/cache@v2
         with:
           path: node_modules

--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -112,6 +112,11 @@ export class EditService {
   }
 
   loadGoogleMapsApi() {
+    if (window['doNotLoadGoogleMapsAPI']) {
+      this.debug('Google Maps API disabled in testing environment');
+      return;
+    }
+
     if (window['google']?.maps) {
       this.debug('Google Maps API already loaded, skipping');
       this.isGoogleMapsApiLoaded = true;

--- a/src/test.ts
+++ b/src/test.ts
@@ -27,6 +27,9 @@ window['Stripe'] = () => {
   }
 };
 
+// Disable loading of external Google Maps API
+window['doNotLoadGoogleMapsAPI'] = true;
+
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,


### PR DESCRIPTION
These fixes do a few things:
- Force the node version to 14 (due to Karma just not working in newer node versions)
- Disable loading the actual external Google Maps API in our tests.

This combination of fixes seems to get the unit tests to pass. The Google Maps failures were triggering errors on my local machine with a downgraded node version, but CI was continuing to have errors I wasn't detecting due to it also loading an incompatible version of node.


(The name of this branch hints at what I thought the initial solution was)