### PR TITLE
Update tag editting to handle custom metadata separately

### DIFF
--- a/src/app/file-browser/components/edit-tags/edit-tags.component.html
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.html
@@ -2,8 +2,11 @@
   <pr-tags [tags]="itemTags" (click)="startEditing()" [readOnly]="false" [class.clickable]="canEdit && !isEditing"
     [canEdit]="canEdit" [animate]="isEditing" [isEditing]="isEditing"></pr-tags>
   <div class="input-group" *ngIf="isEditing" @ngIfScaleAnimation [class.has-tags]="allTags?.length">
-    <input type="text" class="new-tag form-control" placeholder="Add new tag"
-      [(ngModel)]="newTagName" (ngModelChange)="onTagType(newTagName)" (keydown.enter)="onInputEnter(newTagName)">
+    <input type="text" class="new-tag form-control" [placeholder]="placeholderText" [(ngModel)]="newTagName"
+    (ngModelChange)="onTagType(newTagName)" (keydown.enter)="onInputEnter(newTagName)">
+    <div *ngIf="newTagInputError" class="input-vertical-error">
+      {{this.tagType === 'keyword' ? "Tag cannot contain ':'" : "Format must be key:value"}}
+    </div>
     <div class="input-group-append">
       <button class="btn btn-primary" (click)="newTagName ? onInputEnter(newTagName) : endEditing()">{{ newTagName ? 'Add' : 'Done' }}</button>
     </div>
@@ -19,6 +22,10 @@
       </div>
     </div>
   </div>
+  <p class="manage-tags-message" *ngIf="isEditing" @ngIfScaleAnimation>
+    <span class="manage-tags-link" (click)="onManageTagsClick()">
+      Manage {{this.tagType === 'keyword' ? "tags" : 'custom metadata'}}</span> in archive settings.
+  </p>
 </ng-container>
 <ng-container *ngIf="isDialog">
   <div class="dialog-content">
@@ -28,8 +35,11 @@
         <pr-tags [tags]="item.TagVOs" (click)="startEditing()"
           [canEdit]="true" [animate]="isEditing" [isEditing]="isEditing"></pr-tags>
         <div class="input-group">
-          <input type="text" class="new-tag form-control" placeholder="Add new tag" *ngIf="isEditing" @ngIfScaleAnimation
+          <input type="text" class="new-tag form-control" [placeholder]="placeholderText" *ngIf="isEditing" @ngIfScaleAnimation
             [(ngModel)]="newTagName" (keydown.enter)="onInputEnter(newTagName)" (ngModelChange)="onTagType(newTagName)">
+          <div *ngIf="newTagInputError" class="input-vertical-error">
+            {{this.tagType === 'keyword' ? "Tag cannot contain ':'" : "Format must be key:value"}}
+          </div>
           <div class="input-group-append">
             <button class="btn btn-primary" (click)="onInputEnter(newTagName)" [disabled]="!newTagName">Add</button>
           </div>
@@ -46,6 +56,10 @@
           </div>
           <div class="edit-tag" *ngIf="!matchingTags.length">No existing tags found</div>
         </div>
+        <p class="manage-tags-message" *ngIf="isEditing" @ngIfScaleAnimation>
+          <span class="manage-tags-link" (click)="onManageTagsClick()">
+            Manage {{this.tagType === 'keyword' ? "tags" : 'custom metadata'}}</span> in archive settings.
+        </p>
     </div>
 
     </div>

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.scss
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.scss
@@ -42,7 +42,7 @@
 }
 
 .input-group {
-  margin-top: 0.25rem;
+  margin-top: 1.25rem;
 
   .btn {
     padding: 0.5rem;
@@ -99,4 +99,29 @@
 
 .edit-tags-dialog-body {
   padding: 0px 10px;
+}
+
+.input-vertical-error {
+    position: absolute;
+    font-size: 10px;
+    line-height: .85rem * 1.5;
+    background: none;
+    pointer-events: none;
+    opacity: 1;
+    transition: 0.1s ease-in opacity;
+    bottom: 0px;
+    right: 3.75rem;
+    color: $red;
+    z-index: 100;
+}
+
+.manage-tags-message {
+  margin-top: 1.125rem;
+
+  .manage-tags-link {
+    font-weight: 600;
+    color: black;
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -1,25 +1,197 @@
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+/* @format */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Shallow } from 'shallow-render';
+import { Subject, Observable } from 'rxjs';
 
-// import { EditTagsComponent } from './edit-tags.component';
+import { EditTagsComponent, TagType } from './edit-tags.component';
+import { FileBrowserComponentsModule } from '../../file-browser-components.module';
+import { ItemVO, TagVOData, RecordVO } from '@models';
+import { ApiService } from '@shared/services/api/api.service';
+import { DataService } from '@shared/services/data/data.service';
+import { TagsService } from '@core/services/tags/tags.service';
+import { MessageService } from '@shared/services/message/message.service';
+import { SearchService } from '@search/services/search.service';
+import { TagResponse } from '@shared/services/api/tag.repo';
+import { Dialog } from '@root/app/dialog/dialog.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-// describe('EditTagsComponent', () => {
-//   let component: EditTagsComponent;
-//   let fixture: ComponentFixture<EditTagsComponent>;
+const defaultTagList: TagVOData[] = [
+  {
+    tagId: 1,
+    name: 'tagOne',
+    type: 'type.generic.placeholder',
+  },
+  {
+    tagId: 2,
+    name: 'tagTwo',
+    type: 'type.generic.placeholder',
+  },
+  {
+    tagId: 3,
+    name: 'customField:customValueOne',
+    type: 'type.tag.metadata.customField',
+  },
+  {
+    tagId: 4,
+    name: 'customField:customValueTwo',
+    type: 'type.tag.metadata.customField',
+  },
+];
+const defaultItem: ItemVO = new RecordVO({ TagVOs: defaultTagList });
 
-//   beforeEach(async(() => {
-//     TestBed.configureTestingModule({
-//       declarations: [ EditTagsComponent ]
-//     })
-//     .compileComponents();
-//   }));
+describe('EditTagsComponent', () => {
+  let shallow: Shallow<EditTagsComponent>;
+  async function defaultRender(
+    item: ItemVO = defaultItem,
+    tagType: TagType = 'keyword'
+  ) {
+    return await shallow.render(
+      `<pr-edit-tags [item]="item" [tagType]="tagType"></pr-edit-tags>`,
+      {
+        bind: {
+          item: item,
+          tagType: tagType,
+        },
+      }
+    );
+  }
 
-//   beforeEach(() => {
-//     fixture = TestBed.createComponent(EditTagsComponent);
-//     component = fixture.componentInstance;
-//     fixture.detectChanges();
-//   });
+  beforeEach(async(() => {
+    shallow = new Shallow(EditTagsComponent, FileBrowserComponentsModule)
+      .dontMock(NoopAnimationsModule)
+      .import(NoopAnimationsModule)
+      .mock(SearchService, { getTagResults: (tag) => defaultTagList })
+      .mock(TagsService, {
+        getTags: () => defaultTagList,
+        getTags$: () => new Observable<TagVOData[]>(),
+      })
+      .mock(MessageService, { showError: () => {} })
+      .mock(ApiService, {
+        tag: {
+          deleteTagLink: (tag, tagLink) => Promise.resolve(new TagResponse()),
+          create: (tag, tagLink) => Promise.resolve(new TagResponse()),
+        },
+      })
+      .mock(DataService, { fetchFullItems: (items) => Promise.resolve([]) })
+      .mock(Dialog, { open: (token, data, options) => Promise.resolve({}) });
+  }));
 
-//   it('should create', () => {
-//     expect(component).toBeTruthy();
-//   });
-// });
+  it('should create', async () => {
+    const { element } = await defaultRender();
+    expect(element).not.toBeNull();
+  });
+
+  it('should only show keywords in keyword mode', async () => {
+    const { element } = await defaultRender();
+
+    expect(
+      element.componentInstance.itemTags.find((tag) => tag.name === 'tagOne')
+    ).toBeTruthy();
+    expect(
+      element.componentInstance.itemTags.find((tag) => tag.name === 'tagTwo')
+    ).toBeTruthy();
+    expect(
+      element.componentInstance.itemTags.find(
+        (tag) => tag.name === 'customField:customValueOne'
+      )
+    ).not.toBeTruthy();
+    expect(
+      element.componentInstance.itemTags.find(
+        (tag) => tag.name === 'customField:customValueTwo'
+      )
+    ).not.toBeTruthy();
+
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'tagOne'
+      )
+    ).toBeTruthy();
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'tagTwo'
+      )
+    ).toBeTruthy();
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'customField:customValueOne'
+      )
+    ).not.toBeTruthy();
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'customField:customValueTwo'
+      )
+    ).not.toBeTruthy();
+  });
+
+  it('should only show custom metadata in custom metadata mode', async () => {
+    const { element } = await defaultRender(defaultItem, 'customMetadata');
+
+    expect(
+      element.componentInstance.itemTags.find((tag) => tag.name === 'tagOne')
+    ).not.toBeTruthy();
+    expect(
+      element.componentInstance.itemTags.find((tag) => tag.name === 'tagTwo')
+    ).not.toBeTruthy();
+    expect(
+      element.componentInstance.itemTags.find(
+        (tag) => tag.name === 'customField:customValueOne'
+      )
+    ).toBeTruthy();
+    expect(
+      element.componentInstance.itemTags.find(
+        (tag) => tag.name === 'customField:customValueTwo'
+      )
+    ).toBeTruthy();
+
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'tagOne'
+      )
+    ).not.toBeTruthy();
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'tagTwo'
+      )
+    ).not.toBeTruthy();
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'customField:customValueOne'
+      )
+    ).toBeTruthy();
+    expect(
+      element.componentInstance.matchingTags.find(
+        (tag) => tag.name === 'customField:customValueTwo'
+      )
+    ).toBeTruthy();
+  });
+
+  it('should not create custom metadata in keyword mode', async () => {
+    const { element } = await defaultRender();
+    const tagCreateSpy = spyOn(element.componentInstance.api.tag, 'create');
+    await element.componentInstance.onInputEnter('key:value');
+    expect(element.componentInstance.newTagInputError).toBeTruthy();
+    expect(tagCreateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not create keyword in custom metadata mode', async () => {
+    const { element } = await defaultRender(defaultItem, 'customMetadata');
+    const tagCreateSpy = spyOn(element.componentInstance.api.tag, 'create');
+    await element.componentInstance.onInputEnter('keyword');
+    expect(element.componentInstance.newTagInputError).toBeTruthy();
+    expect(tagCreateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should open dialog when manage link is clicked', async () => {
+    const { element, find, inject, fixture } = await defaultRender();
+    const dialogOpenSpy = inject(Dialog);
+
+    element.componentInstance.isEditing = true;
+    fixture.detectChanges();
+
+    find('.manage-tags-message .manage-tags-link').triggerEventHandler(
+      'click',
+      {}
+    );
+    expect(dialogOpenSpy.open).toHaveBeenCalled();
+  });
+});

--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -45,7 +45,13 @@
     <div class="sidebar-item">
       <label>Tags</label>
       <div class="sidebar-item-content">
-        <pr-edit-tags [item]="selectedItem" [canEdit]="canEdit"></pr-edit-tags>
+        <pr-edit-tags [item]="selectedItem" [canEdit]="canEdit" tagType="keyword"></pr-edit-tags>
+      </div>
+    </div>
+    <div class="sidebar-item">
+      <label>Custom Metadata</label>
+      <div class="sidebar-item-content">
+        <pr-edit-tags [item]="selectedItem" [canEdit]="canEdit" tagType="customMetadata"></pr-edit-tags>
       </div>
     </div>
     <div class="sidebar-item">

--- a/src/app/models/tag-vo.ts
+++ b/src/app/models/tag-vo.ts
@@ -1,9 +1,11 @@
+/* @format */
 import { BaseVO, BaseVOData } from './base-vo';
 
 export interface TagVOData extends BaseVOData {
   tagId?: number;
   name?: string;
   status?: string;
+  type?: string;
 }
 
 export interface TagLinkVOData extends BaseVOData {

--- a/src/app/shared/components/tags/tags.component.html
+++ b/src/app/shared/components/tags/tags.component.html
@@ -1,5 +1,9 @@
-<div class="empty" *ngIf="!tags?.length">{{ canEdit && !isEditing ? 'Click to add tags' : 'No tags'}}</div>
+<div class="empty" *ngIf="!tags?.length">{{ canEdit && !isEditing ? 'Click to add' : 'No tags'}}</div>
 <ng-container *ngIf="tags?.length">
   <div class="tag" *ngFor="let tag of orderedTags; trackBy: tagTrackByFn"
-  [@ngIfScaleAnimationDynamic]="animate ? 'animate' : 'static'">{{tag.name}}</div>
+  [@ngIfScaleAnimationDynamic]="animate ? 'animate' : 'static'">
+    <span class="keyword" *ngIf="!tag.name.includes(':')">{{tag.name}}</span>
+    <span class="customMetadataField" *ngIf="tag.name.includes(':')">{{tag.name.split(':')[0]}}</span>
+    <span class="customMetadataValue" *ngIf="tag.name.includes(':')">{{tag.name.slice(tag.name.indexOf(':')+1)}}</span>
+  </div>
 </ng-container>

--- a/src/app/shared/components/tags/tags.component.scss
+++ b/src/app/shared/components/tags/tags.component.scss
@@ -18,12 +18,28 @@ $gutter-size: 0.25rem;
   }
 
   .tag {
-    padding: 0.25rem 0.5rem;
-    border-radius: $border-radius;
+    padding: 0.5rem 0rem;
+    border-radius: 0.5rem;
     margin-right: $gutter-size;
     margin-bottom: $gutter-size;
-    background: rgba($PR-purple, 0.2);
     user-select: none;
+    color: $gray-900;
+    .keyword, .customMetadataField, .customMetadataValue {
+      border-radius: 0.5rem;
+      padding: 0.5rem 1rem;
+    }
+    .keyword {
+      background: rgba($PR-purple, 0.2);
+    }
+    .customMetadataField {
+      border-radius: 0.5rem 0rem 0rem 0.5rem;
+      color: #ffffff;
+      background: #5261b7;
+    }
+    .customMetadataValue {
+      border-radius: 0rem 0.5rem 0.5rem 0rem;
+      background: rgba(#5261b7, 0.2);
+    }
   }
 
   @include beforeDesktop {
@@ -35,6 +51,3 @@ $gutter-size: 0.25rem;
 .empty {
   margin-bottom: 0.25rem;
 }
-
-
-

--- a/src/app/shared/components/tags/tags.component.spec.ts
+++ b/src/app/shared/components/tags/tags.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { TagsComponent } from './tags.component';
 
@@ -8,12 +10,15 @@ describe('TagsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ TagsComponent ]
-    })
-    .compileComponents();
+      declarations: [TagsComponent],
+    }).compileComponents();
   }));
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule],
+      declarations: [TagsComponent],
+    }).compileComponents();
     fixture = TestBed.createComponent(TagsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -21,5 +26,22 @@ describe('TagsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should create tagType and tagValue elements', () => {
+    const tags = [{ name: 'type:value' }];
+    component.tags = tags;
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    const debugTypeElement = fixture.debugElement.query(
+      By.css('.customMetadataField')
+    );
+    expect(debugTypeElement).toBeTruthy();
+
+    const debugValueElement = fixture.debugElement.query(
+      By.css('.customMetadataValue')
+    );
+    expect(debugValueElement).toBeTruthy();
   });
 });

--- a/src/app/shared/components/tags/tags.component.ts
+++ b/src/app/shared/components/tags/tags.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, Input, OnChanges, HostBinding } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  Input,
+  OnChanges,
+  HostBinding,
+} from '@angular/core';
 import { TagVOData } from '@models/tag-vo';
 import { orderBy } from 'lodash';
 import { ngIfScaleAnimationDynamic } from '@shared/animations';
@@ -7,7 +13,7 @@ import { ngIfScaleAnimationDynamic } from '@shared/animations';
   selector: 'pr-tags',
   templateUrl: './tags.component.html',
   styleUrls: ['./tags.component.scss'],
-  animations: [ ngIfScaleAnimationDynamic ]
+  animations: [ngIfScaleAnimationDynamic],
 })
 export class TagsComponent implements OnInit, OnChanges {
   @Input() tags: TagVOData[];
@@ -18,10 +24,9 @@ export class TagsComponent implements OnInit, OnChanges {
 
   orderedTags: TagVOData[] = [];
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
   ngOnChanges() {
     if (!this.tags?.length) {
@@ -40,5 +45,4 @@ export class TagsComponent implements OnInit, OnChanges {
   tagTrackByFn(index, tag: TagVOData) {
     return tag.name;
   }
-
 }


### PR DESCRIPTION
Currently, custom metadata is shown just like any other tag in the metadata sidebar of a file or folder. This commit creates a separate custom metadata section in that sidebar and updates how individual pieces of custom metadata are displayed to make clearer that they are key:value pairs.

Resolves PER-9020: Front-end: Implement design for displaying custom metadata