### PR TITLE
Remove code for unused `/search/record` endpoint

### DIFF
--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -24,17 +24,6 @@ export class SearchRepo extends BaseRepo {
     return this.http.sendRequest<SearchResponse>('/search/archive', data, SearchResponse);
   }
 
-  public recordByNameObservable(query: string, limit?: number): Observable<SearchResponse> {
-    const data = [{
-      SearchVO: {
-        query,
-        numberOfResults: limit
-      }
-    }];
-
-    return this.http.sendRequest<SearchResponse>('/search/record', data, SearchResponse);
-  }
-
   public itemsByNameObservable(query: string, tags: TagVOData[] = [], limit?: number): Observable<SearchResponse> {
     const data = {
       SearchVO: {


### PR DESCRIPTION
The `recordByNameObservable` function which calls the /api/search/record endpoint is not used anywhere in the app currently. Let's go ahead ahead and remove it!