### PR TITLE
Use correct archiveNbr for Featured Archives Data

### DIFF
--- a/src/app/gallery/data/featured.ts
+++ b/src/app/gallery/data/featured.ts
@@ -17,7 +17,7 @@ export const featuredArchives: FeaturedArchive[] = [
     description: '',
   },
   {
-    archiveNbr: 'profile',
+    archiveNbr: '01dq-0000',
     name: 'The Maine Genealogy Archive',
     type: 'type.archive.family',
     description: '',


### PR DESCRIPTION
Accidentally put the wrong archiveNbr in the data for Featured Archives! This commit fixes it.