### PR TITLE
Remove unused `data_size` constants

### DIFF
--- a/constants/master_en.json
+++ b/constants/master_en.json
@@ -48,10 +48,6 @@
       "error": "Errored out"
     }
   },
-  "data_size": {
-    "minimal": "Minimal as possible",
-    "minimal_and_locn": "Minimal as possible and the locnVO"
-  },
   "error": {
     "api": {
       "dev_only": "This endpoint is still in development",


### PR DESCRIPTION
The last references to these two constants were just deleted on the back-end. Delete them from the front-end, too.

PER-8844 Remove unused database code