### PR TITLE
Build application with reCAPTCHA key

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -28,6 +28,7 @@ jobs:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_DEV }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
           FEATURED_ARCHIVES: ${{ secrets.FEATURED_ARCHIVES_DEV }}
+          RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
         run: npm run build:dev
 
       - name: Archive `dist`

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -23,6 +23,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_PROD }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_PROD }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_LIVE_KEY }}
+          RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY }}
         run: npm run build
       - name: Archive `dist`
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -24,6 +24,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_STAGING }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_STAGING }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
+          RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
         run: npm run build:staging
       - name: Archive `dist`
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
While the reCAPTCHA functionality was merged in, the workflows for Github Actions were not updated to build with the API keys. Add the API keys to the build `env` variables so that the functionality is enabled on all environments.

I also added the needed secrets to this repo.