### PR TITLE
Allow users to hide download button on public archive

### DIFF
--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
@@ -13,7 +13,7 @@
       </div>
       <div class="dialog-tab"
         (click)="setTab('public-settings')" [class.active]="activeTab === 'public-settings'">
-        Public Archive Settings
+        Public Gallery
       </div>
     </div>
     <div class="panel" #panel>
@@ -32,7 +32,7 @@
           </ng-template>
         </ng-container>
         <ng-container *ngSwitchCase="'public-settings'">
-          <div class="panel-title">Public Settings</div>
+          <div class="panel-title">Public Gallery Page Settings</div>
           <ng-container *ngIf="hasAccess ; else noAccess">
             <pr-public-settings [archive]="archive"></pr-public-settings>
           </ng-container>

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
@@ -11,6 +11,10 @@
         (click)="setTab('manage-tags')" [class.active]="activeTab === 'manage-tags'">
         Manage Tags
       </div>
+      <div class="dialog-tab"
+        (click)="setTab('public-settings')" [class.active]="activeTab === 'public-settings'">
+        Public Archive Settings
+      </div>
     </div>
     <div class="panel" #panel>
       <ng-container [ngSwitch]="activeTab">
@@ -24,8 +28,14 @@
             </ng-template>
           </ng-container>
           <ng-template #noAccess>
-            <p>You do not have permission to manage tags for this archive. <a href="https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing" target="_blank">Learn more about permissions for managing tags here.</a></p>
+            <p>You do not have permission to manage settings for this archive. <a href="https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing" target="_blank">Learn more about permissions for managing archive settings here.</a></p>
           </ng-template>
+        </ng-container>
+        <ng-container *ngSwitchCase="'public-settings'">
+          <div class="panel-title">Public Settings</div>
+          <ng-container *ngIf="hasAccess ; else noAccess">
+            <pr-public-settings [archive]="archive"></pr-public-settings>
+          </ng-container>
         </ng-container>
       </ng-container>
     </div>

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -68,12 +68,6 @@ export class ArchiveSettingsDialogComponent implements OnInit {
     this.activeTab = tab;
   }
 
-  public togglePublicDownload(): void {
-    const archive = this.account.getArchive();
-    archive.allowPublicDownload = !archive.allowPublicDownload;
-    this.api.archive.update(archive);
-  }
-
   protected bindTagsToArchive(): void {
     const archiveId = this.account.getArchive()?.archiveId;
     for (let i = 0; i < this.tags.length; i++) {

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -4,8 +4,9 @@ import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { TagsService } from '@core/services/tags/tags.service';
 import { TagVO } from '@models/tag-vo';
+import { ArchiveVO } from '@models/index';
 
-type ArchiveSettingsDialogTab = 'manage-tags';
+type ArchiveSettingsDialogTab = 'manage-tags' | 'public-settings';
 
 @Component({
   selector: 'pr-archive-settings-dialog',
@@ -18,6 +19,7 @@ export class ArchiveSettingsDialogComponent implements OnInit {
   public tags: TagVO[] = [];
   public loadingTags: boolean = true;
   public hasAccess: boolean;
+  public archive: ArchiveVO;
 
   protected fetchTagsAttempts: number = 0;
 
@@ -47,6 +49,7 @@ export class ArchiveSettingsDialogComponent implements OnInit {
         }, 1000);
      });
    }
+   this.archive = this.account.getArchive();
   }
 
   public refreshTags(): void {
@@ -61,8 +64,14 @@ export class ArchiveSettingsDialogComponent implements OnInit {
     this.dialogRef.close();
   }
 
-  public setTab(tab: string): void {
-    // do nothing for now
+  public setTab(tab: ArchiveSettingsDialogTab): void {
+    this.activeTab = tab;
+  }
+
+  public togglePublicDownload(): void {
+    const archive = this.account.getArchive();
+    archive.allowPublicDownload = !archive.allowPublicDownload;
+    this.api.archive.update(archive);
   }
 
   protected bindTagsToArchive(): void {

--- a/src/app/core/components/public-settings/public-settings.component.html
+++ b/src/app/core/components/public-settings/public-settings.component.html
@@ -1,6 +1,6 @@
 <div class="public-settings">
   <div class="settings-item">
-    <label>Allow File Downloads</label>
+    <label>Show Download Button</label>
     <div class="form-check form-check-inline">
       <input
         class="form-check-input"
@@ -12,7 +12,7 @@
         [(ngModel)]="allowDownloadsToggle"
         (ngModelChange)="onAllowDownloadsChange()"
       />
-      <label class="form-check-label" for="allowDownloadsToggleOn">On</label>
+      <label class="form-check-label" for="allowDownloadsToggleOn">Show</label>
     </div>
     <div class="form-check form-check-inline">
       <input
@@ -25,15 +25,11 @@
         [(ngModel)]="allowDownloadsToggle"
         (ngModelChange)="onAllowDownloadsChange()"
       />
-      <label class="form-check-label" for="allowDownloadsToggleOff">Off</label>
+      <label class="form-check-label" for="allowDownloadsToggleOff">Hide</label>
     </div>
   </div>
-  <small class="text-muted" [ngSwitch]="allowDownloadsToggle">
-    <ng-container *ngSwitchCase="1">
-      Other users can download any files from your public archive.
-    </ng-container>
-    <ng-container *ngSwitchDefault>
-      Users cannot download any files from your public archive.
-    </ng-container>
+  <small class="text-muted">
+    Display a button that allows viewers of your published items to download a
+    copy of the source file to their device.
   </small>
 </div>

--- a/src/app/core/components/public-settings/public-settings.component.html
+++ b/src/app/core/components/public-settings/public-settings.component.html
@@ -1,0 +1,39 @@
+<div class="public-settings">
+  <div class="settings-item">
+    <label>Allow File Downloads</label>
+    <div class="form-check form-check-inline">
+      <input
+        class="form-check-input"
+        type="radio"
+        name="allowDownloadsToggle"
+        id="allowDownloadsToggleOn"
+        [value]="1"
+        [disabled]="updating"
+        [(ngModel)]="allowDownloadsToggle"
+        (ngModelChange)="onAllowDownloadsChange()"
+      />
+      <label class="form-check-label" for="allowDownloadsToggleOn">On</label>
+    </div>
+    <div class="form-check form-check-inline">
+      <input
+        class="form-check-input"
+        type="radio"
+        name="allowDownloadsToggle"
+        id="allowDownloadsToggleOff"
+        [value]="0"
+        [disabled]="updating"
+        [(ngModel)]="allowDownloadsToggle"
+        (ngModelChange)="onAllowDownloadsChange()"
+      />
+      <label class="form-check-label" for="allowDownloadsToggleOff">Off</label>
+    </div>
+  </div>
+  <small class="text-muted" [ngSwitch]="allowDownloadsToggle">
+    <ng-container *ngSwitchCase="1">
+      Other users can download any files from your public archive.
+    </ng-container>
+    <ng-container *ngSwitchDefault>
+      Users cannot download any files from your public archive.
+    </ng-container>
+  </small>
+</div>

--- a/src/app/core/components/public-settings/public-settings.component.scss
+++ b/src/app/core/components/public-settings/public-settings.component.scss
@@ -1,0 +1,1 @@
+@import '../../../file-browser/components/sharing-dialog/sharing-dialog.component.scss';

--- a/src/app/core/components/public-settings/public-settings.component.spec.ts
+++ b/src/app/core/components/public-settings/public-settings.component.spec.ts
@@ -1,0 +1,95 @@
+import { PublicSettingsComponent } from './public-settings.component';
+
+import { NgModule } from '@angular/core';
+import { Shallow } from 'shallow-render';
+
+import { ArchiveVO } from '@models';
+import { ApiService } from '@shared/services/api/api.service';
+
+@NgModule({
+  declarations: [], // components your module owns.
+  imports: [], // other modules your module needs.
+  providers: [ApiService], // providers available to your module.
+  bootstrap: [], // bootstrap this root component.
+})
+class DummyModule {}
+
+let archive: ArchiveVO;
+let throwError: boolean = false;
+let updatedDownload: boolean = false;
+let updated: boolean = false;
+const mockApiService = {
+  archive: {
+    update: async (data: any) => {
+      if (throwError) {
+        throw 'Test Error';
+      }
+      updated = true;
+      updatedDownload = data.allowPublicDownload as boolean;
+    },
+  },
+};
+
+describe('PublicSettingsComponent', () => {
+  let shallow: Shallow<PublicSettingsComponent>;
+  async function defaultRender(a: ArchiveVO = archive) {
+    return await shallow.render(
+      `<pr-public-settings [archive]="archive"></pr-public-settings>`,
+      {
+        bind: {
+          archive: a,
+        },
+      }
+    );
+  }
+  beforeEach(() => {
+    throwError = false;
+    updatedDownload = null;
+    updated = false;
+    archive = {
+      allowPublicDownload: true,
+    } as ArchiveVO;
+    shallow = new Shallow(PublicSettingsComponent, DummyModule).mock(
+      ApiService,
+      mockApiService
+    );
+  });
+
+  it('should exist', async () => {
+    const { element } = await defaultRender();
+    expect(element).not.toBeNull();
+  });
+
+  describe('it should have the proper option checked by default', () => {
+    it('on', async () => {
+      const { element } = await defaultRender();
+      expect(element.componentInstance.allowDownloadsToggle).toBeTruthy();
+    });
+    it('off', async () => {
+      const { element } = await defaultRender({
+        allowPublicDownload: false,
+      } as ArchiveVO);
+      expect(element.componentInstance.allowDownloadsToggle).toBeFalsy();
+    });
+  });
+
+  it('should save the archive setting when changed', async () => {
+    const { element } = await defaultRender();
+    expect(updated).toBeFalse();
+    element.componentInstance.allowDownloadsToggle = 0;
+    await element.componentInstance.onAllowDownloadsChange();
+    expect(updated).toBeTrue();
+    expect(updatedDownload).toBeFalse();
+    element.componentInstance.allowDownloadsToggle = 1;
+    await element.componentInstance.onAllowDownloadsChange();
+    expect(updatedDownload).toBeTrue();
+  });
+
+  it('should fail silently', async () => {
+    const { element } = await defaultRender();
+    throwError = true;
+    element.componentInstance.allowDownloadsToggle = 0;
+    await element.componentInstance.onAllowDownloadsChange();
+    expect(updated).toBeFalse();
+  });
+});

--- a/src/app/core/components/public-settings/public-settings.component.ts
+++ b/src/app/core/components/public-settings/public-settings.component.ts
@@ -1,0 +1,33 @@
+/* @format */
+import { Component, Input, OnInit } from '@angular/core';
+import { ArchiveVO } from '@models/index';
+import { ApiService } from '@shared/services/api/api.service';
+
+@Component({
+  selector: 'pr-public-settings',
+  templateUrl: './public-settings.component.html',
+  styleUrls: ['./public-settings.component.scss'],
+})
+export class PublicSettingsComponent implements OnInit {
+  @Input() public archive: ArchiveVO;
+  public updating: boolean = false;
+  public allowDownloadsToggle: number = 0;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.allowDownloadsToggle = +this.archive.allowPublicDownload;
+  }
+
+  public async onAllowDownloadsChange() {
+    this.archive.allowPublicDownload = !!this.allowDownloadsToggle;
+    this.updating = true;
+    try {
+      await this.api.archive.update(this.archive);
+    } catch {
+      // fail silently
+    } finally {
+      this.updating = false;
+    }
+  }
+}

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -56,6 +56,7 @@ import { ManageTagsComponent } from './components/manage-tags/manage-tags.compon
 import { WelcomeDialogComponent } from './components/welcome-dialog/welcome-dialog.component';
 import { WelcomeInvitationDialogComponent } from './components/welcome-invitation-dialog/welcome-invitation-dialog.component';
 import { AnnouncementModule } from '../announcement/announcement.module';
+import { PublicSettingsComponent } from './components/public-settings/public-settings.component';
 
 @NgModule({
   imports: [
@@ -100,6 +101,7 @@ import { AnnouncementModule } from '../announcement/announcement.module';
     ManageTagsComponent,
     WelcomeDialogComponent,
     WelcomeInvitationDialogComponent,
+    PublicSettingsComponent,
   ],
   providers: [
     DataService,

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -45,7 +45,7 @@
       readOnlyEmptyMessage="No description"
       type="description-textarea"></pr-inline-value-edit>
     </div>
-    <div class="file-viewer-download" *ngIf="isPublicArchive">
+    <div class="file-viewer-download" *ngIf="isPublicArchive && allowDownloads">
       <button class="btn btn-primary"  (click)="onDownloadClick()">Download</button>
     </div>
     <table>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, Inject, HostListener} from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, Inject, HostListener, Optional} from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Key } from 'ts-key-enum';
@@ -13,6 +13,7 @@ import { DataService } from '@shared/services/data/data.service';
 import { EditService } from '@core/services/edit/edit.service';
 import { DataStatus } from '@models/data-status.enum';
 import { DomSanitizer } from '@angular/platform-browser';
+import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
 
 import type { KeysOfType } from '@shared/utilities/keysoftype';
 
@@ -34,6 +35,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   public isDocument = false;
   public showThumbnail = true;
   public isPublicArchive: boolean = false;
+  public allowDownloads: boolean = false;
 
   public documentUrl = null;
 
@@ -64,6 +66,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
     private sanitizer: DomSanitizer,
     private accountService: AccountService,
     private editService: EditService,
+    @Optional() private publicProfile: PublicProfileService,
   ) {
     // store current scroll position in file list
     this.bodyScrollTop = window.scrollY;
@@ -87,6 +90,12 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
     if (route.snapshot.data?.isPublicArchive) {
       this.isPublicArchive = route.snapshot.data.isPublicArchive;
+    }
+
+    if (publicProfile) {
+      publicProfile.archive$().subscribe(archive => {
+        this.allowDownloads = archive.allowPublicDownload;
+      });
     }
 
     this.canEdit = this.accountService.checkMinimumAccess(this.currentRecord.accessRole, AccessRole.Editor) && !route.snapshot.data?.isPublicArchive;

--- a/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.scss
+++ b/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.scss
@@ -166,8 +166,8 @@ p {
   }
 }
 
-.share-link-settings {
-  .link-settings-item {
+.share-link-settings, .public-settings {
+  .link-settings-item, .settings-item {
     display: flex;
     align-items: center;
 

--- a/src/app/models/archive-vo.ts
+++ b/src/app/models/archive-vo.ts
@@ -35,6 +35,7 @@ export class ArchiveVO extends BaseVO implements DynamicListChild  {
   public type: ArchiveType;
   public isPendingAction: boolean;
   public isNewlyCreated: boolean;
+  public allowPublicDownload: boolean;
 
   constructor(voData: any) {
     super(voData);


### PR DESCRIPTION
This PR allows the user to hide the download button appearing on their public archive. This includes functionality to hide the button if the setting is <span title="or disabled I guess???">enabled,</span> as well as adding functionality to enable/disable the setting in the archive settings modal.

Steps to test:
1. Open a record in your public gallery in one tab/window.
1. In another tab, open the archive settings.
1. Enable and disable the setting, and refresh the other tab to make sure the download button is properly visible or hidden depending on the setting.

Resolves PER-8607 + PER-8832.