### PR TITLE
Add Apple Smart App Banner Meta Tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,6 +21,7 @@
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="msapplication-config" content="assets/icon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
+  <meta name="apple-itunes-app" content="app-id=1571883070">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script type="text/javascript">

--- a/src/index/dev/index.html
+++ b/src/index/dev/index.html
@@ -21,6 +21,7 @@
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="msapplication-config" content="assets/icon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
+  <meta name="apple-itunes-app" content="app-id=1571883070">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script type="text/javascript">

--- a/src/index/prod/index.html
+++ b/src/index/prod/index.html
@@ -22,6 +22,7 @@
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="msapplication-config" content="assets/icon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
+  <meta name="apple-itunes-app" content="app-id=1571883070">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script type="text/javascript">

--- a/src/index/staging/index.html
+++ b/src/index/staging/index.html
@@ -21,6 +21,7 @@
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="msapplication-config" content="assets/icon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
+  <meta name="apple-itunes-app" content="app-id=1571883070">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script type="text/javascript">


### PR DESCRIPTION
Add a meta tag to the base HTML pages to allow iOS to show a smart app banner for the Permanent iOS app.

Resolves PER-8453: Notify members that they can download app (iOS)