### PR TITLE
PER-8503: Preserve newlines in archive description

### DIFF
--- a/src/app/public/components/public-archive/public-archive.component.scss
+++ b/src/app/public/components/public-archive/public-archive.component.scss
@@ -128,3 +128,7 @@ $profile-max-width: 1200px;
     margin-top: $grid-unit / 2;
   }
 }
+
+.profile-description {
+  white-space: pre-line;
+}


### PR DESCRIPTION
This PR preserves newlines in Description field of a Public Archive Profile. This is done through pure CSS. Later fixes may implement functionality to include links or use markdown. Also, the only other multiline profile field (The description to Milestones) does not need this fix since it already preserves newlines.

To test, just use newlines in an archive profile. This fix preserves newlines, but does not preserve extra spaces/indents, similar to how Markdown works.

Picture of the fix:
![2022-01-11-123505](https://user-images.githubusercontent.com/9145247/149009490-c603680f-f715-4fb4-a489-bfb8307c61cb.png)

