### PR TITLE
Android mobile notification

### DIFF
--- a/src/app/announcement/announcement.module.ts
+++ b/src/app/announcement/announcement.module.ts
@@ -3,16 +3,18 @@ import { CommonModule } from '@angular/common';
 import { AnnouncementComponent } from './components/announcement/announcement.component';
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faWindowClose } from '@fortawesome/free-solid-svg-icons';
+import { AndroidAppNotifyComponent } from './components/android-app-notify/android-app-notify.component';
 
 
 @NgModule({
-  declarations: [AnnouncementComponent],
+  declarations: [AnnouncementComponent, AndroidAppNotifyComponent],
   imports: [
     CommonModule,
     FontAwesomeModule
   ],
   exports: [
     AnnouncementComponent,
+    AndroidAppNotifyComponent,
   ]
 })
 export class AnnouncementModule {

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.html
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.html
@@ -1,0 +1,16 @@
+<!-- @format -->
+<div class="android-app-notify" *ngIf="active">
+  <div class="description">
+    <img src="assets/icon/favicon-32x32.png" alt="Permanent Archive" />
+    <div class="description-text">
+      <div class="app-name">Permanent Archive</div>
+      <div class="app-description">Open in the Permanent app</div>
+    </div>
+  </div>
+  <div class="buttons">
+    <div class="prompt-button btn" (click)="showPrompt()">Open</div>
+    <div class="dismiss-button" (click)="dismiss()">
+      <fa-icon [icon]="['fas', 'window-close']"></fa-icon>
+    </div>
+  </div>
+</div>

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.scss
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.scss
@@ -1,0 +1,67 @@
+@import 'variables';
+
+.android-app-notify {
+  width: 100%;
+  background-color: #131b4a;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 0.25rem;
+
+  @include desktop {
+    padding: 0 1.5rem;
+  }
+}
+
+.prompt-button {
+  background-color: #fff;
+  color: #131b4a;
+  line-height: 1;
+}
+
+.description {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  img {
+    margin-right: 0.25rem;
+    @include desktop {
+      margin-right: 1rem;
+    }
+  }
+
+  .description-text {
+    line-height: 1;
+
+    .app-name {
+      font-size: 1.1rem;
+      margin-bottom: 0.25rem;
+    }
+    .app-description {
+      color: #fff9;
+      font-size: 0.8rem;
+    }
+  }
+}
+
+.buttons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0.25rem 0;
+
+  .dismiss-button {
+    &:hover {
+      opacity: 1;
+    }
+    opacity: 0.6;
+    transition: opacity 0.3s;
+    font-size: 1.75em;
+    cursor: pointer;
+    margin-left: 0.75rem;
+    @include desktop {
+      margin-left: 1rem;
+    }
+  }
+}

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.scss
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.scss
@@ -1,9 +1,12 @@
 @import 'variables';
 
+$perm-blue: #131b4a;
+
 .android-app-notify {
   width: 100%;
-  background-color: #131b4a;
+  background-color: $perm-blue;
   color: #fff;
+  box-shadow: 0 0.125rem 0.25rem rgb(0 0 0 / 8%);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -15,8 +18,12 @@
 }
 
 .prompt-button {
-  background-color: #fff;
-  color: #131b4a;
+  color: #fff !important;
+  background-color: $perm-blue !important;
+  border: 1px solid #fff !important;
+  padding: 0.5rem;
+  border-radius: 3em;
+  font-weight: normal !important;
   line-height: 1;
 }
 

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
@@ -1,0 +1,90 @@
+/* @format */
+import { Shallow } from 'shallow-render';
+
+import {
+  AndroidAppNotifyComponent,
+  BeforeInstallPromptEvent,
+} from './android-app-notify.component';
+import { AnnouncementModule } from '@announcement/announcement.module';
+
+class DummyInstallPromptEvent
+  extends Event
+  implements BeforeInstallPromptEvent
+{
+  constructor() {
+    super('beforeinstallprompt');
+  }
+
+  public async prompt(): Promise<void> {
+    prompted = true;
+  }
+
+  get userChoice(): Promise<'accepted' | 'dismissed'> {
+    return Promise.resolve('accepted');
+  }
+}
+
+let prompted: boolean;
+
+describe('AndroidAppNotifyComponent', () => {
+  let shallow: Shallow<AndroidAppNotifyComponent>;
+  const waitForPromptEvent = async (fixture) => {
+    const event = new DummyInstallPromptEvent();
+    window.dispatchEvent(event);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  };
+  beforeEach(() => {
+    prompted = false;
+    shallow = new Shallow(AndroidAppNotifyComponent, AnnouncementModule);
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+  it('should exist', async () => {
+    const { element } = await shallow.render();
+    expect(element).not.toBeNull();
+  });
+  it('should be invisible before `beforeinstallprompt` event', async () => {
+    const { find } = await shallow.render();
+    expect(find('div').length).toBe(0);
+  });
+  it('should appear when the `beforeinstallprompt` fires', async () => {
+    const { find, fixture } = await shallow.render();
+    await waitForPromptEvent(fixture);
+    expect(find('div').length).toBeGreaterThan(0);
+  });
+  it('has a clickable button that shows the prompt', async () => {
+    const { find, fixture } = await shallow.render();
+    await waitForPromptEvent(fixture);
+    find('.prompt-button')[0].triggerEventHandler('click', {});
+    expect(prompted).toBeTruthy();
+  });
+  it('should dismiss itself after the App Install Banner appears', async () => {
+    const { find, fixture } = await shallow.render();
+    await waitForPromptEvent(fixture);
+    find('.prompt-button')[0].triggerEventHandler('click', {});
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(find('div').length).toBe(0);
+  });
+  it('should be dismissable from a close button', async () => {
+    const { find, fixture } = await shallow.render();
+    await waitForPromptEvent(fixture);
+    find('.dismiss-button')[0].triggerEventHandler('click', {});
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(find('div').length).toBe(0);
+    const dismissed = localStorage.getItem(
+      AndroidAppNotifyComponent.storageKey
+    );
+    expect(dismissed).toBeTruthy();
+  });
+  it('should not show up if previously dismissed', async () => {
+    localStorage.setItem(AndroidAppNotifyComponent.storageKey, 'true');
+    const { find, fixture } = await shallow.render();
+    await waitForPromptEvent(fixture);
+    expect(find('div').length).toBe(0);
+  });
+});

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.ts
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.ts
@@ -1,0 +1,49 @@
+/* @format */
+import { Component, OnInit, HostListener, ElementRef } from '@angular/core';
+
+import {
+  adjustLayoutForAnnouncement,
+  resetLayoutForAnnouncement,
+} from '../announcement/announcement.component';
+
+export interface BeforeInstallPromptEvent extends Event {
+  userChoice: Promise<'accepted' | 'dismissed'>;
+  prompt(): Promise<void>;
+}
+
+@Component({
+  selector: 'pr-android-app-notify',
+  templateUrl: './android-app-notify.component.html',
+  styleUrls: ['./android-app-notify.component.scss'],
+})
+export class AndroidAppNotifyComponent implements OnInit {
+  public static readonly storageKey = 'androidAppNotificationDismissed';
+  public active = false;
+  public deferredPrompt: BeforeInstallPromptEvent;
+
+  constructor(public elementRef: ElementRef) {}
+
+  @HostListener('window:beforeinstallprompt', ['$event'])
+  public beforeInstallPrompt(event: BeforeInstallPromptEvent) {
+    this.deferredPrompt = event;
+    if (!localStorage.getItem(AndroidAppNotifyComponent.storageKey)) {
+      this.active = true;
+      adjustLayoutForAnnouncement(this);
+    }
+  }
+
+  ngOnInit(): void {}
+
+  public showPrompt(): void {
+    this.deferredPrompt.prompt();
+    this.deferredPrompt.userChoice.then(() => {
+      this.active = false;
+    });
+  }
+
+  public dismiss(): void {
+    this.active = false;
+    localStorage.setItem(AndroidAppNotifyComponent.storageKey, 'true');
+    resetLayoutForAnnouncement();
+  }
+}

--- a/src/app/announcement/components/announcement/announcement.component.ts
+++ b/src/app/announcement/components/announcement/announcement.component.ts
@@ -7,6 +7,21 @@ import { faWindowClose } from '@fortawesome/free-solid-svg-icons';
 
 const STORAGE_KEY = 'announcementDismissed';
 
+export const adjustLayoutForAnnouncement = (component: {elementRef: ElementRef}) => {
+  const self = component.elementRef.nativeElement as HTMLElement;
+  const adjustedElements = document.querySelectorAll('.adjust-for-announcement');
+  for (const element of Array.from(adjustedElements)) {
+    (element as HTMLElement).style.paddingTop = self.getBoundingClientRect().height + 'px';
+  }
+};
+
+export const resetLayoutForAnnouncement = () => {
+  const adjustedElements = document.querySelectorAll('.adjust-for-announcement');
+  for (const element of Array.from(adjustedElements)) {
+    (element as HTMLElement).style.paddingTop = '0px';
+  }
+};
+
 @Component({
   selector: 'pr-announcement',
   templateUrl: './announcement.component.html',
@@ -17,7 +32,7 @@ export class AnnouncementComponent implements OnInit, AfterViewInit {
   public active: boolean = false;
   public event: AnnouncementEvent;
   public faWindowClose = faWindowClose;
-  constructor(protected elementRef: ElementRef) {}
+  constructor(public elementRef: ElementRef) {}
 
   public ngOnInit(): void {
     if (!this.eventsList) {
@@ -29,11 +44,7 @@ export class AnnouncementComponent implements OnInit, AfterViewInit {
 
   public ngAfterViewInit(): void {
     if (this.active) {
-      const self = this.elementRef.nativeElement as HTMLElement;
-      const adjustedElements = document.querySelectorAll('.adjust-for-announcement');
-      for (const element of Array.from(adjustedElements)) {
-        (element as HTMLElement).style.paddingTop = self.getBoundingClientRect().height + 'px';
-      }
+      adjustLayoutForAnnouncement(this);
     }
   }
 
@@ -41,10 +52,7 @@ export class AnnouncementComponent implements OnInit, AfterViewInit {
     this.active = false;
     window.localStorage.setItem(STORAGE_KEY, this.event.start.toString());
 
-    const adjustedElements = document.querySelectorAll('.adjust-for-announcement');
-    for (const element of Array.from(adjustedElements)) {
-      (element as HTMLElement).style.paddingTop = '0px';
-    }
+    resetLayoutForAnnouncement();
   }
 
   protected isDismissed(): boolean {

--- a/src/app/auth/components/auth/auth.component.html
+++ b/src/app/auth/components/auth/auth.component.html
@@ -6,4 +6,5 @@
   </div>
 </div>
 <pr-announcement></pr-announcement>
+<pr-android-app-notify></pr-android-app-notify>
 <router-outlet></router-outlet>

--- a/src/app/core/components/nav/nav.component.html
+++ b/src/app/core/components/nav/nav.component.html
@@ -23,6 +23,7 @@
   <pr-account-dropdown></pr-account-dropdown>
 </nav>
 <pr-announcement></pr-announcement>
+<pr-android-app-notify></pr-android-app-notify>
 <div class="nav-second-row">
   <pr-breadcrumbs [darkText]="true" [large]="true"></pr-breadcrumbs>
   <div class="sidebar-align">

--- a/src/app/share-preview/components/share-preview/share-preview.component.html
+++ b/src/app/share-preview/components/share-preview/share-preview.component.html
@@ -1,3 +1,4 @@
+<pr-android-app-notify></pr-android-app-notify>
 <div class="share-preview-banner">
   <div class="banner-content">
     <a href="/" class="banner-logo-wrapper">
@@ -10,6 +11,7 @@
     </div>
   </div>
 </div>
+<pr-announcement></pr-announcement>
 <div class="share-preview-archive" *ngIf="shareArchive">
   <div class="share-preview-archive-thumb" prBgImage [bgSrc]="shareArchive.thumbURL200"></div>
   <span>

--- a/src/app/share-preview/share-preview.routes.ts
+++ b/src/app/share-preview/share-preview.routes.ts
@@ -17,6 +17,7 @@ import { RelationshipShareResolveService } from './resolves/relationship-share-r
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { DialogModule } from '../dialog/dialog.module';
 import { LazyLoadFileBrowserSibling } from '@fileBrowser/file-browser.module';
+import { AnnouncementModule } from '../announcement/announcement.module';
 
 const archiveResolve = {
   archive: PreviewArchiveResolveService,
@@ -104,7 +105,8 @@ export const routes: Routes = [
     CommonModule,
     FileBrowserComponentsModule,
     NgbModule,
-    DialogModule
+    DialogModule,
+    AnnouncementModule,
   ],
   declarations: [
     SharePreviewComponent,

--- a/src/assets/icon/site.webmanifest
+++ b/src/assets/icon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Permanent Archive",
+    "short_name": "Permanent",
     "icons": [
         {
             "src": "/icons/android-chrome-192x192.png",
@@ -13,7 +13,16 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
+    "start_url": "/app",
+    "scope": "/",
+    "theme_color": "#131b4a",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "display": "standalone",
+    "prefer_related_applications": true,
+    "related_applications": [
+      {
+      "platform": "play",
+      "id": "org.permanent.PermanentArchive"
+      }
+    ]
 }


### PR DESCRIPTION
This PR adds a new component that responds to the `beforeinstallprompt` event that Chrome on Android sends out to allow us to notify users they can download the Android app. This PR also updates our web app manifest in general so users can, in theory, just add the web-app to their home screen if they choose to do so.

Steps to test:
- You must delete any installations of the Permanent Android App for this to work (the notification is only for installing the app and Chrome will not send it if it detects the app is already installed)
- Open a page in the Chrome for Android and see if the notification thing pops up.
- To just see what the component looks like in your desktop browser (it will not be fully functional):
  - Open the developer console in your browser on the page you want to test on
  - Run the following: `window.dispatchEvent(new Event('beforeinstallprompt'));`
  - The notification component should be visible, and while the dismiss button works, the install button shouldn't as it is relying on specific Chrome on Android functionality
- If you click the dismiss button, it should stay gone. To get it to reappear you have to delete the site data (clear localStorage).

Resolves PER-8850.
Also resolves #114 