### PR TITLE
Install Prettier

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run Prettier
+        run: npx prettier --check --require-pragma .
+
       - name: Run unit tests
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_DEV }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,6 @@
-# package.json is formatted by package managers, so we ignore it here
-package.json
+*.json
+*.webmanifest
+*.yml
+node_modules
+test-reports
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16842,6 +16842,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "npm run secrets && ng test --source-map=false",
     "test:build": "npm run secrets && ng test --source-map=false --watch=false --browsers chrome_headless_no_sandbox",
     "lint": "ng lint",
-    "jest": "jest"
+    "jest": "jest",
+    "prettier": "prettier"
   },
   "private": true,
   "dependencies": {
@@ -104,6 +105,7 @@
     "karma-junit-reporter": "^2.0.1",
     "karma-spec-reporter": "0.0.32",
     "karma-verbose-reporter": "0.0.6",
+    "prettier": "^2.6.2",
     "ts-jest": "^27.0.7",
     "ts-node": "~8.6.2",
     "tslib": "^2.0.0",


### PR DESCRIPTION
I'm tired of having to manually format code. As discussed in #125, we should not even really have to think of this. This PR installs prettier to do formatting for us. This PR does not actually add it to CI, install pre-commit hooks, or run it against any files (though I did have to test it out on some of the files I've recently working on just to make sure it works properly).

My thought is that we probably shouldn't just run it on our whole project all at once. Maybe I'm wrong though? Instead I'm thinking we just run it on any files we have changes on in the future.

Resolves #91