### PR TITLE
PER-8781: Show permissions error for adding members

### DIFF
--- a/src/app/core/components/members-dialog/members-dialog.component.ts
+++ b/src/app/core/components/members-dialog/members-dialog.component.ts
@@ -138,17 +138,18 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
     if (
       archive.accessRole !== 'access.role.manager' && archive.accessRole !== 'access.role.owner'
     ) {
-      this.promptService.confirm(
-        'Learn More',
-        'Add Member',
-        null,
-        null,
-        `You do not have permission to add members to this archive.`
-      ).then(() => {
+      try {
+        await this.promptService.confirm(
+          'Learn More',
+          'Add Member',
+          null,
+          null,
+          `You do not have permission to add members to this archive.`
+        );
         window.open('https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing');
-      }).catch(() => {
-        // Catch Promise rejection, but do nothing on "Cancel" button press
-      });
+      } catch {
+        // Catch PromptService rejection, but do nothing on "Cancel" button press
+      }
       return;
     }
     const deferred = new Deferred();

--- a/src/app/core/components/members-dialog/members-dialog.component.ts
+++ b/src/app/core/components/members-dialog/members-dialog.component.ts
@@ -134,6 +134,23 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
   }
 
   async onAddMemberClick() {
+    const archive = this.accountService.getArchive();
+    if (
+      archive.accessRole !== 'access.role.manager' && archive.accessRole !== 'access.role.owner'
+    ) {
+      this.promptService.confirm(
+        'Learn More',
+        'Add Member',
+        null,
+        null,
+        `You do not have permission to add members to this archive.`
+      ).then(() => {
+        window.open('https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing');
+      }).catch(() => {
+        // Catch Promise rejection, but do nothing on "Cancel" button press
+      });
+      return;
+    }
     const deferred = new Deferred();
     let member: AccountVO;
     const emailField: PromptField = {
@@ -157,10 +174,10 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
       if (member.accessRole === 'access.role.owner') {
         deferred.resolve();
         await this.confirmOwnershipTransfer();
-        response = await this.api.archive.transferOwnership(member, this.accountService.getArchive());
+        response = await this.api.archive.transferOwnership(member, archive);
         this.message.showMessage('Ownership transfer request sent.', 'success');
       } else {
-        response = await this.api.archive.addMember(member, this.accountService.getArchive());
+        response = await this.api.archive.addMember(member, archive);
         this.message.showMessage('Member added successfully.', 'success');
         deferred.resolve();
       }


### PR DESCRIPTION
This PR shows a permission error when you try to add members to an archive and don't have the permission to do so (instead of showing the form and only showing the error after you submit it). You should still see the normal form if you are a manager or owner.

Resolves PER-8781.

![2022-04-08-062654](https://user-images.githubusercontent.com/9145247/162447602-a7ddb6ba-a157-40b0-87bb-7bddec5902c8.png)

