### PR TITLE
Rename /myfiles to /private

### DIFF
--- a/src/app/auth/components/verify/verify.component.ts
+++ b/src/app/auth/components/verify/verify.component.ts
@@ -91,7 +91,7 @@ export class VerifyComponent implements OnInit {
       this.verifyingPhone = true;
       this.formTitle = 'Verify Phone Number';
     } else if (!this.needsEmail) {
-      this.router.navigate(['/myfiles'], { queryParamsHandling: 'preserve'});
+      this.router.navigate(['/private'], { queryParamsHandling: 'preserve'});
     }
 
   }

--- a/src/app/auth/guards/auth.guard.ts
+++ b/src/app/auth/guards/auth.guard.ts
@@ -20,7 +20,7 @@ export class AuthGuard implements CanActivate {
     if (this.account.getAccount()?.accountId) {
       return this.account.hasOwnArchives().then((hasArchives) => {
         if (hasArchives) {
-          return this.router.parseUrl('/app/myfiles');
+          return this.router.parseUrl('/app/private');
         }
         return this.router.parseUrl('/app/onboarding');
       });

--- a/src/app/core/components/all-archives/all-archives.component.ts
+++ b/src/app/core/components/all-archives/all-archives.component.ts
@@ -113,7 +113,7 @@ export class AllArchivesComponent implements OnInit, AfterViewInit, OnDestroy {
             })
             .then(() => {
               deferred.resolve();
-              this.router.navigate(['/myfiles']);
+              this.router.navigate(['/private']);
             })
             .catch((response: BaseResponse) => {
               deferred.resolve();
@@ -128,7 +128,7 @@ export class AllArchivesComponent implements OnInit, AfterViewInit, OnDestroy {
   async switchToArchive(archive: ArchiveVO) {
     try {
       await this.accountService.changeArchive(archive);
-      this.router.navigate(['/myfiles']);
+      this.router.navigate(['/private']);
     } catch (err) {
       if (err instanceof ArchiveResponse) {
         this.message.showError(err.getMessage(), true);

--- a/src/app/core/components/archive-switcher/archive-switcher.component.ts
+++ b/src/app/core/components/archive-switcher/archive-switcher.component.ts
@@ -111,7 +111,7 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
             })
             .then(() => {
               deferred.resolve();
-              this.router.navigate(['/myfiles']);
+              this.router.navigate(['/private']);
             })
             .catch((response: BaseResponse) => {
               deferred.resolve();

--- a/src/app/core/components/left-menu/left-menu.component.html
+++ b/src/app/core/components/left-menu/left-menu.component.html
@@ -58,8 +58,8 @@
           Search
       </a>
       <a class="menu-item"
-        [routerLink]="['/myfiles']"
-        [class.active]="checkMenuItemActive('/myfiles')"
+        [routerLink]="['/private']"
+        [class.active]="checkMenuItemActive('/private')"
         prDragTargetRouterLink>
         <img class="svg-icon" src="assets/svg/left-menu/private-files-icon.svg" />
         Private Files

--- a/src/app/core/components/loading-archive/loading-archive.component.spec.ts
+++ b/src/app/core/components/loading-archive/loading-archive.component.spec.ts
@@ -36,7 +36,7 @@ describe('LoadingArchiveComponent', () => {
     const routerSpy = spyOn(router, 'navigate');
 
     setTimeout(() => {
-      expect(routerSpy).toHaveBeenCalledWith(['/app' , 'myfiles']);
+      expect(routerSpy).toHaveBeenCalledWith(['/app' , 'private']);
       done();
     }, 2500);
   });

--- a/src/app/core/components/loading-archive/loading-archive.component.ts
+++ b/src/app/core/components/loading-archive/loading-archive.component.ts
@@ -14,7 +14,7 @@ export class LoadingArchiveComponent implements OnInit {
 
   ngOnInit(): void {
     setTimeout(() => {
-      this.router.navigate(['/app', 'myfiles']);
+      this.router.navigate(['/app', 'private']);
     }, 1000);
   }
 }

--- a/src/app/core/core.routes.ts
+++ b/src/app/core/core.routes.ts
@@ -24,6 +24,7 @@ import { TagsResolveService } from './resolves/tags.resolve.service';
 import { AllArchivesComponent } from './components/all-archives/all-archives.component';
 import { LoadingArchiveComponent } from './components/loading-archive/loading-archive.component';
 import { RoutedDialogWrapperComponent } from '@shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component';
+import { MyfilesGuard } from './guards/myfiles.guard';
 
 const rootFolderResolve = {
   rootFolder: RootFolderResolveService,
@@ -39,12 +40,21 @@ export const routes: RoutesWithData = [
     children: [
       {
         path: 'myfiles',
+        children: [
+          {
+            path: '**',
+            canActivate: [MyfilesGuard],
+          }
+        ]
+      },
+      {
+        path: 'private',
         loadChildren: () =>
           import('../file-browser/file-browser.module').then(
             (m) => m.FileBrowserModule
           ),
         data: {
-          title: 'My Files',
+          title: 'Private Files',
           showSidebar: true,
           showFolderViewToggle: true,
         },
@@ -93,7 +103,7 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'donate',
-        redirectTo: '/app/(myfiles//dialog:storage)',
+        redirectTo: '/app/(private//dialog:storage)',
       },
       {
         path: 'invitations',
@@ -107,11 +117,11 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'invitations',
-        redirectTo: '/app/(myfiles//dialog:invitations)',
+        redirectTo: '/app/(private//dialog:invitations)',
       },
       {
         path: 'archive/sentInvites',
-        redirectTo: '/app/(myfiles//dialog:invitations)',
+        redirectTo: '/app/(private//dialog:invitations)',
       },
       {
         path: 'connections',
@@ -126,19 +136,19 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'connections',
-        redirectTo: '/app/(myfiles//dialog:connections)',
+        redirectTo: '/app/(private//dialog:connections)',
       },
       {
         path: 'relationships',
-        redirectTo: '/app/(myfiles//dialog:connections)',
+        redirectTo: '/app/(private//dialog:connections)',
       },
       {
         path: 'archive/relationships',
-        redirectTo: '/app/(myfiles//dialog:connections)',
+        redirectTo: '/app/(private//dialog:connections)',
       },
       {
         path: 'relationship_request/:email',
-        redirectTo: '/app/(myfiles//dialog:connections)',
+        redirectTo: '/app/(private//dialog:connections)',
       },
       {
         path: 'profile',
@@ -157,7 +167,7 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'profile',
-        redirectTo: '/app/(myfiles//dialog:profile)',
+        redirectTo: '/app/(private//dialog:profile)',
       },
       {
         path: 'account',
@@ -171,7 +181,7 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'account',
-        redirectTo: '/app/(myfiles//dialog:account)',
+        redirectTo: '/app/(private//dialog:account)',
       },
       {
         path: 'members',
@@ -186,11 +196,11 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'members',
-        redirectTo: '/app/(myfiles//dialog:members)',
+        redirectTo: '/app/(private//dialog:members)',
       },
       {
         path: 'archive/members',
-        redirectTo: '/app/(myfiles//dialog:members)',
+        redirectTo: '/app/(private//dialog:members)',
       },
       {
         path: 'settings',
@@ -204,7 +214,7 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'settings',
-        redirectTo: '/app/(myfiles//dialog:settings)',
+        redirectTo: '/app/(private//dialog:settings)',
       },
       {
         path: 'welcome',
@@ -218,7 +228,7 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'welcome',
-        redirectTo: '/app/(myfiles//dialog:welcome)',
+        redirectTo: '/app/(private//dialog:welcome)',
       },
       {
         path: 'welcomeinvitation',
@@ -232,7 +242,7 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'welcome-invitation',
-        redirectTo: '/app/(myfiles//dialog:welcomeinvitation)',
+        redirectTo: '/app/(private//dialog:welcomeinvitation)',
       },
       {
         path: 'storage',
@@ -246,7 +256,7 @@ export const routes: RoutesWithData = [
       },
       {
         path: 'storage',
-        redirectTo: '/app/(myfiles//dialog:storage)',
+        redirectTo: '/app/(private//dialog:storage)',
       },
       {
         path: 'search',
@@ -258,7 +268,7 @@ export const routes: RoutesWithData = [
         path: 'switching',
         component: LoadingArchiveComponent,
       },
-      { path: '**', redirectTo: 'myfiles' },
+      { path: '**', redirectTo: 'private' },
     ],
   },
   { path: 'm', redirectTo: 'app' },

--- a/src/app/core/guards/myfiles.guard.spec.ts
+++ b/src/app/core/guards/myfiles.guard.spec.ts
@@ -1,0 +1,44 @@
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { MyfilesGuard } from './myfiles.guard';
+
+describe('MyfilesGuard', () => {
+  let guard: MyfilesGuard;
+  const dummyRoute = {} as ActivatedRouteSnapshot;
+  const dummyRouterState: (s: string) => RouterStateSnapshot = (url: string) =>
+    ({ url } as RouterStateSnapshot);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule]
+    });
+    guard = TestBed.inject(MyfilesGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should redirect /app/myfiles to /app/private', () => {
+    const tree: UrlTree = guard.canActivate(
+      dummyRoute,
+      dummyRouterState('/app/myfiles')
+    ) as UrlTree;
+    expect(tree.toString()).toBe('/app/private');
+  });
+
+  it('should redirect a myfiles subdirectory to /app/private/*', () => {
+    const tree: UrlTree = guard.canActivate(
+      dummyRoute,
+      dummyRouterState('/app/myfiles/0001-000m/22')
+    ) as UrlTree;
+    expect(tree.toString()).toBe('/app/private/0001-000m/22');
+  });
+});

--- a/src/app/core/guards/myfiles.guard.ts
+++ b/src/app/core/guards/myfiles.guard.ts
@@ -1,0 +1,31 @@
+/* @format */
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { Observable } from 'rxjs';
+
+/**
+ * Redirects any nested routes from /app/myfiles/** to /app/private/**
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class MyfilesGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ):
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    return this.router.parseUrl(state.url.replace(/^\/app\/myfiles/, '/app/private'));
+  }
+}

--- a/src/app/core/resolves/folder-resolve.service.ts
+++ b/src/app/core/resolves/folder-resolve.service.ts
@@ -91,7 +91,7 @@ export class FolderResolveService implements Resolve<any> {
         } else if (state.url.includes('apps')) {
           this.router.navigate(['/apps']);
         } else {
-          this.router.navigate(['/myfiles']);
+          this.router.navigate(['/private']);
         }
         return Promise.reject(false);
       });

--- a/src/app/core/resolves/lean-folder-resolve.service.ts
+++ b/src/app/core/resolves/lean-folder-resolve.service.ts
@@ -67,7 +67,7 @@ export class LeanFolderResolveService implements Resolve<any> {
         } else if (state.url.includes('apps')) {
           this.router.navigate(['/apps']);
         } else {
-          this.router.navigate(['/myfiles']);
+          this.router.navigate(['/private']);
         }
         return Promise.reject(false);
       });

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -468,7 +468,7 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
     } else if (this.router.routerState.snapshot.url.includes('/public')) {
       rootUrl = '/public';
     } else {
-      rootUrl = '/myfiles';
+      rootUrl = '/private';
     }
 
     if (this.item.isFolder) {

--- a/src/app/onboarding/components/onboarding/onboarding.component.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.ts
@@ -53,7 +53,7 @@ export class OnboardingComponent implements OnInit {
       if (ownArchives.length > 0 && false) {
         // This user already has archives. They don't need to onboard.
         this.showOnboarding = false;
-        this.router.navigate(['/app', 'myfiles']);
+        this.router.navigate(['/app', 'private']);
       } else {
         this.pendingArchives = pendingArchives;
         this.showOnboarding = true;

--- a/src/app/onboarding/guards/onboarding.auth.guard.ts
+++ b/src/app/onboarding/guards/onboarding.auth.guard.ts
@@ -20,7 +20,7 @@ export class OnboardingAuthGuard implements CanActivate {
     if (this.account.getAccount()?.accountId) {
       return this.account.hasOwnArchives().then((hasArchives) => {
         if (hasArchives) {
-          return this.router.parseUrl('/app/myfiles');
+          return this.router.parseUrl('/app/private');
         }
         return true;
       });

--- a/src/app/public/components/public/public.component.ts
+++ b/src/app/public/components/public/public.component.ts
@@ -84,7 +84,7 @@ export class PublicComponent implements OnInit, OnDestroy {
   }
 
   onArchiveThumbClick() {
-    this.router.navigate(['/app', 'myfiles']);
+    this.router.navigate(['/app', 'private']);
   }
 
   onMyAccountClick() {

--- a/src/app/search/components/global-search-bar/global-search-bar.component.ts
+++ b/src/app/search/components/global-search-bar/global-search-bar.component.ts
@@ -264,9 +264,9 @@ export class GlobalSearchBarComponent implements OnInit {
       }
     } else if (item.folder_linkType === 'type.folder_link.private') {
       if (item.parentArchiveNbr === privateRoot.archiveNbr) {
-        routerPath = ['/app', 'myfiles'];
+        routerPath = ['/app', 'private'];
       } else {
-        routerPath = ['/app', 'myfiles', item.parentArchiveNbr, item.parentFolder_linkId];
+        routerPath = ['/app', 'private', item.parentArchiveNbr, item.parentFolder_linkId];
       }
     }
 

--- a/src/app/search/components/global-search-results/global-search-results.component.ts
+++ b/src/app/search/components/global-search-results/global-search-results.component.ts
@@ -209,9 +209,9 @@ export class GlobalSearchResultsComponent implements OnInit, OnDestroy, HasSubsc
       }
     } else if (item.folder_linkType === 'type.folder_link.private') {
       if (item.parentArchiveNbr === privateRoot.archiveNbr) {
-        routerPath = ['/app', 'myfiles'];
+        routerPath = ['/app', 'private'];
       } else {
-        routerPath = ['/app', 'myfiles', item.parentArchiveNbr, item.parentFolder_linkId];
+        routerPath = ['/app', 'private', item.parentArchiveNbr, item.parentFolder_linkId];
       }
     }
 

--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -328,7 +328,7 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
   }
 
   onMyAccountClick() {
-    return this.router.navigate(['/app', 'myfiles']);
+    return this.router.navigate(['/app', 'private']);
   }
 
   async onArchiveThumbClick() {

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.spec.ts
@@ -66,20 +66,20 @@ describe('BreadcrumbsComponent', () => {
     });
     dataService.setCurrentFolder(testFolder);
     expect(component.breadcrumbs.length).toBe(testFolder.pathAsArchiveNbr.length);
-    const expectedUrl = `/myfiles/${testFolder.pathAsArchiveNbr[1]}/${testFolder.pathAsFolder_linkId[1]}`;
+    const expectedUrl = `/private/${testFolder.pathAsArchiveNbr[1]}/${testFolder.pathAsFolder_linkId[1]}`;
     expect(component.breadcrumbs[1].routerPath).toEqual(expectedUrl);
   });
 
   it('should link to My Files for folders in My Files', async () => {
-    await init('/myfiles');
+    await init('/private');
     const testFolder = new FolderVO({
       pathAsArchiveNbr: ['test1', 'test2', 'test3'],
       pathAsText: ['My Files', 'Test Folder Parent', 'Test Folder'],
       pathAsFolder_linkId: [1, 2, 3]
     });
     TestBed.inject(DataService).setCurrentFolder(testFolder);
-    expect(component.breadcrumbs[0].routerPath).toEqual('/myfiles');
-    expect(component.breadcrumbs[1].routerPath).toContain('/myfiles');
+    expect(component.breadcrumbs[0].routerPath).toEqual('/private');
+    expect(component.breadcrumbs[1].routerPath).toContain('/private');
   });
 
   it('should link to Apps for folders in Apps', async () => {

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
@@ -24,7 +24,7 @@ export class Breadcrumb {
   getSpecialRouterPath(displayText) {
     switch (displayText) {
       case 'My Files':
-        return ['/myfiles'];
+        return ['/private'];
       case 'Public':
         return ['/public'];
       case 'Apps':
@@ -127,7 +127,7 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
     } else if (this.router.routerState.snapshot.url.includes('/public')) {
       rootUrl = '/public';
     } else {
-      rootUrl = '/myfiles';
+      rootUrl = '/private';
     }
 
     if (!folder) {

--- a/src/app/shared/directives/drag-target-router-link.directive.ts
+++ b/src/app/shared/directives/drag-target-router-link.directive.ts
@@ -64,7 +64,7 @@ export class DragTargetRouterLinkDirective implements DragTargetDroppableCompone
       return false;
     }
 
-    if (this.routerLink.includes('/myfiles')) {
+    if (this.routerLink.includes('/private')) {
       if (folder.type.includes('root.private')) {
         return false;
       }
@@ -100,7 +100,7 @@ export class DragTargetRouterLinkDirective implements DragTargetDroppableCompone
   }
 
   getFolderTypeFromLink() {
-    if (this.routerLink.includes('/myfiles')) {
+    if (this.routerLink.includes('/private')) {
       return 'type.folder.root.private';
     } else if (this.routerLink.includes('/public')) {
       return 'type.folder.root.public';

--- a/src/app/shared/services/drag/drag.service.ts
+++ b/src/app/shared/services/drag/drag.service.ts
@@ -301,7 +301,7 @@ export class DragService {
         });
       } else {
         switch (dropTarget.breadcrumb.routerPath) {
-          case '/myfiles':
+          case '/private':
             destination = this.accountService.getPrivateRoot();
             break;
           case '/public':


### PR DESCRIPTION
We have been slowly renaming the "My Files" folder to "Private Files" in our application. This PR changes the url for the Private Root from /app/myfiles/** to /app/private/**. The core route configuration was changed so /app/private is now the URL for the private root, and any internal links/redirects within the app were also changed to point to this new location.

To make things a bit nicer for people who may have bookmarked URLs within their archive or may just be hitting a link we missed somewhere else, a new route guard was made that will redirect any subdirectories from /app/myfiles/** to /app/private/**. This is used instead of a more standard redirect to keep the subdirectories in the path intact instead of just redirecting to /app/private.

**Steps 2 Test:**
1. Log into the app and check if the URL says /app/private
2. Open various dialogs and other pages and make sure they redirect to /app/private properly
3. Manually navigate to /app/myfiles and see that it redirects properly to /app/private
4. Move into a folder that's inside of your Private Root, and then change the "private" in the url to "myfiles". Verify that it redirects properly and you're still inside of the folder
   * So for example, I navigated into a subfolder and changed `/app/private/0001-000m/22` to `/app/myfiles/0001-000m/22`. The URL should change back to the private version without kicking you out of the folder.

Resolves PER-8999.