### PR TITLE
PER-8511: Show "Accept Share" when auto approve is on

### DIFF
--- a/src/app/share-preview/components/share-preview/share-preview.component.html
+++ b/src/app/share-preview/components/share-preview/share-preview.component.html
@@ -89,7 +89,13 @@
       </div>
     </div>
     <div class="share-preview-cover-buttons" (click)="stopPropagation($event)" *ngIf="isLoggedIn" >
-      <button class="btn btn-wordpress" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access Requested' : requestAccessText }}</button>
+      <button class="btn btn-wordpress" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">
+        <ng-container *ngIf="hasRequested ; else accessText">Access Requested</ng-container>
+        <ng-template #accessText>
+          <ng-container *ngIf="isAutoApprove ; else requestAccess">Accept Share</ng-container>
+          <ng-template #requestAccess>Request Access</ng-template>
+        </ng-template>
+      </button>
       <button class="btn btn-wordpress" (click)="onArchiveThumbClick()" *ngIf="isRelationshipShare">Switch Archive</button>
     </div>
   </div>
@@ -110,7 +116,7 @@
         <button class="btn btn-alternate" *ngIf="isRelationshipShare">Log in</button>
       </strong>
       <strong *ngIf="isLinkShare && isLoggedIn && !hasRequested">
-        <ng-container *ngIf="sharePreviewVO?.autoApproveToggle === 1 ; else requestFullAccessText">
+        <ng-container *ngIf="isAutoApprove ; else requestFullAccessText">
           Accept and view the share in your archive.
         </ng-container>
         <ng-template #requestFullAccessText>
@@ -120,7 +126,13 @@
       <strong *ngIf="isLinkShare && isLoggedIn && hasRequested">Your request is awaiting approval from {{shareAccount.fullName}}.</strong>
       <strong *ngIf="isRelationshipShare && isLoggedIn">Your current archive does not have access to this content. Switch to view or edit.</strong>
       <div *ngIf="isLinkShare && isLoggedIn">
-        <button class="btn btn-alternate" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access requested' : requestAccessText }}</button>
+        <button class="btn btn-alternate" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">
+          <ng-container *ngIf="hasRequested ; else accessText">Access Requested</ng-container>
+          <ng-template #accessText>
+            <ng-container *ngIf="isAutoApprove ; else requestAccess">Accept Share</ng-container>
+            <ng-template #requestAccess>Request Access</ng-template>
+          </ng-template>
+        </button>
       </div>
     </span>
   </div>

--- a/src/app/share-preview/components/share-preview/share-preview.component.html
+++ b/src/app/share-preview/components/share-preview/share-preview.component.html
@@ -89,7 +89,7 @@
       </div>
     </div>
     <div class="share-preview-cover-buttons" (click)="stopPropagation($event)" *ngIf="isLoggedIn" >
-      <button class="btn btn-wordpress" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access Requested' : 'Request Access' }}</button>
+      <button class="btn btn-wordpress" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access Requested' : requestAccessText }}</button>
       <button class="btn btn-wordpress" (click)="onArchiveThumbClick()" *ngIf="isRelationshipShare">Switch Archive</button>
     </div>
   </div>
@@ -113,7 +113,7 @@
       <strong *ngIf="isLinkShare && isLoggedIn && hasRequested">Your request is awaiting approval from {{shareAccount.fullName}}.</strong>
       <strong *ngIf="isRelationshipShare && isLoggedIn">Your current archive does not have access to this content. Switch to view or edit.</strong>
       <div *ngIf="isLinkShare && isLoggedIn">
-        <button class="btn btn-alternate" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access requested' : 'Request access' }}</button>
+        <button class="btn btn-alternate" (click)="onRequestAccessClick()" [disabled]="waiting || hasRequested" *ngIf="isLinkShare">{{ hasRequested ? 'Access requested' : requestAccessText }}</button>
       </div>
     </span>
   </div>

--- a/src/app/share-preview/components/share-preview/share-preview.component.html
+++ b/src/app/share-preview/components/share-preview/share-preview.component.html
@@ -109,7 +109,14 @@
         </div>
         <button class="btn btn-alternate" *ngIf="isRelationshipShare">Log in</button>
       </strong>
-      <strong *ngIf="isLinkShare && isLoggedIn && !hasRequested">Request full access from {{shareAccount.fullName}}.</strong>
+      <strong *ngIf="isLinkShare && isLoggedIn && !hasRequested">
+        <ng-container *ngIf="sharePreviewVO?.autoApproveToggle === 1 ; else requestFullAccessText">
+          Accept and view the share in your archive.
+        </ng-container>
+        <ng-template #requestFullAccessText>
+          Request full access from {{shareAccount.fullName}}.
+        </ng-template>
+      </strong>
       <strong *ngIf="isLinkShare && isLoggedIn && hasRequested">Your request is awaiting approval from {{shareAccount.fullName}}.</strong>
       <strong *ngIf="isRelationshipShare && isLoggedIn">Your current archive does not have access to this content. Switch to view or edit.</strong>
       <div *ngIf="isLinkShare && isLoggedIn">

--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -63,7 +63,8 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
   isNavigating = false;
 
   archiveConfirmed = false;
-  chooseArchiveText;
+  public chooseArchiveText: string;
+  public requestAccessText: string = 'Request Access';
 
   formType: FormType = this.isInvite ? FormType.Invite : FormType.Signup;
   signupForm: FormGroup;
@@ -192,6 +193,9 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
     if (this.isLinkShare) {
       this.hasRequested = !!this.sharePreviewVO.ShareVO;
       this.hasAccess = this.hasRequested && this.sharePreviewVO.ShareVO.status.includes('ok');
+      if (this.sharePreviewVO?.autoApproveToggle === 1) {
+        this.requestAccessText = 'Accept Share';
+      }
     }
 
     if (this.isInvite || this.isLinkShare) {
@@ -494,5 +498,4 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
   stopPropagation(evt) {
     evt.stopPropagation();
   }
-
 }

--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -64,7 +64,7 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
 
   archiveConfirmed = false;
   public chooseArchiveText: string;
-  public requestAccessText: string = 'Request Access';
+  public isAutoApprove: boolean = false;
 
   formType: FormType = this.isInvite ? FormType.Invite : FormType.Signup;
   signupForm: FormGroup;
@@ -194,7 +194,7 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
       this.hasRequested = !!this.sharePreviewVO.ShareVO;
       this.hasAccess = this.hasRequested && this.sharePreviewVO.ShareVO.status.includes('ok');
       if (this.sharePreviewVO?.autoApproveToggle === 1) {
-        this.requestAccessText = 'Accept Share';
+        this.isAutoApprove = true;
       }
     }
 


### PR DESCRIPTION
This PR just changes the text of the "Request Access" button on shares if auto approve is enabled.

Resolves PER-8511.

## Steps to test
- Generate a share link with auto approve enabled
- Access it via another logged in account
- The button should say "Accept Share" instead of "Request Access"
- Test that the button still says "Request Access" if auto approve is disabled.