### PR TITLE
Set new onboarding chance to 100%

### DIFF
--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -15,7 +15,7 @@ import { DeviceService } from '@shared/services/device/device.service';
 import { GoogleAnalyticsService } from '@shared/services/google-analytics/google-analytics.service';
 
 const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
-const NEW_ONBOARDING_CHANCE = 0.5;
+const NEW_ONBOARDING_CHANCE = 1;
 
 @Component({
   selector: 'pr-signup',


### PR DESCRIPTION
This sets the random chance for new onboarding to 100%, meaning the only way the old onboarding flow is activated is through share invites.

💯