### PR TITLE
Manage tags fixes

### DIFF
--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -30,7 +30,7 @@ export class ArchiveSettingsDialogComponent implements OnInit {
 
   public ngOnInit(): void {
     const accessRole = this.account.getArchive().accessRole;
-    this.hasAccess = accessRole === "access.role.owner"; /*|| accessRole === "access.role.manager"*/
+    this.hasAccess = accessRole === "access.role.owner" || accessRole === "access.role.manager";
     if (this.hasAccess) {
       this.api.tag.getTagsByArchive(this.account.getArchive()).then((response) => {
         this.tags = response.getTagVOs();

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -50,8 +50,11 @@ export class ArchiveSettingsDialogComponent implements OnInit {
   }
 
   public refreshTags(): void {
-    this.tagsService.resetTags();
-    this.ngOnInit();
+    // Wait a bit for the back end to catch up.
+    setTimeout(() => {
+      this.tagsService.resetTags();
+      this.ngOnInit();
+    }, 500);
   }
 
   public onDoneClick(): void {


### PR DESCRIPTION
Commit 1 uncomments out the code that allows managers and owners to both view the manage tags page.

Commit 2 adds a small delay when refreshing the tags list on the archive settings page.

We may only want to merge commit 1.