### PR TITLE
Add create account modal to share preview screen

### DIFF
--- a/src/app/dialog/dialog.component.html
+++ b/src/app/dialog/dialog.component.html
@@ -1,8 +1,11 @@
 <div class="menu-wrapper"
   [ngClass]="{'visible': isVisible, 'dialog-auto-height': height === 'auto', 'dialog-auto-width': width !== 'fullscreen'}"
   #menuWrapper (click)="onMenuWrapperClick($event)">
-  <div class="menu" [ngStyle]="{'max-width': width === 'fullscreen' || isMobile() ? '' : width}"
-    [ngClass]="menuClass">
+  <div 
+    class="menu" 
+    [ngStyle]="{'max-width': width === 'fullscreen' || (isMobile() && !mobileWidth) ? '' : (width ?? mobileWidth), 'borderRadius': borderRadius}"
+    [ngClass]="menuClass"
+  > 
     <ng-template #dialogContent></ng-template>
   </div>
 </div>

--- a/src/app/dialog/dialog.component.scss
+++ b/src/app/dialog/dialog.component.scss
@@ -116,6 +116,14 @@
     overflow: visible;
   }
 
+  .floating-mobile-dialog {
+    top: auto;
+    bottom: 50%;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%) translateY(50%);
+  }
+
   &.visible {
     .profile-editor-dialog, .notification-dialog {
       transform: translateX(0);

--- a/src/app/dialog/dialog.component.ts
+++ b/src/app/dialog/dialog.component.ts
@@ -11,6 +11,8 @@ export class DialogComponent implements AfterViewInit {
   public isVisible = false;
   public height = 'fullscreen';
   public width = 'fullscreen';
+  public mobileWidth: string;
+  public borderRadius = '0px';
 
   public menuClass: string;
 
@@ -41,6 +43,15 @@ export class DialogComponent implements AfterViewInit {
 
       if (options.width) {
         this.width = options.width;
+      }
+
+      if (options.mobileWidth) {
+        this.mobileWidth = options.mobileWidth;
+        this.width = this.width === options.width ? this.width : options.mobileWidth;
+      }
+
+      if (options.borderRadius) {
+        this.borderRadius = options.borderRadius;
       }
 
       if (options.menuClass) {

--- a/src/app/dialog/dialog.service.ts
+++ b/src/app/dialog/dialog.service.ts
@@ -31,7 +31,8 @@ export type DialogComponentToken =
   'TimelineViewComponent' |
   'ArchiveSettingsDialogComponent' |
   'WelcomeDialogComponent' |
-  'WelcomeInvitationDialogComponent'
+  'WelcomeInvitationDialogComponent' |
+  'CreateAccountDialogComponent'
 ;
 
 export interface DialogChildComponentData {
@@ -42,6 +43,8 @@ export interface DialogChildComponentData {
 export interface DialogOptions {
   height?: 'auto' | 'fullscreen';
   width?: 'auto' | 'fullscreen' | any;
+  mobileWidth?: 'auto' | 'fullscreen' | string;
+  borderRadius?: string;
   menuClass?: string;
 }
 

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -419,6 +419,11 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
   onItemClick(event: MouseEvent) {
     if (this.device.isMobileWidth() || !this.canSelect) {
       this.goToItem();
+      this.itemClicked.emit({
+        item: this.item,
+        event: event as MouseEvent,
+        selectable: false,
+      });
     } else {
       this.onItemSingleClick(event);
     }
@@ -502,7 +507,8 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
     this.singleClickTimeout = setTimeout(() => {
       this.itemClicked.emit({
         item: this.item,
-        event: event as MouseEvent
+        event: event as MouseEvent,
+        selectable: true,
       });
     }, SINGLE_CLICK_DELAY);
 

--- a/src/app/file-browser/components/file-list/file-list.component.ts
+++ b/src/app/file-browser/components/file-list/file-list.component.ts
@@ -4,6 +4,7 @@ import {
   OnInit,
   AfterViewInit,
   ElementRef,
+  EventEmitter,
   QueryList,
   ViewChildren,
   HostListener,
@@ -11,6 +12,7 @@ import {
   HostBinding,
   Input,
   Optional,
+  Output,
   ViewChild,
   NgZone,
   Renderer2
@@ -45,6 +47,7 @@ import { RouteHistoryService } from 'ngx-route-history';
 export interface ItemClickEvent {
   event?: MouseEvent;
   item: RecordVO | FolderVO;
+  selectable?: boolean;
 }
 
 export interface FileListItemParent {
@@ -75,6 +78,8 @@ export class FileListComponent implements OnInit, AfterViewInit, OnDestroy, HasS
   isRootFolder = false;
 
   @Input() allowNavigation = true;
+
+  @Output() itemClicked = new EventEmitter<ItemClickEvent>();
 
   private visibleItemsHandlerDebounced: Function;
   private mouseMoveHandlerThrottled: Function;
@@ -373,7 +378,9 @@ export class FileListComponent implements OnInit, AfterViewInit, OnDestroy, HasS
   }
 
   onItemClick(itemClick: ItemClickEvent) {
-    if (!this.showSidebar) {
+    this.itemClicked.emit(itemClick); 
+
+    if (!this.showSidebar || !itemClick.selectable) {
       return;
     }
 

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.html
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.html
@@ -1,0 +1,31 @@
+<!-- @format -->
+<div class="dialog-content">
+  <div class="header">
+    <button class="btn" (click)="close()">
+      <i class="material-icons">close</i>
+    </button>
+  </div>
+  <div class="dialog-body">
+    <p>
+      <strong>Welcome to Permanent.org!</strong> Join {{ sharerName }}'s shared
+      files by signing up for a free account.
+    </p>
+    <p>
+      Collaborate on archives on Permanent.org, and create and curate your own.
+      Get started today with a free gigabyte of storage and no recurring fees.
+      <a
+        href="https://permanent.org"
+        class="learn-more"
+        [ngClass]="isMobile() ? 'mobile' : 'desktop'"
+      >
+        Learn more about Permanent
+      </a>
+    </p>
+    <a [routerLink]="['/app', 'signup']" class="btn btn-primary"
+      >Create Account</a
+    >
+    <a [routerLink]="['/app', 'login']" class="login"
+      >Already have an account?</a
+    >
+  </div>
+</div>

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.scss
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.scss
@@ -1,0 +1,58 @@
+/* @format */
+:host {
+  display: block;
+  width: 100%;
+  border-radius: 5px;
+}
+
+.dialog-content {
+  border-radius: 5px;
+}
+
+.header {
+  .btn {
+    background: none;
+    outline: none;
+    height: 2.5rem;
+    width: auto;
+    margin: 0;
+    flex: 0 0 auto;
+    color: #646464;
+  }
+  height: 2.5rem;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-size: 1.25rem;
+  padding: 0 1.25rem;
+  padding-right: 0;
+}
+
+.btn {
+  background-color: #5261b7;
+  width: 16.25rem;
+  padding: .65625rem .75rem;
+  text-align: center;
+  border: 0rem
+}
+
+.dialog-body {
+  .learn-more {
+    left: auto;
+    right: auto;
+    color: #000;
+  }
+  .learn-more.desktop {
+    font-weight: 600;
+  }
+  .login {
+    display: block;
+    left: auto;
+    right: auto;
+    text-align: center;
+    color: #000;
+  }
+  font-size: 1.125rem;
+  padding: 0px 30px 37px 30px;
+}

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.spec.ts
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.spec.ts
@@ -1,0 +1,66 @@
+/* @format */
+import {
+  ComponentFixture,
+  TestBed,
+  TestModuleMetadata,
+} from '@angular/core/testing';
+import { cloneDeep } from 'lodash';
+
+import { SharedModule } from '@shared/shared.module';
+import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
+import * as Testing from '@root/test/testbedConfig';
+import { InviteVO } from '@root/app/models';
+import { CreateAccountDialogComponent } from './create-account-dialog.component';
+
+describe('CreateAccountDialogComponent', () => {
+  let component: CreateAccountDialogComponent;
+  let fixture: ComponentFixture<CreateAccountDialogComponent>;
+  let dialogData: { sharerName: string };
+  let dialogRef: DialogRef;
+
+  beforeEach(async () => {
+    const config: TestModuleMetadata = cloneDeep(Testing.BASE_TEST_CONFIG);
+
+    dialogData = {
+      sharerName: 'John Rando',
+    };
+
+    dialogRef = new DialogRef(1, null);
+
+    config.imports.push(SharedModule);
+    config.declarations.push(CreateAccountDialogComponent);
+    config.providers.push({
+      provide: DIALOG_DATA,
+      useValue: {
+        sharerName: 'John Rando',
+      },
+    });
+    config.providers.push({
+      provide: DialogRef,
+      useValue: dialogRef,
+    });
+    await TestBed.configureTestingModule(config).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateAccountDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should should take sharerName from the dialog data', () => {
+    expect(component.sharerName).toEqual('John Rando');
+  });
+
+  it('should close when close method is called', () => {
+    const dialogRefSpy = spyOn(dialogRef, 'close');
+
+    component.close();
+
+    expect(dialogRefSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.ts
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.ts
@@ -1,0 +1,29 @@
+/* @format */ 
+import { Component, OnInit, Input, Inject } from '@angular/core';
+import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
+import { DeviceService } from '@shared/services/device/device.service';
+
+@Component({
+  selector: 'pr-create-account-dialog',
+  templateUrl: './create-account-dialog.component.html',
+  styleUrls: ['./create-account-dialog.component.scss'],
+})
+export class CreateAccountDialogComponent implements OnInit {
+  sharerName: string = this.data.sharerName;
+
+  constructor(
+    private dialogRef: DialogRef,
+    private device: DeviceService,
+    @Inject(DIALOG_DATA) public data: any
+  ) {}
+
+  ngOnInit(): void {}
+
+  isMobile(): boolean {
+    return this.device.isMobileWidth();
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/share-preview/components/share-preview/share-preview.component.html
+++ b/src/app/share-preview/components/share-preview/share-preview.component.html
@@ -30,9 +30,9 @@
   <pr-breadcrumbs></pr-breadcrumbs>
 </div>
 <div class="share-preview-content" [ngClass]="{'navigating': isNavigating}">
-  <router-outlet></router-outlet>
+  <router-outlet (activate)="subscribeToItemClicks($event)" (deactivate)="unsubscribeFromItemClicks()"></router-outlet>
 </div>
-<div class="share-preview-cover from-bottom" [ngClass]="{'share-preview-cover-visible': showCover}" (click)="toggleCover()" *ngIf="!hasAccess">
+<div class="share-preview-cover from-bottom" [ngClass]="{'share-preview-cover-visible': showCover}" (click)="toggleCover()" *ngIf="(!hasAccess && isLoggedIn)">
   <div class="share-preview-cover-content" (click)="stopPropagation($event)">
     <p *ngIf="!isLoggedIn">
       <span *ngIf="isInvite || (isLinkShare && formType === 0)">Get full access to {{shareAccount.fullName}}'s shared item and claim your free gigabyte of storage.</span>
@@ -102,7 +102,7 @@
     </div>
   </div>
 </div>
-<div class="share-preview-footer" [ngClass]="{'share-preview-footer-visible': !showCover}" *ngIf="!hasAccess">
+<div class="share-preview-footer" [ngClass]="{'share-preview-footer-visible': !showCover}" *ngIf="!hasAccess && isLoggedIn">
   <div class="share-preview-footer-content">
     <span (click)="toggleCover()">
       <strong *ngIf="!isLoggedIn">

--- a/src/app/share-preview/components/share-preview/share-preview.component.scss
+++ b/src/app/share-preview/components/share-preview/share-preview.component.scss
@@ -143,11 +143,6 @@ $share-preview-banner-height: 100px;
     margin-right: 10px;
   }
 
-  .share-preview-archive-name {
-    // color: $gray-700;
-    // font-size: 12px;
-  }
-
   .share-preview-archive-buttons {
     flex: 0 1 auto;
     display: flex;
@@ -311,9 +306,6 @@ $share-preview-banner-height: 100px;
   .share-preview-cover-buttons {
     margin: 0 auto;
     display: inline-flex;
-    .btn {
-      // display: block;
-    }
   }
 }
 
@@ -322,51 +314,3 @@ $share-preview-banner-height: 100px;
     color: white;
   }
 }
-
-  // .share-preview-form {
-  //   flex: 0 1 500px;
-  //   border-radius: 2rem;
-  //   padding: 4rem;
-  //   background-color: white;
-  //   color: white;
-  //   text-align: center;
-  // }
-
-// .share-preview-form-wrapper {
-//   $transition-length: 0.5;
-
-//   position: fixed;
-//   transform: translateY(100%);
-//   top: 0;
-//   left: 0;
-//   right: 0;
-//   bottom: 0;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   transition:  background-color $transition-length ease-in, top 0s linear $transition-length;
-
-//   .share-preview-form {
-//     transform: translateY(100vh);
-//     transition:  transform $transition-length ease-in;
-//     box-shadow: $box-shadow-sm;
-
-//     flex: 0 1 500px;
-//     border-radius: 2rem;
-//     padding: 4rem;
-//     background-color: white;
-//     color: white;
-//     text-align: center;
-//   }
-
-//   &.share-preview-form-visible {
-//     background: rgba(black, 0.4);
-//     transform: translateY(0);
-//     flex: 0 1 400px;
-
-//     .share-preview-form {
-//       transform: translateY(0);
-//       transition:  transform $transition-length ease-out;
-//     }
-//   }
-// }

--- a/src/app/share-preview/components/share-preview/share-preview.component.spec.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.spec.ts
@@ -1,25 +1,115 @@
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  async,
+  fakeAsync,
+  ComponentFixture,
+  TestBed,
+  TestModuleMetadata,
+  tick,
+} from '@angular/core/testing';
+import { EventEmitter } from '@angular/core';
+import {
+  Router,
+  ActivatedRoute,
+  ActivatedRouteSnapshot,
+} from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { cloneDeep } from 'lodash';
 
-// import { SharePreviewComponent } from './share-preview.component';
+import { SharedModule } from '@shared/shared.module';
+import * as Testing from '@root/test/testbedConfig';
+import { SharePreviewComponent } from './share-preview.component';
+import { Dialog } from '@root/app/dialog/dialog.module';
+import { RecordVO } from '@root/app/models';
 
-// describe('SharePreviewComponent', () => {
-//   let component: SharePreviewComponent;
-//   let fixture: ComponentFixture<SharePreviewComponent>;
+describe('SharePreviewComponent', () => {
+  let component: SharePreviewComponent;
+  let fixture: ComponentFixture<SharePreviewComponent>;
+  let dialog: Dialog;
+  let router: Router;
 
-//   beforeEach(async(() => {
-//     TestBed.configureTestingModule({
-//       declarations: [ SharePreviewComponent ]
-//     })
-//     .compileComponents();
-//   }));
+  beforeEach(async () => {
+    const config: TestModuleMetadata = cloneDeep(Testing.BASE_TEST_CONFIG);
+    config.imports.push(SharedModule);
+    config.imports.push(RouterTestingModule);
+    config.declarations.push(SharePreviewComponent);
 
-//   beforeEach(() => {
-//     fixture = TestBed.createComponent(SharePreviewComponent);
-//     component = fixture.componentInstance;
-//     fixture.detectChanges();
-//   });
+    let mockRoute = new ActivatedRoute();
+    mockRoute.snapshot = new ActivatedRouteSnapshot();
+    mockRoute.snapshot.data = {
+      sharePreviewVO: {
+        ArchiveVO: {},
+        AccountVO: {},
+        ShareVO: { accessRole: 'viewer', status: 'pending' },
+        status: 'pending',
+      },
+      currentFolder: { displayName: 'test' },
+    };
+    mockRoute.snapshot.params = { shareToken: 'test' };
+    mockRoute.snapshot.queryParams = { requestAccess: 'test' };
 
-//   it('should create', () => {
-//     expect(component).toBeTruthy();
-//   });
-// });
+    let firstChild = new ActivatedRouteSnapshot();
+    firstChild.data = { sharePreviewView: {} };
+    spyOnProperty(mockRoute.snapshot, 'firstChild', 'get').and.returnValue(
+      firstChild
+    );
+
+    let parent = new ActivatedRoute();
+    spyOnProperty(mockRoute, 'parent', 'get').and.returnValue(parent);
+
+    config.providers.push({
+      provide: ActivatedRoute,
+      useValue: mockRoute,
+    });
+
+    await TestBed.configureTestingModule(config).compileComponents();
+
+    dialog = TestBed.inject(Dialog);
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SharePreviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should open dialog shortly after loading if user logged out', fakeAsync(() => {
+    const dialogSpy = spyOn(dialog, 'open').and.returnValue(Promise.resolve());
+
+    component.isLoggedIn = false;
+    component.ngAfterViewInit();
+    tick(1005);
+
+    expect(dialogSpy).toHaveBeenCalled();
+  }));
+
+  it('should not open dialog shortly after loading if user logged in', fakeAsync(() => {
+    const dialogSpy = spyOn(dialog, 'open');
+
+    component.isLoggedIn = true;
+    component.ngAfterViewInit();
+    tick(1005);
+
+    expect(dialogSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should open dialog when a thumbnail is clicked', fakeAsync(() => {
+    const dialogSpy = spyOn(dialog, 'open').and.returnValue(Promise.resolve());;
+
+    const mockFileList = { itemClicked: new EventEmitter<any>() };
+
+    component.subscribeToItemClicks(mockFileList);
+    mockFileList.itemClicked.emit({
+      item: new RecordVO({}),
+      selectable: false,
+    });
+    tick();
+
+    expect(dialogSpy).toHaveBeenCalled();
+  }));
+});

--- a/src/app/share-preview/share-preview.module.ts
+++ b/src/app/share-preview/share-preview.module.ts
@@ -8,6 +8,7 @@ import { FolderView } from '@shared/services/folder-view/folder-view.enum';
 import { FormsModule } from '@angular/forms';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { DialogModule } from '../dialog/dialog.module';
+import { CreateAccountDialogComponent } from './components/create-account-dialog/create-account-dialog.component';
 
 @NgModule({
   declarations: [

--- a/src/app/share-preview/share-preview.routes.ts
+++ b/src/app/share-preview/share-preview.routes.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ComponentFactoryResolver, Optional } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CommonModule } from '@angular/common';
 
@@ -10,12 +10,15 @@ import { FileBrowserComponentsModule } from '@fileBrowser/file-browser-component
 import { PreviewFolderResolveService } from './resolves/preview-folder-resolve.service';
 import { ShareUrlResolveService } from './resolves/share-url-resolve.service';
 import { ShareNotFoundComponent } from './components/share-not-found/share-not-found.component';
+import { CreateAccountDialogComponent } from './components/create-account-dialog/create-account-dialog.component';
 import { FileListComponent } from '@fileBrowser/components/file-list/file-list.component';
 import { InviteShareResolveService } from './resolves/invite-share-resolve.service';
 import { RelationshipShareResolveService } from './resolves/relationship-share-resolve.service';
+import { RoutedDialogWrapperComponent } from '@shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component';
+import { DialogChildComponentData } from '@root/app/dialog/dialog.module';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { DialogModule } from '../dialog/dialog.module';
+import { Dialog, DialogModule } from '../dialog/dialog.module';
 import { LazyLoadFileBrowserSibling } from '@fileBrowser/file-browser.module';
 import { AnnouncementModule } from '../announcement/announcement.module';
 
@@ -110,7 +113,8 @@ export const routes: Routes = [
   ],
   declarations: [
     SharePreviewComponent,
-    ShareNotFoundComponent
+    ShareNotFoundComponent,
+    CreateAccountDialogComponent,
   ],
   providers: [
     PreviewResolveService,
@@ -121,5 +125,22 @@ export const routes: Routes = [
     RelationshipShareResolveService
   ]
 })
-export class SharePreviewRoutingModule { }
+export class SharePreviewRoutingModule {
+  private dialogComponents: DialogChildComponentData[] =[
+    {
+      token: 'CreateAccountDialogComponent',
+      component: CreateAccountDialogComponent,
+    },
+  ]
 
+  constructor(
+    @Optional() private dialog?: Dialog,
+    @Optional() private resolver?: ComponentFactoryResolver
+  ) {
+    this.dialog.registerComponents(
+      this.dialogComponents,
+      this.resolver,
+      true
+    );
+  }
+}


### PR DESCRIPTION
Notes:
- I set the existing banner up to not render in cases where the user is not logged in, because making that banner coexist with the modal was looking difficult and we never want it to do that anyway
- Most of the changes to `share-preview.component.ts` are because I semi-accidentally ran Prettier on it
- I also deleted some commented out CSS that I came across