### PR TITLE
Fix Public Gallery environment detection issue

### DIFF
--- a/src/app/gallery/components/gallery/gallery.component.scss
+++ b/src/app/gallery/components/gallery/gallery.component.scss
@@ -8,7 +8,6 @@
 }
 
 .public-gallery {
-  overflow-x: hidden;
   padding: 0 2em;
   color: #131b4a;
   max-width: 1080px;

--- a/src/app/gallery/components/gallery/gallery.component.ts
+++ b/src/app/gallery/components/gallery/gallery.component.ts
@@ -10,13 +10,14 @@ import { SecretsService } from '@shared/services/secrets/secrets.service';
   styleUrls: ['./gallery.component.scss'],
 })
 export class GalleryComponent implements OnInit {
+  public environment: string = '';
   public archives: FeaturedArchive[] = this.getFeaturedArchives();
-  public environment: string = environment.environment;
   constructor() {}
 
   ngOnInit(): void {}
 
   protected getFeaturedArchives(): FeaturedArchive[] {
+    this.environment = environment.environment;
     if (
       this.environment !== 'prod' &&
       SecretsService.hasStatic('FEATURED_ARCHIVES')


### PR DESCRIPTION
A tricky thing we didn't catch in the original PR was that the `archives` property on the GalleryComponent class was being intialized before the `environment` property. As a result, when loading in Featured Archives, the environment property was still undefined and could not detect when the application was in production mode, making it unable to load the production Featured Archives data. This fixes this issue by explicitly defining the `environment` property in `getFeaturedArchives` so this initialization issue doesn't happen.

I also fixed some CSS that doesn't cause any issues with archives but does cause issues in the rare case there are no featured archives (when the fixed bug is active or on the staging environment for example).

Picture of both bugs:
![2022-08-17-145633](https://user-images.githubusercontent.com/9145247/185250398-576bf6b6-114a-487d-882e-45c58e7e75a1.png)
Notice:
- the lack of archives even though this is production and it should be loading from our array of static data
- the weird scrollbars on the side of the screen

This fixes both of those.

