### PR TITLE
PER-8463: Onboarding Wire Up

### DIFF
--- a/src/app/auth/auth.routes.ts
+++ b/src/app/auth/auth.routes.ts
@@ -13,6 +13,8 @@ import { ForgotPasswordComponent } from '@auth/components/forgot-password/forgot
 import { TermsComponent } from '@shared/components/terms/terms.component';
 import { ShareInviteResolveService } from './resolves/share-invite-resolve.service';
 
+import { AuthGuard } from './guards/auth.guard';
+
 export const childRoutes: Routes = [
   { path: 'login', component: LoginComponent, data: { title: 'Log In' } },
   { path: 'signup', component: SignupComponent, data: { title: 'Sign Up' }, resolve: { shareInviteData: ShareInviteResolveService }},
@@ -26,9 +28,10 @@ export const childRoutes: Routes = [
   { path: '**', redirectTo: 'login'}
 ];
 
-const routes = [
+const routes: Routes = [
   {
     path: '',
+    canActivate: [ AuthGuard ],
     component: AuthComponent,
     children: childRoutes
   }
@@ -53,4 +56,3 @@ const routes = [
   ]
 })
 export class AuthRoutingModule { }
-

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -71,10 +71,17 @@ export class LoginComponent implements OnInit {
             window.location.assign(`/app/public?cta=timeline`);
           }
         } else {
-          this.router.navigate(['/'], { queryParamsHandling: 'preserve'})
-            .then(() => {
-              this.message.showMessage(`Logged in as ${this.accountService.getAccount().primaryEmail}.`, 'success');
-            });
+          const archives = this.accountService.getArchives().filter(
+            (archive) => !archive.isPending()
+          );
+          if (archives.length > 0) {
+            this.router.navigate(['/'], { queryParamsHandling: 'preserve'})
+              .then(() => {
+                this.message.showMessage(`Logged in as ${this.accountService.getAccount().primaryEmail}.`, 'success');
+              });
+          } else {
+            this.router.navigate(['/app/onboarding']);
+          }
         }
       })
       .catch((response: AuthResponse) => {

--- a/src/app/auth/components/signup/signup.component.html
+++ b/src/app/auth/components/signup/signup.component.html
@@ -6,7 +6,7 @@
     {{shareFromName}} has shared <em>{{shareItem.displayName}}</em> with you
   </h1>
   <div class="input-group-vertical">
-    <pr-form-input *ngIf="showInviteCode" fieldName="invitation" placeholder="Invitation code (optional)" [control]="signupForm.controls['invitation']" 
+    <pr-form-input *ngIf="showInviteCode" fieldName="invitation" placeholder="Invitation code (optional)" [control]="signupForm.controls['invitation']"
       [config]="{autocomplete: 'off', autocorrect: 'off', autocapitalize: 'off', spellcheck: 'off'}"></pr-form-input>
     <pr-form-input fieldName="name" placeholder="Full name" [control]="signupForm.controls['name']"
       [config]="{autocomplete: 'name', autocorrect: 'off', autocapitalize: 'yes', spellcheck: 'off'}"></pr-form-input>

--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -118,39 +118,7 @@ export class SignupComponent implements OnInit {
         } else {
           this.accountService.logIn(formValue.email, formValue.password, true, true)
             .then(() => {
-              this.message.showMessage(`Logged in as ${this.accountService.getAccount().primaryEmail}.`, 'success');
-
-              if (this.route.snapshot.queryParams.eventCategory) {
-                this.ga.sendEvent({
-                  hitType: 'event',
-                  eventCategory: this.route.snapshot.queryParams.eventCategory,
-                  eventAction: 'signup'
-                });
-              }
-
-              if (this.route.snapshot.queryParams.shareByUrl) {
-                this.router.navigate(['/share', this.route.snapshot.queryParams.shareByUrl]);
-              } else if (this.route.snapshot.queryParams.cta === 'timeline') {
-                if (this.device.isMobile() || !this.device.didOptOut()) {
-                  this.router.navigate(['/public'], { queryParams: { cta: 'timeline' }});
-                } else {
-                  window.location.assign(`/app/public?cta=timeline`);
-                }
-              } else if (!this.isForShareInvite) {
-                if (this.device.isMobile() || !this.device.didOptOut()) {
-                  this.router.navigate(['/']);
-                } else {
-                  window.location.assign('/app');
-                }
-              } else if (this.shareItemIsRecord) {
-                setTimeout(() => {
-                  this.router.navigate(['/shares', 'withme']);
-                }, 500);
-              } else {
-                setTimeout(() => {
-                  this.router.navigate(['/shares', 'withme', this.shareItem.archiveNbr, this.shareItem.folder_linkId]);
-                }, 500);
-              }
+              this.redirectUserFromSignup();
             });
         }
       })
@@ -158,5 +126,41 @@ export class SignupComponent implements OnInit {
         this.message.showError(response.getMessage(), true);
         this.waiting = false;
       });
+  }
+
+  public redirectUserFromSignup() {
+    this.message.showMessage(`Logged in as ${this.accountService.getAccount().primaryEmail}.`, 'success');
+
+    if (this.route.snapshot.queryParams.eventCategory) {
+      this.ga.sendEvent({
+        hitType: 'event',
+        eventCategory: this.route.snapshot.queryParams.eventCategory,
+        eventAction: 'signup'
+      });
+    }
+
+    if (this.route.snapshot.queryParams.shareByUrl) {
+      this.router.navigate(['/share', this.route.snapshot.queryParams.shareByUrl]);
+    } else if (this.route.snapshot.queryParams.cta === 'timeline') {
+      if (this.device.isMobile() || !this.device.didOptOut()) {
+        this.router.navigate(['/public'], { queryParams: { cta: 'timeline' }});
+      } else {
+        window.location.assign(`/app/public?cta=timeline`);
+      }
+    } else if (!this.isForShareInvite) {
+      if (this.device.isMobile() || !this.device.didOptOut()) {
+        this.router.navigate(['/app', 'onboarding']);
+      } else {
+        window.location.assign('/app/onboarding');
+      }
+    } else if (this.shareItemIsRecord) {
+      setTimeout(() => {
+        this.router.navigate(['/shares', 'withme']);
+      }, 500);
+    } else {
+      setTimeout(() => {
+        this.router.navigate(['/shares', 'withme', this.shareItem.archiveNbr, this.shareItem.folder_linkId]);
+      }, 500);
+    }
   }
 }

--- a/src/app/auth/guards/auth.guard.ts
+++ b/src/app/auth/guards/auth.guard.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+import { AccountService } from '@shared/services/account/account.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthGuard implements CanActivate {
+  constructor(
+    private account: AccountService,
+    private router: Router,
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    if (this.account.getAccount()?.accountId) {
+      this.account.refreshArchives().then((archives) => {
+        const ownArchives = archives.filter(
+          (archive) => !archive.isPending()
+        );
+        if (ownArchives.length > 0) {
+          this.router.navigate(['/app/myfiles']);
+        } else {
+          this.router.navigate(['/app/onboarding']);
+        }
+      });
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/src/app/auth/guards/auth.guard.ts
+++ b/src/app/auth/guards/auth.guard.ts
@@ -15,19 +15,15 @@ export class AuthGuard implements CanActivate {
 
   canActivate(
     route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    state: RouterStateSnapshot,
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     if (this.account.getAccount()?.accountId) {
-      this.account.refreshArchives().then((archives) => {
-        const ownArchives = archives.filter(
-          (archive) => !archive.isPending()
-        );
-        if (ownArchives.length > 0) {
-          this.router.navigate(['/app/myfiles']);
-        } else {
-          this.router.navigate(['/app/onboarding']);
+      return this.account.hasOwnArchives().then((hasArchives) => {
+        if (hasArchives) {
+          return this.router.parseUrl('/app/myfiles');
         }
+        return this.router.parseUrl('/app/onboarding');
       });
-      return false;
     }
     return true;
   }

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -18,7 +18,9 @@ export class AuthGuard implements CanActivate {
       if (isSessionValid && this.account.isLoggedIn()) {
         return true;
       } else {
-        this.account.refreshAccount();
+        if (isSessionValid !== this.account.isLoggedIn()) {
+          this.account.clear();
+        }
         this.router.navigate(['/app', 'auth', 'login'], { queryParams: next.queryParams });
         return false;
       }

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -18,6 +18,7 @@ export class AuthGuard implements CanActivate {
       if (isSessionValid && this.account.isLoggedIn()) {
         return true;
       } else {
+        this.account.refreshAccount();
         this.router.navigate(['/app', 'auth', 'login'], { queryParams: next.queryParams });
         return false;
       }

--- a/src/app/onboarding/components/onboarding/onboarding.component.html
+++ b/src/app/onboarding/components/onboarding/onboarding.component.html
@@ -4,7 +4,7 @@
   </div>
 </div>
 <pr-debugger [currentScreen]="screen" (setState)="setState($event)"></pr-debugger>
-<div class="onboarding" *ngIf="!skipOnboarding ; else loading">
+<div class="onboarding" *ngIf="showOnboarding ; else loading">
   <ng-container [ngSwitch]="screen">
     <pr-welcome-screen (nextScreen)="setScreen($event)" (acceptInvitation)="acceptArchiveInvitation($event)" [pendingArchives]="pendingArchives" *ngSwitchCase="OnboardingScreen.welcomeScreen"></pr-welcome-screen>
     <pr-create-new-archive (createdArchive)="setNewArchive($event)" *ngSwitchCase="OnboardingScreen.newArchive"></pr-create-new-archive>

--- a/src/app/onboarding/components/onboarding/onboarding.component.html
+++ b/src/app/onboarding/components/onboarding/onboarding.component.html
@@ -4,11 +4,14 @@
   </div>
 </div>
 <pr-debugger [currentScreen]="screen" (setState)="setState($event)"></pr-debugger>
-<div class="onboarding">
+<div class="onboarding" *ngIf="!skipOnboarding ; else loading">
   <ng-container [ngSwitch]="screen">
-    <pr-welcome-screen (nextScreen)="setScreen($event)" (acceptInvitation)="setNewArchive($event)" [pendingArchives]="pendingArchives" *ngSwitchCase="OnboardingScreen.welcomeScreen"></pr-welcome-screen>
+    <pr-welcome-screen (nextScreen)="setScreen($event)" (acceptInvitation)="acceptArchiveInvitation($event)" [pendingArchives]="pendingArchives" *ngSwitchCase="OnboardingScreen.welcomeScreen"></pr-welcome-screen>
     <pr-create-new-archive (createdArchive)="setNewArchive($event)" *ngSwitchCase="OnboardingScreen.newArchive"></pr-create-new-archive>
     <div *ngSwitchCase="OnboardingScreen.done">Done with process! (At this point we'd bring the user to the main app in their new archive). <br /> This account's main archive: <pre>{{ currentArchive | json}}</pre></div>
     <div *ngSwitchDefault>Something went wrong.</div>
   </ng-container>
 </div>
+<ng-template #loading>
+    <div class="loading">Loading...</div>
+</ng-template>

--- a/src/app/onboarding/components/onboarding/onboarding.component.scss
+++ b/src/app/onboarding/components/onboarding/onboarding.component.scss
@@ -2,3 +2,7 @@
   text-align: center;
   padding: 10%;
 }
+
+.loading {
+  text-align: center;
+}

--- a/src/app/onboarding/components/onboarding/onboarding.component.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.ts
@@ -74,8 +74,13 @@ export class OnboardingComponent implements OnInit {
 
   public setNewArchive(archive: ArchiveVO): void {
     this.currentArchive = archive;
-    this.account.setArchive(archive);
-    this.setScreen(OnboardingScreen.done);
+    const updateAccount = new AccountVO({defaultArchiveId: archive.archiveId});
+    this.account.updateAccount(updateAccount).then(() => {
+      this.account.setArchive(archive);
+      this.api.archive.change(archive).then(() => {
+        this.setScreen(OnboardingScreen.done);
+      });
+    });
   }
 
   public setState(state: Partial<OnboardingComponent>): void {

--- a/src/app/onboarding/components/onboarding/onboarding.component.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.ts
@@ -23,7 +23,7 @@ export class OnboardingComponent implements OnInit {
   public useApi: boolean = true;
   public OnboardingScreen: typeof OnboardingScreen = OnboardingScreen;
 
-  public skipOnboarding: boolean = true;
+  public showOnboarding: boolean = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -45,11 +45,11 @@ export class OnboardingComponent implements OnInit {
       );
       if (ownArchives.length > 0 && false) {
         // This user already has archives. They don't need to onboard.
-        this.skipOnboarding = true;
+        this.showOnboarding = false;
         this.router.navigate(['/app', 'myfiles']);
       } else {
         this.pendingArchives = pendingArchives;
-        this.skipOnboarding = false;
+        this.showOnboarding = true;
       }
     });
   }
@@ -91,9 +91,9 @@ export class OnboardingComponent implements OnInit {
   }
 
   public acceptArchiveInvitation(archive: ArchiveVO): void {
-    this.skipOnboarding = true;
+    this.showOnboarding = false;
     this.api.archive.accept(archive).then(() => {
-      this.skipOnboarding = false;
+      this.showOnboarding = true;
       this.setNewArchive(archive);
     }).catch(() => {
       // TODO: This should be a MessageService message.

--- a/src/app/onboarding/components/onboarding/onboarding.component.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.ts
@@ -74,6 +74,7 @@ export class OnboardingComponent implements OnInit {
 
   public setNewArchive(archive: ArchiveVO): void {
     this.currentArchive = archive;
+    this.account.setArchive(archive);
     this.setScreen(OnboardingScreen.done);
   }
 
@@ -93,7 +94,6 @@ export class OnboardingComponent implements OnInit {
     this.skipOnboarding = true;
     this.api.archive.accept(archive).then(() => {
       this.skipOnboarding = false;
-      this.account.setArchive(archive);
       this.setNewArchive(archive);
     }).catch(() => {
       // TODO: This should be a MessageService message.

--- a/src/app/onboarding/components/welcome-screen/welcome-screen.component.ts
+++ b/src/app/onboarding/components/welcome-screen/welcome-screen.component.ts
@@ -18,7 +18,6 @@ export class WelcomeScreenComponent implements OnInit {
   constructor() { }
 
   ngOnInit(): void {
-    console.log(this.pendingArchives);
   }
 
   public goToScreen(screen: OnboardingScreen): void {
@@ -26,7 +25,6 @@ export class WelcomeScreenComponent implements OnInit {
   }
 
   public acceptPendingArchive(archive: ArchiveVO): void {
-    // TODO: accept invitation via API and wait for it to return
     this.acceptInvitation.emit(archive);
   }
 }

--- a/src/app/onboarding/guards/onboarding.auth.guard.ts
+++ b/src/app/onboarding/guards/onboarding.auth.guard.ts
@@ -15,21 +15,17 @@ export class OnboardingAuthGuard implements CanActivate {
 
   canActivate(
     route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    state: RouterStateSnapshot,
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     if (this.account.getAccount()?.accountId) {
-      return this.account.refreshArchives().then((archives) => {
-        const ownArchives = archives.filter(
-          (archive) => !archive.isPending()
-        );
-        if (ownArchives.length > 0) {
-          this.router.navigate(['/app/myfiles']);
-          return false;
-        } else {
-          return true;
+      return this.account.hasOwnArchives().then((hasArchives) => {
+        if (hasArchives) {
+          return this.router.parseUrl('/app/myfiles');
         }
+        return true;
       });
     }
-    return false;
+    return this.router.parseUrl('/app/auth');
   }
 
 }

--- a/src/app/onboarding/guards/onboarding.auth.guard.ts
+++ b/src/app/onboarding/guards/onboarding.auth.guard.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+import { AccountService } from '@shared/services/account/account.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OnboardingAuthGuard implements CanActivate {
+  constructor(
+    private account: AccountService,
+    private router: Router,
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    if (this.account.getAccount()?.accountId) {
+      return this.account.refreshArchives().then((archives) => {
+        const ownArchives = archives.filter(
+          (archive) => !archive.isPending()
+        );
+        if (ownArchives.length > 0) {
+          this.router.navigate(['/app/myfiles']);
+          return false;
+        } else {
+          return true;
+        }
+      });
+    }
+    return false;
+  }
+
+}

--- a/src/app/onboarding/onboarding.module.ts
+++ b/src/app/onboarding/onboarding.module.ts
@@ -10,11 +10,16 @@ import { SharedModule } from '@shared/shared.module';
 import { DebuggerComponent } from './components/debugger/debugger.component';
 
 @NgModule({
-  declarations: [OnboardingComponent, WelcomeScreenComponent, CreateNewArchiveComponent, DebuggerComponent],
+  declarations: [
+    OnboardingComponent,
+    WelcomeScreenComponent,
+    CreateNewArchiveComponent,
+    DebuggerComponent,
+  ],
   imports: [
     CommonModule,
     OnboardingRoutingModule,
     SharedModule,
-  ]
+  ],
 })
 export class OnboardingModule { }

--- a/src/app/onboarding/onboarding.routes.ts
+++ b/src/app/onboarding/onboarding.routes.ts
@@ -2,19 +2,24 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import {OnboardingComponent} from './components/onboarding/onboarding.component';
+import { CreateNewArchiveComponent } from './components/create-new-archive/create-new-archive.component';
+import { OnboardingAuthGuard } from './guards/onboarding.auth.guard';
 
 export const routes: Routes = [
   {
     path: '',
     component: OnboardingComponent,
+    canActivate: [ OnboardingAuthGuard ],
+    children: [
+      {
+        path: 'new-archive',
+        component: CreateNewArchiveComponent,
+        data: {
+          onboardingScreen: 'newArchive',
+        }
+      },
+    ],
   },
-  {
-    path: 'new-archive',
-    component: OnboardingComponent,
-    data: {
-      onboardingScreen: 'newArchive',
-    }
-  }
 ];
 
 @NgModule({

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -194,7 +194,9 @@ export class AccountService {
     return this.api.archive.getAllArchives(this.account)
       .then((response: ArchiveResponse) => {
         const archives = response.getArchiveVOs();
-        this.setArchives(archives);
+        if (archives.length >  0) {
+            this.setArchives(archives);
+        }
         return this.getArchives();
       });
   }
@@ -274,7 +276,9 @@ export class AccountService {
             newAccount.isNew = currentAccount.isNew;
           }
           this.setAccount(newAccount);
-          this.setArchive(response.getArchiveVO());
+          if (response.getArchiveVO().archiveId) {
+              this.setArchive(response.getArchiveVO());
+          }
           this.skipSessionCheck = true;
 
           this.accountChange.emit(this.account);

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -199,6 +199,14 @@ export class AccountService {
       });
   }
 
+  public async hasOwnArchives() {
+    const archives = await this.refreshArchives();
+    const ownArchives = archives.filter(
+      (archive) => !archive.isPending()
+    );
+    return ownArchives.length > 0;
+  }
+
   public async refreshRoot() {
     const response = await this.api.folder.getRoot();
     const root = response.getFolderVO();

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -194,9 +194,7 @@ export class AccountService {
     return this.api.archive.getAllArchives(this.account)
       .then((response: ArchiveResponse) => {
         const archives = response.getArchiveVOs();
-        if (archives.length >  0) {
-            this.setArchives(archives);
-        }
+        this.setArchives(archives);
         return this.getArchives();
       });
   }
@@ -276,7 +274,7 @@ export class AccountService {
             newAccount.isNew = currentAccount.isNew;
           }
           this.setAccount(newAccount);
-          if (response.getArchiveVO().archiveId) {
+          if (response.getArchiveVO()?.archiveId) {
               this.setArchive(response.getArchiveVO());
           }
           this.skipSessionCheck = true;

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -29,7 +29,14 @@ export class AccountRepo extends BaseRepo {
       passwordVerify: passwordConfirm
     });
 
-    const data = [{ AccountVO: accountVO, AccountPasswordVO: accountPasswordVO }];
+    const data = [{ AccountVO: accountVO, AccountPasswordVO: accountPasswordVO, SimpleVO: null }];
+
+    // HACK: This should be replaced with a function parameter
+    if (window.location.search.includes('createArchive')) {
+      data[0].SimpleVO = new SimpleVO({key: 'createArchive', value: true});
+    } else if (window.location.search.includes('noArchive')) {
+      data[0].SimpleVO = new SimpleVO({key: 'createArchive', value: false});
+    }
 
     return this.http.sendRequest<AccountResponse>('/account/post', data, AccountResponse);
 


### PR DESCRIPTION
This PR hooks up the onboarding flow in two ways:
- Adds route guards and redirects to ensure that the onboarding flow is triggered when a user has no archives.
    - In addition, locks down the routing for the auth and onboarding sections of the app as well, so the user can never navigate to the wrong place.
- Hooks up additional API requests in the onboarding flow (specifically, getting archive member invitations).


Two small hacks are present right now:
- For testing purposes, I've added a feature where QA can add a query parameter to /auth/signup to always create an archive or never create an archive. The full a/b testing code will be handled in parallel with the next ticket.
- I wanted to show a popup message when there was an error accepting an archive invitation but... the Message Service and its component were difficult to get working and I didn't want to waste time on this for something that could be fixed in the next PR.