### PR TITLE
PER-8679: add missing words

### DIFF
--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
@@ -288,7 +288,9 @@ export class FileListControlsComponent implements OnInit, OnDestroy, HasSubscrip
       return;
     }
 
-    if (await this.prompt.confirmBoolean('Unshare', `Are you sure you remove this from your shared items?`)) {
+    if (await this.prompt.confirmBoolean('Unshare',
+       'Are you sure you wish to remove this from your shared items?')
+    ) {
       try {
         this.edit.unshareItem(this.selectedItems[0]);
       } catch (err) {


### PR DESCRIPTION
The text in this pop-up was wrong.  Fix it.

To test, have two archives, A and B.  From archive A, share a file to archive B.  In archive B, go to "Shares" and select the shared item.  Click "Unshare" in the top menu.  The modal that pops up should have the new text.