### PR TITLE
Fix Sass deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -370,6 +370,15 @@
             }
           }
         },
+        "sass": {
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/sass/-/sass-1.36.0.tgz",
+          "integrity": "sha512-fQzEjipfOv5kh930nu3Imzq3ie/sGDc/4KtQMJlt7RRdrkQSfe37Bwi/Rf/gfuYHsIuE1fIlDMvpyMcEwjnPvg==",
+          "dev": true,
+          "requires": {
+            "chokidar": ">=3.0.0 <4.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7930,8 +7939,7 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "binaryjs": {
       "version": "0.2.1",
@@ -8047,7 +8055,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -8315,7 +8322,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -8331,7 +8337,6 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
           "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-          "dev": true,
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
@@ -8341,7 +8346,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -11281,7 +11285,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -11518,7 +11521,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -12272,6 +12274,11 @@
       "dev": true,
       "optional": true
     },
+    "immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -12577,7 +12584,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -12673,8 +12679,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -12691,7 +12696,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -12717,8 +12721,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.6",
@@ -16297,8 +16300,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -17040,8 +17042,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "4.0.1",
@@ -18940,7 +18941,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -19289,12 +19289,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.36.0.tgz",
-      "integrity": "sha512-fQzEjipfOv5kh930nu3Imzq3ie/sGDc/4KtQMJlt7RRdrkQSfe37Bwi/Rf/gfuYHsIuE1fIlDMvpyMcEwjnPvg==",
-      "dev": true,
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.0.tgz",
+      "integrity": "sha512-C4zp79GCXZfK0yoHZg+GxF818/aclhp9F48XBu/+bm9vXEVAYov9iU3FBVRMq3Hx3OA4jfKL+p2K9180mEh0xQ==",
       "requires": {
-        "chokidar": ">=3.0.0 <4.0.0"
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
     "sass-loader": {
@@ -19934,8 +19935,7 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-loader": {
       "version": "3.0.0",
@@ -20891,7 +20891,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ngx-route-history": "0.0.4",
     "progressbar.js": "1.0.1",
     "rxjs": "6.6.3",
+    "sass": "^1.54.0",
     "shallow-render": "12.0.1",
     "time-ago-pipe": "^1.3.2",
     "ts-key-enum": "^2.0.2",

--- a/src/app/apps/components/connector/connector.component.scss
+++ b/src/app/apps/components/connector/connector.component.scss
@@ -69,11 +69,11 @@ $info-height: $file-list-row-height;
 }
 
 .connector-actions {
-  padding-top: $grid-unit / 2;
+  padding-top: $grid-unit * 0.5;
 
   .btn {
     margin: 0 auto;
-    margin-bottom: $grid-unit / 2;
+    margin-bottom: $grid-unit * 0.5;
   }
 }
 
@@ -86,9 +86,9 @@ $info-height: $file-list-row-height;
 }
 
 [prBgImage] {
-  height: $info-height - ($grid-unit / 2);
-  width: $info-height - ($grid-unit / 2);
-  flex: 0 0 $info-height - ($grid-unit / 2);
+  height: $info-height - ($grid-unit * 0.5);
+  width: $info-height - ($grid-unit * 0.5);
+  flex: 0 0 $info-height - ($grid-unit * 0.5);
   margin: 5px 0px;
   margin-right: 5px;
 }

--- a/src/app/core/components/account-settings/account-settings.component.scss
+++ b/src/app/core/components/account-settings/account-settings.component.scss
@@ -15,7 +15,7 @@ p {
 
   .settings-group-title {
     font-weight: $font-weight-bold;
-    padding: $grid-unit / 2 0;
+    padding: $grid-unit * 0.5 0;
   }
 }
 
@@ -31,7 +31,7 @@ p {
 
   & > label {
     font-weight: $font-weight-bold;
-    padding: $grid-unit / 2 0;
+    padding: $grid-unit * 0.5 0;
     margin-bottom: 0px;
     flex: 0 0 12rem;
     display: flex;
@@ -39,7 +39,7 @@ p {
 
     i {
       font-size: $mat-icon-sm;
-      margin-left: $grid-unit / 2;
+      margin-left: $grid-unit * 0.5;
       cursor: pointer;
     }
   }

--- a/src/app/core/components/all-archives/all-archives.component.scss
+++ b/src/app/core/components/all-archives/all-archives.component.scss
@@ -6,7 +6,7 @@
   @include hasFloatSidebar;
 
   @include beforeDesktop {
-    padding: 0 $grid-unit / 2;
+    padding: 0 $grid-unit * 0.5;
   } 
 }
 .sidebar {

--- a/src/app/core/components/billing-settings/billing-settings.component.scss
+++ b/src/app/core/components/billing-settings/billing-settings.component.scss
@@ -15,7 +15,7 @@ p {
 
   .settings-group-title {
     font-weight: $font-weight-bold;
-    padding: $grid-unit / 2 0;
+    padding: $grid-unit * 0.5 0;
   }
 }
 
@@ -31,7 +31,7 @@ p {
 
   & > label {
     font-weight: $font-weight-bold;
-    padding: $grid-unit / 2 0;
+    padding: $grid-unit * 0.5 0;
     margin-bottom: 0px;
     flex: 0 0 12rem;
   }

--- a/src/app/core/components/left-menu/left-menu.component.scss
+++ b/src/app/core/components/left-menu/left-menu.component.scss
@@ -9,7 +9,7 @@ $active-color: $PR-orange;
 $active-indicator-color: lighten($active-color, 7%);
 
 $archive-options-shadow-color: rgba($black, .1);
-$archive-options-shadow-spread: $grid-unit / 4;
+$archive-options-shadow-spread: $grid-unit * 0.25;
 $archive-options-shadow-offset: 0.5rem;
 
 :host {
@@ -100,7 +100,7 @@ $archive-options-shadow-offset: 0.5rem;
     font-weight: 700;
     text-decoration: none;
 
-    transition: background-color $transition-length / 4 ease-in;
+    transition: background-color $transition-length * 0.25 ease-in;
 
     a {
       color: white;
@@ -242,7 +242,7 @@ $archive-options-shadow-offset: 0.5rem;
       .archive-name {
         padding: 0 !important;
         font-weight: bold;
-        padding: $grid-unit / 2;
+        padding: $grid-unit * 0.5;
       }
 
       .archive-access {
@@ -280,7 +280,7 @@ $archive-options-shadow-offset: 0.5rem;
         justify-content: center;
         cursor: pointer;
         background-color: $PR-blue;
-        transition: background-color $transition-length / 4 ease-in;
+        transition: background-color $transition-length * 0.25 ease-in;
 
         &:hover {
           background-color: $hover-color;
@@ -294,7 +294,7 @@ $archive-options-shadow-offset: 0.5rem;
       flex: 0 0 auto;
       background-color: $PR-blue;
       hr {
-        margin: $grid-unit / 2;
+        margin: $grid-unit * 0.5;
         border-color: white;
       }
       overflow-y: hidden;
@@ -302,7 +302,7 @@ $archive-options-shadow-offset: 0.5rem;
 
     .archive-options-option {
       height: 2 * $grid-unit;
-      padding: 0 $grid-unit / 2;
+      padding: 0 $grid-unit * 0.5;
       padding-left: $grid-unit * 1.5;
       display: flex;
       align-items: center;

--- a/src/app/core/components/members-dialog/members-dialog.component.scss
+++ b/src/app/core/components/members-dialog/members-dialog.component.scss
@@ -58,6 +58,6 @@
   align-items: center;
   button {
     @include gridHeightButtonSmall;
-    margin-left: $grid-unit / 2;
+    margin-left: $grid-unit * 0.5;
   }
 }

--- a/src/app/core/components/nav/nav.component.scss
+++ b/src/app/core/components/nav/nav.component.scss
@@ -140,11 +140,11 @@ nav.nav-desktop {
       &:after {
         position: absolute;
         top: 0;
-        right: -$grid-unit / 4;
+        right: -$grid-unit * 0.25;
         display: block;
         content: '';
-        height: $grid-unit / 2;
-        width: $grid-unit / 2;
+        height: $grid-unit * 0.5;
+        width: $grid-unit * 0.5;
         background: $red;
         border-radius: 50%;
 

--- a/src/app/core/components/notification-preferences/notification-preferences.component.scss
+++ b/src/app/core/components/notification-preferences/notification-preferences.component.scss
@@ -21,11 +21,11 @@
 
 .preference-group-title {
   font-weight: $font-weight-bold;
-  padding: $grid-unit / 2 0;
+  padding: $grid-unit * 0.5 0;
 }
 
 .form-check {
-  margin-bottom: $grid-unit / 2;
+  margin-bottom: $grid-unit * 0.5;
 
   input {
     cursor: pointer;

--- a/src/app/core/components/profile-edit/profile-edit.component.scss
+++ b/src/app/core/components/profile-edit/profile-edit.component.scss
@@ -8,8 +8,8 @@
 .header {
   @include tabbedDialogHeader($PR-blue-light);
   button {
-    margin-left: -$grid-unit / 2;
-    margin-right: $grid-unit / 2;
+    margin-left: -$grid-unit * 0.5;
+    margin-right: $grid-unit * 0.5;
   }
 }
 
@@ -23,7 +23,7 @@
 
 .panel {
   flex: 1 1 auto;
-  padding: 0 $grid-unit / 2;
+  padding: 0 $grid-unit * 0.5;
   display: flex;
   flex-direction: column;
   @include desktop {
@@ -75,7 +75,7 @@
 
       input {
         cursor: pointer;
-        margin-right: $grid-unit / 2;
+        margin-right: $grid-unit * 0.5;
       }
 
       label {
@@ -98,7 +98,7 @@
       font-weight: $font-weight-semibold;
       display: flex;
       align-items: center;
-      margin-bottom: $grid-unit / 2;
+      margin-bottom: $grid-unit * 0.5;
     }
 
     em {
@@ -148,7 +148,7 @@
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  padding-bottom: $grid-unit / 4;
+  padding-bottom: $grid-unit * 0.25;
   height: $grid-unit * 3;
 
   $list: rgba($black, 0), rgba($black, 0.7);
@@ -162,7 +162,7 @@
   i {
     color: white;
     font-size: $mat-icon-sm;
-    margin-right: $grid-unit / 4;
+    margin-right: $grid-unit * 0.25;
   }
 }
 
@@ -192,7 +192,7 @@
   max-width: pxToGrid(400px);
   > span {
     min-height: $line-height-base;
-    padding-top: $grid-unit / 2;
+    padding-top: $grid-unit * 0.5;
     flex: 0 0 auto;
   }
 }

--- a/src/app/core/components/relationships/relationships.component.scss
+++ b/src/app/core/components/relationships/relationships.component.scss
@@ -67,7 +67,7 @@ p {
   @include hasFloatSidebar;
 
   @include beforeDesktop {
-    padding: 0 $grid-unit / 2;
+    padding: 0 $grid-unit * 0.5;
   } 
 }
 

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.scss
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import 'variables';
 
 :host {
@@ -81,8 +83,8 @@
   }
 
   .select-active {
-    height: $multi-select-radius * (2/3);
-    width: $multi-select-radius * (2/3);
+    height: $multi-select-radius * math.div(2, 3);
+    width: $multi-select-radius * math.div(2, 3);
     border-radius: 50%;
     background: $PR-blue;
     opacity: 0;

--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.scss
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.scss
@@ -16,7 +16,7 @@
   flex: 1 1 100%;
   display: flex;
   align-items: center;
-  height: $file-list-controls-height / 2;
+  height: $file-list-controls-height * 0.5;
 
   > * {
     font-weight: 600;
@@ -34,7 +34,7 @@
     .col-title::after {
       @include material-icon;
       content: 'expand_more';
-      margin-left: $grid-unit / 2;
+      margin-left: $grid-unit * 0.5;
       font-size: $font-size-lg;
       display: inline-flex;
       align-items: center;
@@ -61,7 +61,7 @@
     opacity: 0.5;
     cursor: pointer;
     font-size: 0.85em;
-    padding-left: $grid-unit / 2;
+    padding-left: $grid-unit * 0.5;
 
     &:hover {
       opacity: 0.8;
@@ -159,7 +159,7 @@
 
 .top-row {
   display: flex;
-  height: $file-list-controls-height / 2;
+  height: $file-list-controls-height * 0.5;
   align-items: center;
 
 }
@@ -203,7 +203,7 @@ pr-folder-view-toggle {
     @include until(1100px) {
       font-size: $font-size-sm;
       &:not(:last-child) {
-        margin-right: $grid-unit / 4;
+        margin-right: $grid-unit * 0.25;
       }
 
       i {
@@ -214,7 +214,7 @@ pr-folder-view-toggle {
 
     @include until (1200px) {
       &:not(:last-child) {
-        margin-right: $grid-unit / 2;
+        margin-right: $grid-unit * 0.5;
       }
     }
 

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.scss
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import 'variables';
 
 $row-height: $file-list-row-height;
@@ -18,19 +20,19 @@ $bg-transition-length: 0.075s;
     padding-bottom: 5px;
     @for $i from 3 through 10 {
       @media screen and (min-width: $i * $max-grid-width + 1){
-        width: 100% / $i;
+        width: math.div(100%, $i);
       }
     }
   }
 }
 
 :host.grid-view {
-  padding: 0 $file-list-grid-gutter / 2;
+  padding: 0 $file-list-grid-gutter * 0.5;
   margin-bottom: $file-list-grid-gutter;
 
   @include beforeDesktop {
-    padding: 0 $file-list-grid-gutter / 4;
-    margin-bottom: $file-list-grid-gutter / 2;
+    padding: 0 $file-list-grid-gutter * 0.25;
+    margin-bottom: $file-list-grid-gutter * 0.5;
   }
 
   .share-preview-content & {
@@ -43,7 +45,7 @@ $bg-transition-length: 0.075s;
     width: 50%;
     @for $i from 2 through 10 {
       @media screen and (min-width: ($i * $max-grid-width-sidebar) + $sidebar-width + $left-menu-width + 1){
-        width: 100% / $i;
+        width: math.div(100%, $i);
       }
     }
   }
@@ -51,7 +53,7 @@ $bg-transition-length: 0.075s;
   .public-content & {
     @for $i from 2 through 10 {
       @media screen and (min-width: ($i * $max-grid-width-public) + $profile-sidebar-width + 1){
-        width: 100% / $i;
+        width: math.div(100%, $i);
       }
     }
   }
@@ -129,8 +131,8 @@ $bg-transition-length: 0.075s;
 
   i, fa-icon {
     flex: 0 0 auto;
-    margin-left: $grid-unit / 2;
-    margin-right: $grid-unit / 2;
+    margin-left: $grid-unit * 0.5;
+    margin-right: $grid-unit * 0.5;
   }
 
   .second-row {
@@ -237,9 +239,9 @@ $bg-transition-length: 0.075s;
 }
 
 [prBgImage], .file-list-item-folder-icon {
-  height: $row-height - ($grid-unit / 2);
-  width: $row-height - ($grid-unit / 2);
-  flex: 0 0 $row-height - ($grid-unit / 2);
+  height: $row-height - ($grid-unit * 0.5);
+  width: $row-height - ($grid-unit * 0.5);
+  flex: 0 0 $row-height - ($grid-unit * 0.5);
   margin: pxToGrid(5px);
 
   .grid-view & {
@@ -249,7 +251,7 @@ $bg-transition-length: 0.075s;
     margin: 0px;
     box-shadow: inset 0px 0px 0px $grid-selected-border - 1px $gray-300;
     transition: box-shadow $bg-transition-length $tweaked-ease;
-    border-radius: $grid-unit / 2;
+    border-radius: $grid-unit * 0.5;
     overflow: hidden;
   }
 
@@ -292,7 +294,7 @@ $bg-transition-length: 0.075s;
 
 .grid-view .grid-item-type-icon {
   $diameter: $grid-unit * 2;
-  $margin: $grid-unit / 2;
+  $margin: $grid-unit * 0.5;
   position: absolute;
   bottom: $grid-info-section-height + $margin;
   right: $margin;

--- a/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.scss
+++ b/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.scss
@@ -53,7 +53,7 @@ p {
 }
 
 .shares-title, .shares-empty {
-  margin-top: $grid-unit / 2;
+  margin-top: $grid-unit * 0.5;
   height: $grid-unit * 2;
   display: flex;
   align-items: center;
@@ -83,7 +83,7 @@ p {
     @include gridHeightButton;
     width: auto;
     margin: 0;
-    margin-left: $grid-unit / 2;
+    margin-left: $grid-unit * 0.5;
   }
 }
 
@@ -97,13 +97,13 @@ p {
   min-width: 0;
 
   &:not(:last-child) {
-    margin-bottom: $grid-unit / 2;
+    margin-bottom: $grid-unit * 0.5;
   }
 
   .archive-thumb {
     height: $grid-unit * 2;
     flex: 0 0 $grid-unit * 2;
-    margin-right: $grid-unit / 2;
+    margin-right: $grid-unit * 0.5;
   }
 
   .archive-name {
@@ -123,7 +123,7 @@ p {
     .btn {
       @include gridHeightButtonSmall;
       width: 6rem;
-      margin-left: $grid-unit / 2;
+      margin-left: $grid-unit * 0.5;
     }
   }
 
@@ -187,7 +187,7 @@ p {
 
     select {
       @include gridHeightInputSmall;
-      margin-left: -$grid-unit / 2;
+      margin-left: -$grid-unit * 0.5;
       margin-right: auto;
     }
 

--- a/src/app/file-browser/components/sharing/sharing.component.scss
+++ b/src/app/file-browser/components/sharing/sharing.component.scss
@@ -18,9 +18,9 @@
   $preview-height: $file-list-row-height;
 
   [prBgImage] {
-    height: $preview-height - ($grid-unit / 2);
-    width: $preview-height - ($grid-unit / 2);
-    flex: 0 0 $preview-height - ($grid-unit / 2);
+    height: $preview-height - ($grid-unit * 0.5);
+    width: $preview-height - ($grid-unit * 0.5);
+    flex: 0 0 $preview-height - ($grid-unit * 0.5);
     margin-right: 5px;
   }
 

--- a/src/app/file-browser/components/sidebar/sidebar.component.scss
+++ b/src/app/file-browser/components/sidebar/sidebar.component.scss
@@ -56,10 +56,10 @@ $sidebar-thumb-height: 200px;
 }
 
 .sidebar-item {
-  padding: $grid-unit / 2 $grid-unit;
+  padding: $grid-unit * 0.5 $grid-unit;
   label {
     font-weight: 600;
-    margin-bottom: $grid-unit / 2;
+    margin-bottom: $grid-unit * 0.5;
   }
 
   .sidebar-item-content {

--- a/src/app/notifications/components/notification-dialog/notification-dialog.component.scss
+++ b/src/app/notifications/components/notification-dialog/notification-dialog.component.scss
@@ -25,7 +25,7 @@
 .footer {
   display: flex;
   justify-content: center;
-  padding: $grid-unit / 2;
+  padding: $grid-unit * 0.5;
   border-top: $file-list-border;
   .btn {
     @include gridHeightButtonSmall;

--- a/src/app/pledge/components/new-pledge/new-pledge.component.scss
+++ b/src/app/pledge/components/new-pledge/new-pledge.component.scss
@@ -125,5 +125,5 @@ button {
 }
 
 .error {
-  padding-top: $grid-unit / 2;
+  padding-top: $grid-unit * 0.5;
 }

--- a/src/app/public/components/public-archive/public-archive.component.scss
+++ b/src/app/public/components/public-archive/public-archive.component.scss
@@ -3,7 +3,7 @@
 :host {
   display: block;
   width: 100%;
-  padding: 0 $grid-unit / 2;
+  padding: 0 $grid-unit * 0.5;
 }
 
 $photo-desktop: pxToGrid(300px);
@@ -19,7 +19,7 @@ $profile-max-width: 1200px;
   position: relative;
 
   @include beforeDesktop {
-    margin: 0 -$grid-unit / 2;
+    margin: 0 -$grid-unit * 0.5;
   }
 }
 
@@ -99,7 +99,7 @@ $profile-max-width: 1200px;
 
     label {
       margin: 0;
-      margin-right: $grid-unit / 2;
+      margin-right: $grid-unit * 0.5;
       font-weight: $font-weight-semibold;
       white-space: nowrap;
     }
@@ -112,7 +112,7 @@ $profile-max-width: 1200px;
     }
 
     > * {
-      margin-bottom: $grid-unit / 2;
+      margin-bottom: $grid-unit * 0.5;
     }
   }
 }
@@ -125,7 +125,7 @@ $profile-max-width: 1200px;
   }
 
   @include beforeDesktop {
-    margin-top: $grid-unit / 2;
+    margin-top: $grid-unit * 0.5;
   }
 }
 

--- a/src/app/public/components/public-profile/public-profile.component.scss
+++ b/src/app/public/components/public-profile/public-profile.component.scss
@@ -42,7 +42,7 @@ $profile-max-width: 1200px;
   @include profileField;
 
   &:last-child {
-    margin-bottom: $grid-unit / 2;
+    margin-bottom: $grid-unit * 0.5;
   }
 }
 
@@ -60,5 +60,5 @@ $profile-max-width: 1200px;
 }
 
 .profile-field-description {
-  margin-top: $grid-unit / 2;
+  margin-top: $grid-unit * 0.5;
 }

--- a/src/app/search/components/global-search-bar/global-search-bar.component.scss
+++ b/src/app/search/components/global-search-bar/global-search-bar.component.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import 'variables';
 
 @keyframes fadein {
@@ -166,7 +168,7 @@ $result-padding-y: 0.25rem;
       font-weight: 600;
 
       i {
-        font-size: $mat-icon-sm * (2/3);
+        font-size: $mat-icon-sm * math.div(2, 3);
         margin-right: 0.25em;
         position: relative;
         top: 0.1em;

--- a/src/app/search/components/global-search-results/global-search-results.component.scss
+++ b/src/app/search/components/global-search-results/global-search-results.component.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import 'variables';
 
 :host {
@@ -184,13 +186,13 @@ $result-gutter: 1rem;
   padding-top: 0.5rem;
   margin-left: -10px;
   margin-right: -10px;
-  padding: 0 $gutter / 2;
+  padding: 0 $gutter * 0.5;
 
   .item-result-wrapper {
     flex: 0 0 auto;
     width: 50%;
     margin: 0;
-    padding: $gutter / 2;
+    padding: $gutter * 0.5;
   }
 
   .item-result {
@@ -219,7 +221,7 @@ $result-gutter: 1rem;
   @for $i from 2 through 6 {
     @media screen and (min-width: ($i * $max-grid-width) + 1) and (max-width: $tablet-horizontal){
       .item-result-wrapper {
-        width: 100% / $i;
+        width: math.div(100%, $i);
       }
     }
   }
@@ -227,7 +229,7 @@ $result-gutter: 1rem;
   @for $i from 3 through 10 {
     @media screen and (min-width: ($i * $result-width-desktop) + $left-menu-width + 1){
       .item-result-wrapper {
-        width: 100% / $i;
+        width: math.div(100%, $i);
       }
     }
   }

--- a/src/app/shared/components/account-dropdown/account-dropdown.component.scss
+++ b/src/app/shared/components/account-dropdown/account-dropdown.component.scss
@@ -26,7 +26,7 @@ button {
   text-overflow: ellipsis;
   
   > span {
-    margin-right: $grid-unit / 4;
+    margin-right: $grid-unit * 0.25;
   }
 
   i {
@@ -43,7 +43,7 @@ i.badge {
   color: $warning;
   font-size: $mat-icon-sm;
 
-  top: -$grid-unit / 4;
+  top: -$grid-unit * 0.25;
   right: 0;
   z-index: 3;
 
@@ -77,7 +77,7 @@ i.badge {
 
     i {
       font-size: $mat-icon-sm;
-      margin-right: $grid-unit / 2;
+      margin-right: $grid-unit * 0.5;
       animation:  fadeIn 125ms $tweaked-ease, pulse 2s $tweaked-ease infinite;
     }
   }

--- a/src/app/shared/components/archive-search-box/archive-search-box.component.scss
+++ b/src/app/shared/components/archive-search-box/archive-search-box.component.scss
@@ -30,7 +30,7 @@ input {
     display: flex;
     align-items: center;
 
-    padding: $grid-unit / 2;
+    padding: $grid-unit * 0.5;
 
     &:hover {
       cursor: pointer;
@@ -39,13 +39,13 @@ input {
 }
 
 .archive-result {
-  padding: $grid-unit / 2;
+  padding: $grid-unit * 0.5;
 
   .archive-thumb {
     height: $grid-unit * 2;
     width: $grid-unit * 2;
     flex: 0 0 auto;
-    margin-right: $grid-unit / 2;
+    margin-right: $grid-unit * 0.5;
     border-radius: $border-radius;
   }
 

--- a/src/app/shared/components/archive-small/archive-small.component.scss
+++ b/src/app/shared/components/archive-small/archive-small.component.scss
@@ -62,7 +62,7 @@ $thumb-size: 50px;
   button {
     margin: 0;
     @include gridHeightButtonSmall;
-    margin-left: $grid-unit / 2;
+    margin-left: $grid-unit * 0.5;
   }
 }
 $desktop-height: pxToGrid(60px);
@@ -104,11 +104,11 @@ $desktop-height: pxToGrid(60px);
         padding: 0px;
         > a {
           display: flex;
-          padding: $grid-unit / 4 $grid-unit / 2;
+          padding: $grid-unit * 0.25 $grid-unit * 0.5;
           align-items: center;
 
           > i {
-            margin-right: $grid-unit / 2;
+            margin-right: $grid-unit * 0.5;
           }
 
           &:hover {

--- a/src/app/shared/components/beta-toggle/beta-toggle.component.scss
+++ b/src/app/shared/components/beta-toggle/beta-toggle.component.scss
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  padding: $grid-unit / 2;
+  padding: $grid-unit * 0.5;
   font-size: $font-size-xs;
   line-height: 1;
 
@@ -13,5 +13,5 @@
 
 .btn {
   width: auto;
-  margin: $grid-unit / 2 0 0px;
+  margin: $grid-unit * 0.5 0 0px;
 }

--- a/src/app/shared/components/folder-view-toggle/folder-view-toggle.component.scss
+++ b/src/app/shared/components/folder-view-toggle/folder-view-toggle.component.scss
@@ -5,8 +5,8 @@
 }
 
 button {
-  padding-left: $grid-unit / 2;
-  padding-right: $grid-unit / 2;
+  padding-left: $grid-unit * 0.5;
+  padding-right: $grid-unit * 0.5;
   background: none;
   display: flex;
   align-items: center;
@@ -34,6 +34,6 @@ button {
   }
 
   @include until(1100px) {
-    padding: 0 $grid-unit / 4;
+    padding: 0 $grid-unit * 0.25;
   }
 }

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 
-$inline-padding-x: $grid-unit / 5;
-$inline-padding-y: $grid-unit / 2;
+$inline-padding-x: $grid-unit * 0.2;
+$inline-padding-y: $grid-unit * 0.5;
 
 :host {
   display: block;

--- a/src/app/views/components/timeline-view/timeline-view.component.scss
+++ b/src/app/views/components/timeline-view/timeline-view.component.scss
@@ -28,7 +28,7 @@
   width: 150px;
 
   .control-row {
-    padding: $btn-padding-y / 2;
+    padding: $btn-padding-y * 0.5;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/styles/_dialog.scss
+++ b/src/styles/_dialog.scss
@@ -54,7 +54,7 @@ $header-height: 3 * $grid-unit;
     position: relative;
     display: flex;
     align-items: center;
-    padding-left: $grid-unit / 2;
+    padding-left: $grid-unit * 0.5;
     cursor: pointer;
     user-select: none;
     font-size: $font-size-sm;
@@ -68,7 +68,7 @@ $header-height: 3 * $grid-unit;
       background-color: $gray-500;
       position: absolute;
       left: 0;
-      width: $grid-unit / 5;
+      width: $grid-unit * 0.2;
       top: 0;
       bottom: 0;
       opacity: 0;
@@ -94,14 +94,14 @@ $header-height: 3 * $grid-unit;
 
     i {
       font-size: $mat-icon-sm;
-      margin-left: $grid-unit / 2;
+      margin-left: $grid-unit * 0.5;
     }
   }
 }
 
 @mixin tabbedDialogPanel {
   flex: 1 1 auto;
-  padding: 0 $grid-unit / 2;
+  padding: 0 $grid-unit * 0.5;
   @include desktop {
     padding: $grid-unit;
     overflow-y: auto;
@@ -167,7 +167,7 @@ $header-height: 3 * $grid-unit;
       display: block;
 
       label {
-        margin-bottom: $grid-unit / 4;
+        margin-bottom: $grid-unit * 0.25;
       }
     }
   }
@@ -185,13 +185,13 @@ $header-height: 3 * $grid-unit;
       }
 
       &:not(:last-child) {
-        margin-right: $grid-unit / 2;
+        margin-right: $grid-unit * 0.5;
       }
     }
   }
 
   .form-control {
-    padding: $grid-unit / 2 $grid-unit / 5;
+    padding: $grid-unit * 0.5 $grid-unit * 0.2;
     height: auto;
   }
 
@@ -200,7 +200,7 @@ $header-height: 3 * $grid-unit;
   }
 
   .form-check:not(:last-child) {
-    margin-right: $grid-unit / 2;
+    margin-right: $grid-unit * 0.5;
   }
 
   button {

--- a/src/styles/_fileList.scss
+++ b/src/styles/_fileList.scss
@@ -29,17 +29,17 @@ pr-file-list, pr-shares {
     &.grid-view {
       .file-list-scroll {
         padding-top: $file-list-grid-gutter;
-        margin: 0 (-$file-list-grid-gutter / 2);
-        margin-right: -($file-list-grid-gutter / 2) ;
+        margin: 0 (-$file-list-grid-gutter * 0.5);
+        margin-right: -($file-list-grid-gutter * 0.5) ;
   
         @include beforeDesktop {
-          margin: 0 (-$file-list-grid-gutter / 2);
+          margin: 0 (-$file-list-grid-gutter * 0.5);
         }
       }
 
       &.show-sidebar .file-list-scroll {
         margin-right: -$grid-unit;
-        padding-right: $grid-unit - ($file-list-grid-gutter/2);
+        padding-right: $grid-unit - ($file-list-grid-gutter*0.5);
       }
   
       .file-list-scroll:after {

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -118,7 +118,7 @@ form {
   .input-vertical.checkbox {
     background: $gray-600;
     color: white;
-    padding: $input-padding-y / 2 $input-padding-x;
+    padding: $input-padding-y * 0.5 $input-padding-x;
 
     .form-check {
       margin: 0;

--- a/src/styles/_grid.scss
+++ b/src/styles/_grid.scss
@@ -1,7 +1,9 @@
+@use "sass:math";
+
 $grid-unit-px: 20px;
 $grid-unit: 1.25rem;
-$half-unit: $grid-unit / 2;
+$half-unit: $grid-unit * 0.5;
 
 @function pxToGrid($px) {
-  @return ($px / $grid-unit-px) * $grid-unit;
+  @return math.div($px, $grid-unit-px) * $grid-unit;
 }

--- a/src/styles/_menus.scss
+++ b/src/styles/_menus.scss
@@ -60,8 +60,8 @@ pr-dialog {
       overflow-y: auto;
 
       .page-subheading {
-        margin-right: $grid-unit / 2;
-        margin-left: $grid-unit / 2;
+        margin-right: $grid-unit * 0.5;
+        margin-left: $grid-unit * 0.5;
       }
     }
 

--- a/src/styles/_ng-bootstrap.scss
+++ b/src/styles/_ng-bootstrap.scss
@@ -42,7 +42,7 @@ ngb-datepicker {
 ngb-timepicker {
   .ngb-tp-input-container, .ngb-tp-meridian {
     input, button {
-      padding: $input-padding-y-sm / 2 $input-padding-x-sm / 2;
+      padding: $input-padding-y-sm * 0.5 $input-padding-x-sm * 0.5;
     }
 
     button {

--- a/src/styles/_profile.scss
+++ b/src/styles/_profile.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $profile-max-width: 1000px;
 $profile-sidebar-width: pxToGrid(360px);
 
@@ -26,15 +28,15 @@ $profile-sidebar-width: pxToGrid(360px);
   background-position: 50% 50%;
   position: relative;
   margin-left: 2 * $grid-unit;
-  margin-bottom: -$desktop-size * 2/3 + $grid-unit;
-  transform: translateY(-(2/3 * 100%));
+  margin-bottom: math.div(-$desktop-size * 2, 3) + $grid-unit;
+  transform: translateY(-(math.div(2, 3) * 100%));
   cursor: pointer;
 
   @include beforeDesktop {
     height: $mobile-size;
     width: $mobile-size;
-    margin-left: $grid-unit / 2;
-    margin-bottom: -$mobile-size/2 + $grid-unit;
+    margin-left: $grid-unit * 0.5;
+    margin-bottom: -$mobile-size*0.5 + $grid-unit;
   }
 }
 
@@ -105,8 +107,8 @@ $profile-sidebar-width: pxToGrid(360px);
 
   @include desktop {
     &.in-thirds > * {
-      flex: 0 1 (100% * 1/3);
-      max-width: 100% * 1/3;
+      flex: 0 1 math.div(100% * 1, 3);
+      max-width: math.div(100% * 1, 3);
   
       &.two-thirds {
         flex: 0 1 68.9%;
@@ -123,13 +125,13 @@ $profile-sidebar-width: pxToGrid(360px);
 
 @mixin profileField {
   label {
-    margin-bottom: $grid-unit / 4;
+    margin-bottom: $grid-unit * 0.25;
     font-weight: $font-weight-semibold;
   }
 
   pr-inline-value-edit {
-    margin-left: $grid-unit / 4;
-    margin-right: $grid-unit / 4;
+    margin-left: $grid-unit * 0.25;
+    margin-right: $grid-unit * 0.25;
 
     &:not(:first-of-type) {
       margin-top: $grid-unit;

--- a/src/styles/_ui.scss
+++ b/src/styles/_ui.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 button.btn, a.btn {
   display: block;
   margin: 10px auto;
@@ -173,7 +175,7 @@ a {
   $size: 34px;
   background: rgba(white, 0.2);
   height: $size;
-  border-radius: $size / 2;
+  border-radius: $size * 0.5;
   color: $PR-orange;
   font-weight: 700;
   text-transform: uppercase;
@@ -296,7 +298,7 @@ $drag-outline-border: 5px;
     justify-content: center;
 
     min-width: 15rem;
-    max-width: $file-list-width-desktop / 3;
+    max-width: calc($file-list-width-desktop / 3);
     // transform-origin: 50% 50%;
 
     .drag-service-cursor-item, .drag-service-cursor-action {

--- a/src/styles/_utilities.scss
+++ b/src/styles/_utilities.scss
@@ -129,7 +129,7 @@
   color: #F7C985;
 
   i {
-    font-size: $height - ($grid-unit / 4);
+    font-size: $height - ($grid-unit * 0.25);
   }
 }
 

--- a/src/styles/vendor/bootstrap/_card.scss
+++ b/src/styles/vendor/bootstrap/_card.scss
@@ -43,7 +43,7 @@
 }
 
 .card-subtitle {
-  margin-top: -($card-spacer-y / 2);
+  margin-top: -($card-spacer-y * 0.5);
   margin-bottom: 0;
 }
 
@@ -98,15 +98,15 @@
 //
 
 .card-header-tabs {
-  margin-right: -($card-spacer-x / 2);
+  margin-right: -($card-spacer-x * 0.5);
   margin-bottom: -$card-spacer-y;
-  margin-left: -($card-spacer-x / 2);
+  margin-left: -($card-spacer-x * 0.5);
   border-bottom: 0;
 }
 
 .card-header-pills {
-  margin-right: -($card-spacer-x / 2);
-  margin-left: -($card-spacer-x / 2);
+  margin-right: -($card-spacer-x * 0.5);
+  margin-left: -($card-spacer-x * 0.5);
 }
 
 // Card image

--- a/src/styles/vendor/bootstrap/_carousel.scss
+++ b/src/styles/vendor/bootstrap/_carousel.scss
@@ -225,9 +225,9 @@
 
 .carousel-caption {
   position: absolute;
-  right: ((100% - $carousel-caption-width) / 2);
+  right: ((100% - $carousel-caption-width) * 0.5);
   bottom: 20px;
-  left: ((100% - $carousel-caption-width) / 2);
+  left: ((100% - $carousel-caption-width) * 0.5);
   z-index: 10;
   padding-top: 20px;
   padding-bottom: 20px;

--- a/src/styles/vendor/bootstrap/_custom-forms.scss
+++ b/src/styles/vendor/bootstrap/_custom-forms.scss
@@ -63,7 +63,7 @@
   // Background-color and (when enabled) gradient
   &::before {
     position: absolute;
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: (($line-height-base - $custom-control-indicator-size) * 0.5);
     left: -$custom-control-gutter;
     display: block;
     width: $custom-control-indicator-size;
@@ -78,7 +78,7 @@
   // Foreground (icon)
   &::after {
     position: absolute;
-    top: (($line-height-base - $custom-control-indicator-size) / 2);
+    top: (($line-height-base - $custom-control-indicator-size) * 0.5);
     left: -$custom-control-gutter;
     display: block;
     width: $custom-control-indicator-size;

--- a/src/styles/vendor/bootstrap/_functions.scss
+++ b/src/styles/vendor/bootstrap/_functions.scss
@@ -54,7 +54,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) * 0.001;
 
   @if ($yiq >= $yiq-contrasted-threshold) {
     @return $yiq-text-dark;

--- a/src/styles/vendor/bootstrap/_images.scss
+++ b/src/styles/vendor/bootstrap/_images.scss
@@ -32,7 +32,7 @@
 }
 
 .figure-img {
-  margin-bottom: ($spacer / 2);
+  margin-bottom: ($spacer * 0.5);
   line-height: 1;
 }
 

--- a/src/styles/vendor/bootstrap/_jumbotron.scss
+++ b/src/styles/vendor/bootstrap/_jumbotron.scss
@@ -1,5 +1,5 @@
 .jumbotron {
-  padding: $jumbotron-padding ($jumbotron-padding / 2);
+  padding: $jumbotron-padding ($jumbotron-padding * 0.5);
   margin-bottom: $jumbotron-padding;
   background-color: $jumbotron-bg;
   @include border-radius($border-radius-lg);

--- a/src/styles/vendor/bootstrap/_popover.scss
+++ b/src/styles/vendor/bootstrap/_popover.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .popover {
   position: absolute;
   top: 0;
@@ -44,7 +46,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: $popover-arrow-height ($popover-arrow-width * 0.5) 0;
   }
 
   .arrow::before {
@@ -70,7 +72,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2) 0;
+    border-width: ($popover-arrow-width * 0.5) $popover-arrow-height ($popover-arrow-width * 0.5) 0;
   }
 
   .arrow::before {
@@ -93,7 +95,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: 0 ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2);
+    border-width: 0 ($popover-arrow-width * 0.5) $popover-arrow-height ($popover-arrow-width * 0.5);
   }
 
   .arrow::before {
@@ -113,7 +115,7 @@
     left: 50%;
     display: block;
     width: $popover-arrow-width;
-    margin-left: ($popover-arrow-width / -2);
+    margin-left: math.div($popover-arrow-width, -2);
     content: "";
     border-bottom: $popover-border-width solid $popover-header-bg;
   }
@@ -131,7 +133,7 @@
 
   .arrow::before,
   .arrow::after {
-    border-width: ($popover-arrow-width / 2) 0 ($popover-arrow-width / 2) $popover-arrow-height;
+    border-width: ($popover-arrow-width * 0.5) 0 ($popover-arrow-width * 0.5) $popover-arrow-height;
   }
 
   .arrow::before {

--- a/src/styles/vendor/bootstrap/_tooltip.scss
+++ b/src/styles/vendor/bootstrap/_tooltip.scss
@@ -37,7 +37,7 @@
 
     &::before {
       top: 0;
-      border-width: $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+      border-width: $tooltip-arrow-height ($tooltip-arrow-width * 0.5) 0;
       border-top-color: $tooltip-arrow-color;
     }
   }
@@ -53,7 +53,7 @@
 
     &::before {
       right: 0;
-      border-width: ($tooltip-arrow-width / 2) $tooltip-arrow-height ($tooltip-arrow-width / 2) 0;
+      border-width: ($tooltip-arrow-width * 0.5) $tooltip-arrow-height ($tooltip-arrow-width * 0.5) 0;
       border-right-color: $tooltip-arrow-color;
     }
   }
@@ -67,7 +67,7 @@
 
     &::before {
       bottom: 0;
-      border-width: 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+      border-width: 0 ($tooltip-arrow-width * 0.5) $tooltip-arrow-height;
       border-bottom-color: $tooltip-arrow-color;
     }
   }
@@ -83,7 +83,7 @@
 
     &::before {
       left: 0;
-      border-width: ($tooltip-arrow-width / 2) 0 ($tooltip-arrow-width / 2) $tooltip-arrow-height;
+      border-width: ($tooltip-arrow-width * 0.5) 0 ($tooltip-arrow-width * 0.5) $tooltip-arrow-height;
       border-left-color: $tooltip-arrow-color;
     }
   }

--- a/src/styles/vendor/bootstrap/_variables.scss
+++ b/src/styles/vendor/bootstrap/_variables.scss
@@ -258,7 +258,7 @@ $h4-font-size:                $font-size-base * 1.5 !default;
 $h5-font-size:                $font-size-base * 1.25 !default;
 $h6-font-size:                $font-size-base !default;
 
-$headings-margin-bottom:      ($spacer / 2) !default;
+$headings-margin-bottom:      ($spacer * 0.5) !default;
 $headings-font-family:        inherit !default;
 $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
@@ -618,12 +618,12 @@ $nav-pills-link-active-color:       $component-active-color !default;
 $nav-pills-link-active-bg:          $component-active-bg !default;
 
 $nav-divider-color:                 $gray-200 !default;
-$nav-divider-margin-y:              ($spacer / 2) !default;
+$nav-divider-margin-y:              ($spacer * 0.5) !default;
 
 // Navbar
 
-$navbar-padding-y:                  ($spacer / 2) !default;
-$navbar-padding-x:                  ($spacer / 2) !default;
+$navbar-padding-y:                  ($spacer * 0.5) !default;
+$navbar-padding-x:                  ($spacer * 0.5) !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;
 
@@ -631,7 +631,7 @@ $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height:                   ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;
 $navbar-brand-height:               $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) / 2 !default;
+$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) * 0.5 !default;
 
 $navbar-toggler-padding-y:          .25rem !default;
 $navbar-toggler-padding-x:          .75rem !default;
@@ -702,7 +702,7 @@ $card-bg:                           $white !default;
 
 $card-img-overlay-padding:          1.25rem !default;
 
-$card-group-margin:                 ($grid-gutter-width / 2) !default;
+$card-group-margin:                 ($grid-gutter-width * 0.5) !default;
 $card-deck-margin:                  $card-group-margin !default;
 
 $card-columns-count:                3 !default;

--- a/src/styles/vendor/bootstrap/mixins/_grid-framework.scss
+++ b/src/styles/vendor/bootstrap/mixins/_grid-framework.scss
@@ -9,8 +9,8 @@
     position: relative;
     width: 100%;
     min-height: 1px; // Prevent columns from collapsing when empty
-    padding-right: ($gutter / 2);
-    padding-left: ($gutter / 2);
+    padding-right: ($gutter * 0.5);
+    padding-left: ($gutter * 0.5);
   }
 
   @each $breakpoint in map-keys($breakpoints) {

--- a/src/styles/vendor/bootstrap/mixins/_grid.scss
+++ b/src/styles/vendor/bootstrap/mixins/_grid.scss
@@ -2,10 +2,12 @@
 //
 // Generate semantic grid columns with these mixins.
 
+@use "sass:math";
+
 @mixin make-container() {
   width: 100%;
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: ($grid-gutter-width * 0.5);
+  padding-left: ($grid-gutter-width * 0.5);
   margin-right: auto;
   margin-left: auto;
 }
@@ -23,8 +25,8 @@
 @mixin make-row() {
   display: flex;
   flex-wrap: wrap;
-  margin-right: ($grid-gutter-width / -2);
-  margin-left: ($grid-gutter-width / -2);
+  margin-right: math.div($grid-gutter-width, -2);
+  margin-left: math.div($grid-gutter-width, -2);
 }
 
 @mixin make-col-ready() {
@@ -34,19 +36,19 @@
   // later on to override this initial width.
   width: 100%;
   min-height: 1px; // Prevent collapsing
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: ($grid-gutter-width * 0.5);
+  padding-left: ($grid-gutter-width * 0.5);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
-  flex: 0 0 percentage($size / $columns);
+  flex: 0 0 percentage(math.div($size, $columns));
   // Add a `max-width` to ensure content within each column does not blow out
   // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
   // do not appear to require this.
-  max-width: percentage($size / $columns);
+  max-width: percentage(math.div($size, $columns));
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
-  $num: $size / $columns;
+  $num: math.div($size, $columns);
   margin-left: if($num == 0, 0, percentage($num));
 }

--- a/src/styles/vendor/bootstrap/utilities/_embed.scss
+++ b/src/styles/vendor/bootstrap/utilities/_embed.scss
@@ -1,5 +1,7 @@
 // Credit: Nicolas Gallagher and SUIT CSS.
 
+@use "sass:math";
+
 .embed-responsive {
   position: relative;
   display: block;
@@ -29,24 +31,24 @@
 
 .embed-responsive-21by9 {
   &::before {
-    padding-top: percentage(9 / 21);
+    padding-top: percentage(math.div(9, 21));
   }
 }
 
 .embed-responsive-16by9 {
   &::before {
-    padding-top: percentage(9 / 16);
+    padding-top: percentage(math.div(9, 16));
   }
 }
 
 .embed-responsive-4by3 {
   &::before {
-    padding-top: percentage(3 / 4);
+    padding-top: percentage(3 * 0.25);
   }
 }
 
 .embed-responsive-1by1 {
   &::before {
-    padding-top: percentage(1 / 1);
+    padding-top: percentage(math.div(1, 1));
   }
 }


### PR DESCRIPTION
As a result of the upgrade to Angular 12, we now have a LOT of warnings for Sass for using the `/` operator which will become deprecated soon. This was brought up in #136, but we decided to ignore it. However, these deprecation warnings end up taking up a lot of space in logs when compiling and testing, so when tests fail (especially on Github Actions) it's hard to find where the actual error is. Fortunately, Sass provides an easy migration tool to fix all of these in preparation for future versions of Sass. This PR bumps up the version of Sass (so it's more explicitly set to a current version that is set up for the transition to the new format instead of just relying on transitive dependencies) and then runs that migration tool.

To test:
* Build the project and confirm there are no more deprecation warnings
* Make sure that none of the resulting CSS/styling is affected by these changes.

Resolves #139.