### PR TITLE
Remove `--rewrite` flag when uploading sourcemaps

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Sentry CLI
-        uses: mathrix-education/setup-sentry-cli@1.0.0
+        uses: mathieu-bour/setup-sentry-cli@1.2.0
         with:
           token: ${{ secrets.SENTRY_TOKEN }}
           organization: permanentorg

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -62,7 +62,7 @@ jobs:
           cp -r dist/mdot dist/p
           declare -x VERSION=mdot@$(jq -r '.version' package.json)
           sentry-cli releases set-commits $VERSION --auto
-          sentry-cli releases files $VERSION upload-sourcemaps --rewrite --validate --verbose --strip-common-prefix ./dist/ --ignore mdot
+          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:
     needs: build

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Sentry CLI
-        uses: mathrix-education/setup-sentry-cli@1.0.0
+        uses: mathieu-bour/setup-sentry-cli@1.2.0
         with:
           token: ${{ secrets.SENTRY_TOKEN }}
           organization: permanentorg

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -54,7 +54,7 @@ jobs:
           cp -r dist/mdot dist/p
           declare -x VERSION=mdot@$(jq -r '.version' package.json)
           sentry-cli releases set-commits $VERSION --auto
-          sentry-cli releases files $VERSION upload-sourcemaps --rewrite --validate --verbose --strip-common-prefix ./dist/ --ignore mdot
+          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:
     needs: build

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -55,7 +55,7 @@ jobs:
           cp -r dist/mdot dist/p
           declare -x VERSION=mdot@$(jq -r '.version' package.json)
           sentry-cli releases set-commits $VERSION --auto
-          sentry-cli releases files $VERSION upload-sourcemaps --rewrite --validate --verbose --strip-common-prefix ./dist/ --ignore mdot
+          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:
     needs: build

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Sentry CLI
-        uses: mathrix-education/setup-sentry-cli@1.0.0
+        uses: mathieu-bour/setup-sentry-cli@1.2.0
         with:
           token: ${{ secrets.SENTRY_TOKEN }}
           organization: permanentorg


### PR DESCRIPTION
The upload sourcemaps job of build process is currently broken! Looks like `sentry-cli` updated and we don't need to add the `--rewrite` flag. The `--verbose` flag is also no longer a valid parameter, so I've replaced it with `--log-level info`.