### PR TITLE
Change Password MFA

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -301,6 +301,11 @@ export class AccountService {
       })).toPromise();
   }
 
+  public checkForMFAWithLogin(oldPassword: string): Promise<AuthResponse> {
+    return this.api.auth.logIn(this.account.primaryEmail, oldPassword, this.account.rememberMe, this.account.keepLoggedIn)
+      .toPromise();
+  }
+
   public logOut(): Promise<AuthResponse> {
     return this.api.auth.logOut()
       .pipe(map((response: AuthResponse) => {
@@ -321,7 +326,6 @@ export class AccountService {
       .pipe(map((response: AuthResponse) => {
         if (response.isSuccessful) {
           this.setAccount(response.getAccountVO());
-          this.setArchive(response.getArchiveVO());
 
           this.accountChange.emit(this.account);
           return response;

--- a/src/app/shared/services/api/base.ts
+++ b/src/app/shared/services/api/base.ts
@@ -2,6 +2,10 @@ import { HttpService } from '@shared/services/http/http.service';
 import { SimpleVO, ResponseMessageType } from '@root/app/models';
 import { compact } from 'lodash';
 
+export interface CSRFResponse {
+  csrf: string;
+}
+
 export class BaseResponse {
   public isSuccessful: boolean;
   public isSystemUp: boolean;

--- a/src/app/shared/services/http/http.service.ts
+++ b/src/app/shared/services/http/http.service.ts
@@ -49,6 +49,29 @@ export class HttpService {
         return response;
       })).toPromise();
   }
+
+  public sendV2Request<T>(endpoint: string, data: any = {}): Observable<T> {
+    const requestBody = {
+      ...data,
+      csrf: this.storage.session.get(CSRF_KEY)
+    };
+    const url = this.apiUrl + endpoint;
+    return this.http.post(url, requestBody, {
+      headers: {
+        'Request-Version': '2',
+        'Content-Type': 'application/json',
+      }
+    }).pipe(map((response: any) => {
+      if (response?.csrf) {
+        this.storage.session.set(CSRF_KEY, JSON.stringify(response.csrf));
+      }
+      return response as T;
+    }));
+  }
+
+  public sendV2RequestPromise<T>(endpoint: string, data: any = {}): Promise<T> {
+    return this.sendV2Request<T>(endpoint, data).toPromise();
+  }
 }
 
 export { Observable };


### PR DESCRIPTION
This PR shows a prompt for MFA code when changing password if MFA is enabled on a user's account. This commit also incorporates the first usage of a "V2" endpoint in the web-app.

Steps to test:
1. Enable MFA on an account.
2. Try changing the password on the account
3. Verify an MFA code is sent and the prompt is shown.
4. Verify that you are not logged out after the password is changed!
5. Test out incorrect MFA codes, canceling out of the prompt, etc.

Resolves PER-9053.
