### PR TITLE
Update verification text to include phone number

### DIFF
--- a/src/app/auth/components/mfa/mfa.component.html
+++ b/src/app/auth/components/mfa/mfa.component.html
@@ -3,7 +3,7 @@
     Verify Access
   </h1>
   <p>
-    A verification code has been sent to your email address.
+    A verification code has been sent to your email address or phone number.
     <br>
     <br>
     Enter it below to continue.


### PR DESCRIPTION
When a user with MFA configured logs in, they need to enter the verification code sent to their MFA device. When authentication was entirely internal, this always included their email address, and may have *also* included their phone number. With the switch to FusionAuth, it is only ever one or the other.

Updating the API and front end to properly communicate which was sent is non-trivial, and anyway this is all going to be deleted as we move this functionality out of the client and into the IdP. Instead, simply update the explanatory text on the verify MFA page to better explain what is happening.

PER-8532 Allow legacy password auth via IdP