### PR TITLE
Disable folder thumbnails in archive manager

### DIFF
--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -132,6 +132,7 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
   @Input() isSelected = false;
   @Input() showAccess = false;
   @Input() canSelect = true;
+  @Input() showFolderThumbnails = false;
 
   public isMultiSelected =  false;
   public isDragTarget = false;
@@ -841,6 +842,10 @@ export class FileListItemComponent implements OnInit, AfterViewInit, OnChanges, 
   }
 
   private getFolderThumbnail(): void {
+    if (!this.showFolderThumbnails) {
+      this.folderContentsType = FolderContentsType.BROKEN_THUMBNAILS;
+      return;
+    }
     const sortPriorities = [
       'type.record.image',
       'type.record.video',

--- a/src/app/file-browser/components/file-list/file-list.component.html
+++ b/src/app/file-browser/components/file-list/file-list.component.html
@@ -13,6 +13,7 @@
     [allowNavigation]="allowNavigation"
     [isSelected]="showSidebar ? selectedItems.has(item) : false"
     [canSelect]="showSidebar"
+    [showFolderThumbnails]="showFolderThumbnails"
     (itemClicked)="onItemClick($event)"
     (itemVisible)="onItemVisible($event)"
     (refreshView)="refreshView()"

--- a/src/app/file-browser/components/file-list/file-list.component.ts
+++ b/src/app/file-browser/components/file-list/file-list.component.ts
@@ -77,6 +77,8 @@ export class FileListComponent implements OnInit, AfterViewInit, OnDestroy, HasS
   showFolderDescription = false;
   isRootFolder = false;
 
+  public showFolderThumbnails = false;
+
   @Input() allowNavigation = true;
 
   @Output() itemClicked = new EventEmitter<ItemClickEvent>();
@@ -132,6 +134,8 @@ export class FileListComponent implements OnInit, AfterViewInit, OnDestroy, HasS
     if (this.route.snapshot.data.noFileListNavigation) {
       this.allowNavigation = false;
     }
+
+    this.showFolderThumbnails = this.route.snapshot.data?.isPublicArchive;
 
     this.dataService.setCurrentFolder(this.currentFolder);
 


### PR DESCRIPTION
Due to migration changes and session locking on our API requests, folder thumbnail generation is too slow and we have decided to disable it in the archive manager right now. The default `folder` icon is used instead, without sending any API requests. While thumbnails are disabled in the archive manager, they are still enabled in the public gallery.

Ideally, folder thumbnails would also explicitly be enabled on the share preview page as well, however, folder thumbnails cannot be fetched from the front end on this page because of permissions issues (the folder thumbnail code has to be able to see the contents of the folder, which can only be done when logged in *with access already* or in a public folder).

Resolves PER-9067.

Steps to test:
1. Make sure to clear your session storage before testing. You can go into your browser's dev tools and go into the Application (Chromium) or Storage (Firefox) section to manage SessionStorage. Verify that `folderThumbnailCache` is deleted before testing so it doesn't interfere with the testing.
2. Browse folders and subfolders in the archive manager and verify that there aren't an excessive number of `getWithChildren` API calls in dev tools.
3. Switch to grid mode and verify that the folder icons are the default folder icon, with no thumbnails or other icons showing up.
4. View folders on a public gallery and verify that folder thumbnails are still being generated there.
5. View folders on a share preview page and verify that no folder thumbnails (or useless `getWithChildren` calls) are being generated.

On screens where folder thumbnails shouldn't be generated, you can also verify the code isn't running by checking to see if a `folderThumbnailCache` has been generated, which it shouldn't be as long as you haven't viewed a public archive.

<sub>night time PRs let's go :sunglasses: </sub>