### PR TITLE
Show reCaptcha before verifying phone numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4316,6 +4316,11 @@
         "@types/node": "*"
       }
     },
+    "@types/grecaptcha": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/grecaptcha/-/grecaptcha-3.0.4.tgz",
+      "integrity": "sha512-7l1Y8DTGXkx/r4pwU1nMVAR+yD/QC+MCHKXAyEX/7JZhwcN1IED09aZ9vCjjkcGdhSQiu/eJqcXInpl6eEEEwg=="
+    },
     "@types/hammerjs": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
@@ -12082,6 +12087,15 @@
       "requires": {
         "intersection-observer": ">=0.11.0",
         "tslib": ">=1.9.0"
+      }
+    },
+    "ng-recaptcha": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ng-recaptcha/-/ng-recaptcha-9.0.0.tgz",
+      "integrity": "sha512-39YfJh1+p6gvfsGUhC8cmjhFZ1TtQ1OJES5SUgnanPL2aQuwrSX4WyTFh2liFn1dQqtGUVd5O4EhbcexB7AECQ==",
+      "requires": {
+        "@types/grecaptcha": "^3.0.3",
+        "tslib": "^2.2.0"
       }
     },
     "ngx-bootstrap": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ios-inner-height": "^1.1.1",
     "lodash": "^4.17.21",
     "ng-in-viewport": "^6.1.3",
+    "ng-recaptcha": "^9.0.0",
     "ngx-bootstrap": "^5.6.1",
     "ngx-cookie-service": "^13.2.1",
     "ngx-countup": "^7.3.3",

--- a/src/app/auth/auth.routes.ts
+++ b/src/app/auth/auth.routes.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { RecaptchaModule } from 'ng-recaptcha';
+
 import { SharedModule } from '@shared/shared.module';
 
 import { AuthComponent } from './components/auth/auth.component';
@@ -46,6 +48,7 @@ const routes: Routes = [
     RouterModule.forChild(routes),
     SharedModule,
     AnnouncementModule,
+    RecaptchaModule,
   ],
   declarations: [
     LoginComponent,

--- a/src/app/auth/components/verify/verify.component.html
+++ b/src/app/auth/components/verify/verify.component.html
@@ -1,17 +1,25 @@
 <pr-login-logo></pr-login-logo>
-<form [formGroup]="verifyForm" (ngSubmit)="onSubmit(verifyForm.value)">
-  <h1 class="form-title">
-    {{formTitle}}
-  </h1>
-  <p>
-    A verification code has been sent to your {{verifyingEmail ? 'email address' : 'mobile device'}}.
-    <br>
-    <br>
-    Enter it below to continue.
-  </p>
-  <input type="{{verifyingEmail ? 'text' : 'tel'}}" class="form-control" id="token" placeholder="Code"
-    [formControl]="verifyForm.controls['token']"
-    autocomplete="one-time-code" autocorrect="off" autocapitalize="off" spellcheck="false">
-    <button type="submit" class="btn btn-primary" [disabled]="waiting">{{formTitle}}</button>
-    <button type="button" class="btn btn-primary" [disabled]="waiting" (click)="resendCode()">Resend Code</button>
-</form>
+<ng-container *ngIf="(verifyingPhone || showCaptchaForEmail) && captchaEnabled && !captchaPassed; else verifyFormElement">
+  <div class="captcha">
+    <p>Please complete this verification challenge to receive a code on your device.</p>
+    <re-captcha [siteKey]="captchaSiteKey" (resolved)="resolveCaptcha($event)" (error)="onCaptchaError($event)"></re-captcha>
+  </div>
+</ng-container>
+<ng-template #verifyFormElement>
+  <form [formGroup]="verifyForm" (ngSubmit)="onSubmit(verifyForm.value)">
+    <h1 class="form-title">
+      {{formTitle}}
+    </h1>
+    <p>
+      A verification code has been sent to your {{verifyingEmail ? 'email address' : 'mobile device'}}.
+      <br>
+      <br>
+      Enter it below to continue.
+    </p>
+    <input type="{{verifyingEmail ? 'text' : 'tel'}}" class="form-control" id="token" placeholder="Code"
+      [formControl]="verifyForm.controls['token']"
+      autocomplete="one-time-code" autocorrect="off" autocapitalize="off" spellcheck="false">
+      <button type="submit" class="btn btn-primary" [disabled]="waiting">{{formTitle}}</button>
+      <button type="button" class="btn btn-primary" [disabled]="waiting" (click)="resendCode()">Resend Code</button>
+  </form>
+</ng-template>

--- a/src/app/auth/components/verify/verify.component.scss
+++ b/src/app/auth/components/verify/verify.component.scss
@@ -1,0 +1,9 @@
+.captcha {
+  text-align: center;
+
+  re-captcha {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/src/optional-secrets.js
+++ b/src/optional-secrets.js
@@ -3,6 +3,10 @@ const optionalSecrets = [
     name: 'FEATURED_ARCHIVES',
     default: '[]',
   },
+  {
+    name: 'RECAPTCHA_API_KEY',
+    default: '',
+  }
 ];
 
 module.exports = optionalSecrets;


### PR DESCRIPTION
Show the re-captcha component before sending any verification text messages to the user.

To test, you will need to add a reCAPTCHA Site Key to your `.env` file under the `RECAPTCHA_API_KEY` key. You should be able to get a reCAPTCHA site key from [here,](https://www.google.com/u/1/recaptcha/admin) and if you are on the Permanent Engineering Team, you should already see a Permanent Web-App key to use with your environment. We will need to make sure to add the Permanent Web App key to our secrets before merging!

If you want to test the behavior without having to send text messages, you can set the `showCaptchaForEmail` property on the `VerifyComponent` to true, which will enable the same reCAPTCHA functionality for e-mails as well, which should be a lot easier to test with (since you can just add +'s to your e-mail address if it's already verified... that doesn't work as well with phone numbers!).

Steps to test:
1. Make sure you have a reCAPTCHA key in your `.env` file
2. Add a phone number to your account (or update your e-mail if you are using the `showCaptchaForEmail` functionality)
3. Click the verify phone number/e-mail button.
4. Verify that a reCAPTCHA is shown, and that the verification code is not actually sent until the CAPTCHA has been verified.