### PR TITLE
PER-8726: Use pointer cursor on links with no href

### DIFF
--- a/src/styles/_ui.scss
+++ b/src/styles/_ui.scss
@@ -164,7 +164,7 @@ nav .btn {
   word-break: break-all;
 }
 
-a:link {
+a {
   cursor: pointer;
   transition: color 0.3s;
 }


### PR DESCRIPTION
## Description
The "Archives" and "Log Out" links on the top right menu were not showing the proper cursor. I think this was broken by the sweeping link style changes introduced in #41, and this small bit of styling was missed. This PR fixes the issue by making sure that all `a` tags show the pointer cursor, as the "Archive" and "Log Out" links did not have a `href` attribute (using JavaScript magic to act just like links without CSS recognizing that they were links).

## Steps to Test
Open the top right menu and hover over the "Archive" and "Log Out" buttons. Test various other links to make sure that something doesn't have a style we're not expecting. (I don't think we're using `a` tags for anything other than links or buttons though.)

