### PR TITLE
Fix "Remember Me" Functionality

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -268,8 +268,12 @@ export class AccountService {
   public logIn(email: string, password: string, rememberMe: boolean, keepLoggedIn: boolean): Promise<any> {
     this.skipSessionCheck = false;
 
-    if (rememberMe && this.cookies.check('rememberMe')) {
+    if (rememberMe) {
       this.cookies.set('rememberMe', email);
+    } else {
+      if (this.cookies.check('rememberMe')) {
+        this.cookies.delete('rememberMe');
+      }
     }
 
     const currentAccount = this.account;


### PR DESCRIPTION
The "Remember Me" functionality broke at some point in the web-app. This restores the functionality, by bypassing the check to see if the "rememberMe" cookie is already set (otherwise it can never be set!). Additionally, the app is now set to properly stop remembering a username if the "remember me" checkbox is unchecked.

To test:
1. Clear cookies (so any previously set `rememberMe` cookie is cleared out)
1. On the login page, check the “Remember me” option
2. Log in
3. Log out
4. Close the tab
5. Open Permanent in a new tab and navigate to the login page
6. Observe that your email is prepopulated

Resolves PER-8958.