### PR TITLE
PER-8255: Change error message

### DIFF
--- a/src/app/core/components/upload-progress/upload-progress.component.html
+++ b/src/app/core/components/upload-progress/upload-progress.component.html
@@ -16,10 +16,10 @@
         <strong>{{fileCount.completed}}</strong> of <strong>{{fileCount.total}}</strong>files uploaded 
     </div>
   </div>
-  <div *ngIf="status === UploadSessionStatus.ConnectionError" class="upload">
+  <div *ngIf="status === UploadSessionStatus.DefaultError" class="upload">
     <div class="message">
       <strong>
-        Connection error
+        Oops, something went wrong!
       </strong>
       <br>
       <span *ngIf="fileCount.completed">{{fileCount.completed}} uploaded, </span>

--- a/src/app/core/components/upload-progress/upload-progress.component.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.ts
@@ -40,7 +40,7 @@ export class UploadProgressComponent {
         case UploadSessionStatus.Done:
           this.upload.dismissProgress();
           break;
-        case UploadSessionStatus.ConnectionError:
+        case UploadSessionStatus.DefaultError:
           this.upload.dismissProgress();
           break;
         case UploadSessionStatus.StorageError:

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -67,8 +67,8 @@ export class UploadService implements HasSubscriptions, OnDestroy {
         case UploadSessionStatus.Done:
           this.accountService.refreshAccountDebounced();
           break;
-        case UploadSessionStatus.ConnectionError:
-          this.message.showError('Unable to connect - try again in a moment');
+        case UploadSessionStatus.DefaultError:
+          this.message.showError('Oops, something went wrong! Please try again. If the issue persists, reach out to us at support@permanent.org.');
           this.accountService.refreshAccountDebounced();
           break;
         case UploadSessionStatus.StorageError:

--- a/src/app/core/services/upload/upload.session.ts
+++ b/src/app/core/services/upload/upload.session.ts
@@ -9,7 +9,7 @@ export enum UploadSessionStatus {
   Start,
   InProgress,
   Done,
-  ConnectionError,
+  DefaultError,
   StorageError,
 }
 
@@ -124,7 +124,7 @@ export class UploadSession {
         );
       } else {
         this.emitError(
-          UploadSessionStatus.ConnectionError,
+          UploadSessionStatus.DefaultError,
           item,
         );
       }


### PR DESCRIPTION
We use "connection error" as our default error message, which is
confusing to users.  Change the name of the variable to better reflect
the problem and the message to users similarly.