### PR TITLE
PER-8672: Allow empty profile to be private.

### DIFF
--- a/src/app/models/profile-item-vo.ts
+++ b/src/app/models/profile-item-vo.ts
@@ -18,7 +18,8 @@ export type FieldNameUI =
 'profile.location' |
 'profile.phone_nbr' |
 'profile.social_media' |
-'profile.timezone';
+'profile.timezone' |
+'profile.FORCE_PUBLIC_UPDATE';
 
 export type FieldNameUIShort =
 'basic' |

--- a/src/app/shared/services/profile/profile.service.ts
+++ b/src/app/shared/services/profile/profile.service.ts
@@ -237,7 +237,19 @@ export class ProfileService {
     });
 
     if (!minItems.length) {
-      return;
+      if (this.checkProfilePublic() === setPublic) {
+        return;
+      } else {
+        const currentArchive = this.account.getArchive();
+        const publicDummy: ProfileItemVOData = {
+          archiveId: currentArchive.archiveId,
+          fieldNameUI: 'profile.FORCE_PUBLIC_UPDATE',
+          string1: setPublic ? 'true' : 'false',
+          type: 'type.widget.string',
+          publicDT: setPublic ? new Date().toISOString() : null
+        };
+        minItems.push(publicDummy);
+      }
     }
 
     try {


### PR DESCRIPTION
## Description
There is an issue with setting a user's profile visibility when their archive's profile is mostly empty. This is because the profile's visibility status is actually bound to the various `ProfileItemVO`s that belong the that profile, using the `publicDT` field.

Essentially, the web-app goes through <del>all</del> <ins>some of</ins><sup> 1</sup> the `ProfileItemVO`s on an Archive and checks the `publicDT` field of each. If there is at least one non-null `publicDT` field, the profile is considered public. Otherwise, if they are all null, the profile is considered private. However, as a default case, if there are no profile fields at all<sup>1</sup> the profile is considered public. This is what is causing the current error; on an empty profile there are no `ProfileItemVO`s to set the `publicDT` field to null.

<sup>1: Any fields that are considered "ALWAYS_PUBLIC" are filtered out of these checks and are not part of this check process.</sup>

This PR will add a dummy `ProfileItemVO` with a null `publicDT` to the user's Archive in the event the previously mentioned error would occur, allowing them to save an empty profile as private. I've set this dummy `ProfileItemVO` to hopefully be recognizable and readable in the database in case we ever need to debug things further.

Ideally, this fix would involve restructuring the way we store a profile's public status on the back end, but for now this is a quick fix that takes advantage of the back end's... loose way of structuring archive profile information.

## Steps to Test
* Open the "Archive Profile" page on an archive with a completely empty profile (it doesn't matter if it's newly created or a pre-existing archive you just cleared out).
* Set the profile to private.
* Refresh the page and note how the profile remains set to private.
* Make sure nothing else is broken.
  * Technically, setting an empty profile to private shouldn't actually change how the Public Archive Profile page looks since... well the page is already empty.


Resolves PER-8672.
