### PR TITLE
Onboarding A/B testing

### DIFF
--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -108,8 +108,14 @@ export class SignupComponent implements OnInit {
     this.waiting = true;
 
     this.accountService.signUp(
-      formValue.email, formValue.name, formValue.password, formValue.confirm,
-      formValue.agreed, formValue.optIn, null, formValue.invitation
+      formValue.email,
+      formValue.name,
+      formValue.password,
+      formValue.confirm,
+      formValue.agreed,
+      formValue.optIn,
+      null,
+      formValue.invitation,
     ).then((response: AccountResponse) => {
         const account = response.getAccountVO();
         if (account.needsVerification()) {

--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -111,6 +111,9 @@ export class SignupComponent implements OnInit {
     if (window.location.search.includes('noArchive')) {
       return false;
     }
+    if (this.isForShareInvite) {
+      return true;
+    }
     return true;
   }
 

--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -15,6 +15,7 @@ import { DeviceService } from '@shared/services/device/device.service';
 import { GoogleAnalyticsService } from '@shared/services/google-analytics/google-analytics.service';
 
 const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
+const NEW_ONBOARDING_CHANCE = 0;
 
 @Component({
   selector: 'pr-signup',
@@ -114,7 +115,7 @@ export class SignupComponent implements OnInit {
     if (this.isForShareInvite) {
       return true;
     }
-    return true;
+    return Math.random() > NEW_ONBOARDING_CHANCE;
   }
 
   onSubmit(formValue: any) {

--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -104,6 +104,16 @@ export class SignupComponent implements OnInit {
   ngOnInit() {
   }
 
+  shouldCreateDefaultArchive() {
+    if (window.location.search.includes('createArchive')) {
+      return true;
+    }
+    if (window.location.search.includes('noArchive')) {
+      return false;
+    }
+    return true;
+  }
+
   onSubmit(formValue: any) {
     this.waiting = true;
 
@@ -116,6 +126,7 @@ export class SignupComponent implements OnInit {
       formValue.optIn,
       null,
       formValue.invitation,
+      this.shouldCreateDefaultArchive(),
     ).then((response: AccountResponse) => {
         const account = response.getAccountVO();
         if (account.needsVerification()) {

--- a/src/app/embed/components/newsletter-signup/newsletter-signup.component.ts
+++ b/src/app/embed/components/newsletter-signup/newsletter-signup.component.ts
@@ -116,6 +116,7 @@ export class NewsletterSignupComponent implements OnInit {
       false,
       null,
       formValue.invitation,
+      true,
     ).then((response: AccountResponse) => {
         return this.accountService.logIn(formValue.email, formValue.password, true, true)
           .then(() => {

--- a/src/app/embed/components/newsletter-signup/newsletter-signup.component.ts
+++ b/src/app/embed/components/newsletter-signup/newsletter-signup.component.ts
@@ -108,8 +108,14 @@ export class NewsletterSignupComponent implements OnInit {
     this.waiting = true;
 
     this.accountService.signUp(
-      formValue.email, formValue.name, formValue.password, formValue.password,
-      formValue.agreed, false, null, formValue.invitation
+      formValue.email,
+      formValue.name,
+      formValue.password,
+      formValue.password,
+      formValue.agreed,
+      false,
+      null,
+      formValue.invitation,
     ).then((response: AccountResponse) => {
         return this.accountService.logIn(formValue.email, formValue.password, true, true)
           .then(() => {

--- a/src/app/embed/components/signup-embed/signup-embed.component.ts
+++ b/src/app/embed/components/signup-embed/signup-embed.component.ts
@@ -77,6 +77,7 @@ export class SignupEmbedComponent implements OnInit {
       formValue.optIn,
       null,
       formValue.invitation,
+      true,
     ).then((response: AccountResponse) => {
         const account = response.getAccountVO();
         if (account.needsVerification()) {

--- a/src/app/embed/components/signup-embed/signup-embed.component.ts
+++ b/src/app/embed/components/signup-embed/signup-embed.component.ts
@@ -69,8 +69,14 @@ export class SignupEmbedComponent implements OnInit {
     this.waiting = true;
 
     this.accountService.signUp(
-      formValue.email, formValue.name, formValue.password, formValue.confirm,
-      formValue.agreed, formValue.optIn, null, formValue.invitation
+      formValue.email,
+      formValue.name,
+      formValue.password,
+      formValue.confirm,
+      formValue.agreed,
+      formValue.optIn,
+      null,
+      formValue.invitation,
     ).then((response: AccountResponse) => {
         const account = response.getAccountVO();
         if (account.needsVerification()) {

--- a/src/app/pledge/components/claim-storage/claim-storage.component.ts
+++ b/src/app/pledge/components/claim-storage/claim-storage.component.ts
@@ -65,6 +65,7 @@ export class ClaimStorageComponent implements OnInit {
       formValue.optIn,
       null,
       null,
+      true,
     ).then(async (response: AccountResponse) => {
         const account = response.getAccountVO();
         await this.pledgeService.linkAccount(account);

--- a/src/app/pledge/components/claim-storage/claim-storage.component.ts
+++ b/src/app/pledge/components/claim-storage/claim-storage.component.ts
@@ -57,8 +57,14 @@ export class ClaimStorageComponent implements OnInit {
     this.waiting = true;
 
     this.accountService.signUp(
-      formValue.email, formValue.name, formValue.password, formValue.password,
-      formValue.agreed, formValue.optIn, null, null
+      formValue.email,
+      formValue.name,
+      formValue.password,
+      formValue.password,
+      formValue.agreed,
+      formValue.optIn,
+      null,
+      null,
     ).then(async (response: AccountResponse) => {
         const account = response.getAccountVO();
         await this.pledgeService.linkAccount(account);

--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -378,8 +378,14 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
     this.waiting = true;
 
     this.accountService.signUp(
-      formValue.email, formValue.name, formValue.password, formValue.password,
-      formValue.agreed, formValue.optIn, null, formValue.invitation
+      formValue.email,
+      formValue.name,
+      formValue.password,
+      formValue.password,
+      formValue.agreed,
+      formValue.optIn,
+      null,
+      formValue.invitation,
     )
       .then((response: AccountResponse) => {
         this.sendGaEvent('signup');

--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -386,6 +386,7 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
       formValue.optIn,
       null,
       formValue.invitation,
+      true,
     )
       .then((response: AccountResponse) => {
         this.sendGaEvent('signup');

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -387,6 +387,7 @@ export class AccountService {
     optIn: boolean,
     phone: string,
     inviteCode: string,
+    createDefaultArchive: boolean,
   ) {
     this.skipSessionCheck = false;
 
@@ -405,6 +406,7 @@ export class AccountService {
       optIn,
       phone,
       inviteCode,
+      createDefaultArchive,
     )
       .pipe(map((response: AccountResponse) => {
         if (response.isSuccessful) {

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -379,8 +379,14 @@ export class AccountService {
   }
 
   public async signUp(
-    email: string, fullName: string, password: string, passwordConfirm: string,
-    agreed: boolean, optIn: boolean, phone: string, inviteCode: string
+    email: string,
+    fullName: string,
+    password: string,
+    passwordConfirm: string,
+    agreed: boolean,
+    optIn: boolean,
+    phone: string,
+    inviteCode: string,
   ) {
     this.skipSessionCheck = false;
 
@@ -390,7 +396,16 @@ export class AccountService {
       } catch (err) {}
     }
 
-    return this.api.account.signUp(email, fullName, password, passwordConfirm, agreed, optIn, phone, inviteCode)
+    return this.api.account.signUp(
+      email,
+      fullName,
+      password,
+      passwordConfirm,
+      agreed,
+      optIn,
+      phone,
+      inviteCode,
+    )
       .pipe(map((response: AccountResponse) => {
         if (response.isSuccessful) {
           const newAccount = response.getAccountVO();

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -35,7 +35,11 @@ export class AccountRepo extends BaseRepo {
       passwordVerify: passwordConfirm
     });
 
-    const data = [{ AccountVO: accountVO, AccountPasswordVO: accountPasswordVO, SimpleVO: null }];
+    const data = [{
+      AccountVO: accountVO,
+      AccountPasswordVO: accountPasswordVO,
+      SimpleVO: null,
+    }];
 
     // HACK: This should be replaced with a function parameter
     if (window.location.search.includes('createArchive')) {

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -20,6 +20,7 @@ export class AccountRepo extends BaseRepo {
     optIn: boolean,
     phone: string,
     inviteCode: string,
+    createDefaultArchive: boolean,
   ) {
     const accountVO = new AccountVO({
       primaryEmail: email,
@@ -38,18 +39,10 @@ export class AccountRepo extends BaseRepo {
     const data = [{
       AccountVO: accountVO,
       AccountPasswordVO: accountPasswordVO,
-      SimpleVO: null,
+      SimpleVO: new SimpleVO({key: 'createArchive', value: createDefaultArchive}),
     }];
 
-    // HACK: This should be replaced with a function parameter
-    if (window.location.search.includes('createArchive')) {
-      data[0].SimpleVO = new SimpleVO({key: 'createArchive', value: true});
-    } else if (window.location.search.includes('noArchive')) {
-      data[0].SimpleVO = new SimpleVO({key: 'createArchive', value: false});
-    }
-
     return this.http.sendRequest<AccountResponse>('/account/post', data, AccountResponse);
-
   }
 
   public update(accountVO: AccountVO) {

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -12,8 +12,14 @@ export class AccountRepo extends BaseRepo {
   }
 
   public signUp(
-    email: string, fullName: string, password: string, passwordConfirm: string,
-    agreed: boolean, optIn: boolean, phone: string, inviteCode: string
+    email: string,
+    fullName: string,
+    password: string,
+    passwordConfirm: string,
+    agreed: boolean,
+    optIn: boolean,
+    phone: string,
+    inviteCode: string,
   ) {
     const accountVO = new AccountVO({
       primaryEmail: email,


### PR DESCRIPTION
Set up A/B testing for new signups to use the new onboarding workflow, and set the random chance of so doing to 0 for now. Move the hacky query parameter check into the main signup component, and set all the secondary signup components to opt out of the new workflow.

I'm currently targeting PR #96 with this PR, but I believe if that gets merged to `main` the base branch of this PR will automatically update. If this PR is approved before #96 is merged, then I'll likely push my changes to that branch so as to avoid a merge conflict; let me know if you want to do something different, @meisekimiu!

I have not yet tested this extensively, but I wanted to get it up for review soonest.

[PER-8725 Start A/B testing signups](https://permanent.atlassian.net/browse/PER-8725)