### PR TITLE
PER-8843: Remove donor level

### DIFF
--- a/constants/master_en.json
+++ b/constants/master_en.json
@@ -10,18 +10,6 @@
       "editor": "Editor"
     }
   },
-  "account": {
-    "level": {
-      "benefactor": "Benefactor",
-      "founding_patron": "Founding Patron",
-      "innovators_circle": "Innovators Circle",
-      "none": "None",
-      "partner": "Partner",
-      "presidents_circle": "Presidents Circle",
-      "principals_circle": "Principals Circle",
-      "supporter": "Supporter"
-    }
-  },
   "activity": {
     "grouping": {
       "account": "Account",

--- a/src/app/models/account-vo.ts
+++ b/src/app/models/account-vo.ts
@@ -30,7 +30,6 @@ export interface AccountVOData extends BaseVOData {
   zip?: string;
   primaryPhone?: string;
   defaultArchiveId?: any;
-  level?: string;
   betaParticipant?: any;
   status?: any;
   type?: any;
@@ -73,7 +72,6 @@ export class AccountVO extends BaseVO {
   public zip;
   public primaryPhone;
   public defaultArchiveId;
-  public level;
   public betaParticipant;
   public status;
   public type;

--- a/src/test/data.2.json
+++ b/src/test/data.2.json
@@ -11,7 +11,6 @@
     "zip": null,
     "primaryPhone": null,
     "defaultArchiveId": 2,
-    "level": null,
     "status": "status.auth.ok",
     "type": "type.account.standard",
     "agreed": null,

--- a/src/test/data.json
+++ b/src/test/data.json
@@ -11,7 +11,6 @@
     "zip": null,
     "primaryPhone": null,
     "defaultArchiveId": 1,
-    "level": null,
     "status": "status.auth.ok",
     "type": "type.account.standard",
     "agreed": null,

--- a/src/test/responses/auth.login.success.json
+++ b/src/test/responses/auth.login.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": null,
             "defaultArchiveId": 1,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "agreed": null,

--- a/src/test/responses/auth.login.success.unverifiedEmail.json
+++ b/src/test/responses/auth.login.success.unverifiedEmail.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": null,
             "defaultArchiveId": 9175,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "emailStatus": "status.auth.unverified",

--- a/src/test/responses/auth.signup.success.json
+++ b/src/test/responses/auth.signup.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": null,
             "defaultArchiveId": 1,
-            "level": null,
             "status": "status.auth.need_email",
             "type": "type.account.standard",
             "createdDT": "2018-07-16T21:41:01.000000",

--- a/src/test/responses/auth.verify.success.json
+++ b/src/test/responses/auth.verify.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": null,
             "defaultArchiveId": 1,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "agreed": null,

--- a/src/test/responses/auth.verify.unverifiedBoth.success.json
+++ b/src/test/responses/auth.verify.unverifiedBoth.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": null,
             "defaultArchiveId": 9175,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "emailStatus": "status.auth.unverified",

--- a/src/test/responses/auth.verify.unverifiedEmail.success.json
+++ b/src/test/responses/auth.verify.unverifiedEmail.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": null,
             "defaultArchiveId": 9175,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "emailStatus": "status.auth.unverified",

--- a/src/test/responses/auth.verify.unverifiedPhone.success.json
+++ b/src/test/responses/auth.verify.unverifiedPhone.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": null,
             "defaultArchiveId": 9175,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "emailStatus": "status.auth.verified",

--- a/src/test/responses/auth.verify.verifyEmailNoPhone.success.json
+++ b/src/test/responses/auth.verify.verifyEmailNoPhone.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": "8324553388",
             "defaultArchiveId": 1,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "emailStatus": "status.auth.verified",

--- a/src/test/responses/auth.verify.verifyEmailThenPhone.success.json
+++ b/src/test/responses/auth.verify.verifyEmailThenPhone.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": "8324553388",
             "defaultArchiveId": 1,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "emailStatus": "status.auth.verified",

--- a/src/test/responses/auth.verify.verifyPhone.success.json
+++ b/src/test/responses/auth.verify.verifyPhone.success.json
@@ -15,7 +15,6 @@
             "zip": null,
             "primaryPhone": "8324553388",
             "defaultArchiveId": 1,
-            "level": null,
             "status": "status.auth.ok",
             "type": "type.account.standard",
             "emailStatus": "status.auth.verified",


### PR DESCRIPTION
In a sibling change, I removed the concept of account or donor level
from the backend and database.  Remove it here too for completeness.

PER-8843: Add support for Apple and Google Pay on donations-firebase

See https://github.com/PermanentOrg/back-end/pull/178 for the back-end side of this.

@meisekimiu , this is quite minimal but I didn't see any other places where we use this "account level" concept on the front end.  Apologies if I'm missing something!