### PR TITLE
PER-8497: Fix overlap between widget and upload progress notification

### DIFF
--- a/src/app/core/components/upload-progress/upload-progress.component.scss
+++ b/src/app/core/components/upload-progress/upload-progress.component.scss
@@ -71,7 +71,7 @@ $easing: $tweaked-ease;
   visibility: hidden;
   background: white;
   position: relative;
-  
+
   &.visible {
     transform: translateY(-100%);
     transition: transform $transition-length $easing, opacity $transition-length $easing, visibility 0s linear  0s;
@@ -106,6 +106,7 @@ $easing: $tweaked-ease;
     box-shadow: $box-shadow;
     user-select: none;
     opacity: 0;
+    margin-right: 92px;
     transform: translateY(#{$screen-padding});
 
     &.visible {


### PR DESCRIPTION
Moving it over so it doesn't overlap the Zoho widget. The 92px size was calculated from the Zoho widget's specified CSS width+padding dimensions. This fix is only on desktop view. I'm not even sure how we'd do a fix on mobile view?

Resolves PER-8497.