### PR TITLE
Remove unused non-owner constant

### DIFF
--- a/constants/master_en.json
+++ b/constants/master_en.json
@@ -6,7 +6,6 @@
       "curator": "Curator",
       "manager": "Manager",
       "minor": "Minor",
-      "nonOwner": "Non-Owner",
       "owner": "Owner",
       "viewer": "Viewer",
       "editor": "Editor"


### PR DESCRIPTION
As far as we can tell, this constant was never used. Remove it.

See also: https://github.com/PermanentOrg/back-end/pull/31

Thanks to @cecilia-donnelly for finding the original issue, and fixing it on the back-end!