### PR TITLE
Wrap tags and custom metadata within colored background "pills"

### DIFF
--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -1,28 +1,59 @@
-<div class="file-viewer" [ngClass]="{'minimal': useMinimalView, 'editing-date': editingDate, 'can-edit': canEdit}">
+<!-- @format -->
+<div
+  class="file-viewer"
+  [ngClass]="{
+    minimal: useMinimalView,
+    'editing-date': editingDate,
+    'can-edit': canEdit
+  }"
+>
   <div class="file-viewer-close">
-    <a (click)="close()">
-      <i class="ion-md-arrow-dropleft"></i> Back
-    </a>
+    <a (click)="close()"> <i class="ion-md-arrow-dropleft"></i> Back </a>
   </div>
   <div class="thumb-target">
-    <div class="thumb-wrapper" *ngFor="let record of records; let i = index;" [hidden]="!isQueued(i)"
-      [ngClass]="{'prev': i == currentIndex - 1, 'next': i == currentIndex + 1, 'current': i == currentIndex, 'queue': isQueued(i)}">
-      <div class="thumb-preview no-placeholder" prBgImage [bgSrc]="record.thumbURL200" *ngIf="isQueued(i)"></div>
+    <div
+      class="thumb-wrapper"
+      *ngFor="let record of records; let i = index"
+      [hidden]="!isQueued(i)"
+      [ngClass]="{
+        prev: i == currentIndex - 1,
+        next: i == currentIndex + 1,
+        current: i == currentIndex,
+        queue: isQueued(i)
+      }"
+    >
+      <div
+        class="thumb-preview no-placeholder"
+        prBgImage
+        [bgSrc]="record.thumbURL200"
+        *ngIf="isQueued(i)"
+      ></div>
       <div *ngIf="currentRecord == record" class="full" [ngSwitch]="">
-        <pr-thumbnail [item]="currentRecord" *ngIf="showThumbnail"></pr-thumbnail>
+        <pr-thumbnail
+          [item]="currentRecord"
+          *ngIf="showThumbnail"
+        ></pr-thumbnail>
         <pr-video [item]="currentRecord" *ngIf="isVideo"></pr-video>
         <pr-audio [item]="currentRecord" *ngIf="isAudio"></pr-audio>
         <iframe [src]="documentUrl" *ngIf="isDocument && documentUrl"></iframe>
       </div>
     </div>
-    <div class="file-viewer-control file-viewer-control-previous" (click)="incrementCurrentRecord(true)"
-      *ngIf="currentIndex > 0"><span>&#8249;</span></div>
-    <div class="file-viewer-control file-viewer-control-next" (click)="incrementCurrentRecord()"
-      *ngIf="currentIndex < records.length - 1"><span>&#8250;</span></div>
+    <div
+      class="file-viewer-control file-viewer-control-previous"
+      (click)="incrementCurrentRecord(true)"
+      *ngIf="currentIndex > 0"
+    >
+      <span>&#8249;</span>
+    </div>
+    <div
+      class="file-viewer-control file-viewer-control-next"
+      (click)="incrementCurrentRecord()"
+      *ngIf="currentIndex < records.length - 1"
+    >
+      <span>&#8250;</span>
+    </div>
   </div>
-  <div class="file-viewer-name">
-    {{currentRecord.displayName}}
-  </div>
+  <div class="file-viewer-name">{{ currentRecord.displayName }}</div>
   <div class="file-viewer-metadata">
     <pr-inline-value-edit
       [displayValue]="currentRecord.displayName"
@@ -33,22 +64,26 @@
       emptyMessage="Click to add name"
       readOnlyEmptyMessage="No name"
       type="text"
-      class="h5"></pr-inline-value-edit>
+      class="h5"
+    ></pr-inline-value-edit>
     <div class="file-viewer-description">
       <pr-inline-value-edit
-      *ngIf="canEdit || currentRecord.description"
-      [displayValue]="currentRecord.description"
-      [itemId]="currentRecord.folder_linkId"
-      [canEdit]="canEdit"
-      (doneEditing)="onFinishEditing('description', $event)"
-      emptyMessage="Click to add description"
-      readOnlyEmptyMessage="No description"
-      type="description-textarea"></pr-inline-value-edit>
+        *ngIf="canEdit || currentRecord.description"
+        [displayValue]="currentRecord.description"
+        [itemId]="currentRecord.folder_linkId"
+        [canEdit]="canEdit"
+        (doneEditing)="onFinishEditing('description', $event)"
+        emptyMessage="Click to add description"
+        readOnlyEmptyMessage="No description"
+        type="description-textarea"
+      ></pr-inline-value-edit>
     </div>
     <div class="file-viewer-download" *ngIf="isPublicArchive && allowDownloads">
-      <button class="btn btn-primary"  (click)="onDownloadClick()">Download</button>
+      <button class="btn btn-primary" (click)="onDownloadClick()">
+        Download
+      </button>
     </div>
-    <table>
+    <table class="metadata-table">
       <tr>
         <td>Date</td>
         <td>
@@ -62,26 +97,38 @@
             (doneEditing)="onFinishEditing('displayDT', $event)"
             (toggledDatePicker)="onDateToggle($event)"
             type="date"
-            class="no-padding"></pr-inline-value-edit>
+            class="no-padding"
+          ></pr-inline-value-edit>
         </td>
       </tr>
       <tr>
-        <td>Uploaded</td><td>{{currentRecord.createdDT | date}}</td>
+        <td>Uploaded</td>
+        <td>{{ currentRecord.createdDT | date }}</td>
       </tr>
       <tr>
-        <td>Size</td><td>{{currentRecord.size | dsFileSize}}</td>
+        <td>Size</td>
+        <td>{{ currentRecord.size | dsFileSize }}</td>
       </tr>
       <tr>
-        <td>Type</td><td>{{currentRecord.type | prConstants | titlecase}}</td>
+        <td>Type</td>
+        <td>{{ currentRecord.type | prConstants | titlecase }}</td>
       </tr>
       <tr>
-        <td>Tags</td><td (click)="onTagsClick()"><pr-tags [tags]="currentRecord.TagVOs"></pr-tags></td>
+        <td>Tags</td>
+        <td (click)="onTagsClick()">
+          <pr-tags [tags]="currentRecord.TagVOs"></pr-tags>
+        </td>
       </tr>
       <tr>
         <td>Location</td>
         <td class="location-container" (click)="onLocationClick()">
-          <pr-static-map [location]="currentRecord.LocnVO" *ngIf="currentRecord.LocnVO"></pr-static-map>
-          <span *ngIf="currentRecord.LocnVO">{{(currentRecord.LocnVO | prLocation)?.full}}</span>
+          <pr-static-map
+            [location]="currentRecord.LocnVO"
+            *ngIf="currentRecord.LocnVO"
+          ></pr-static-map>
+          <span *ngIf="currentRecord.LocnVO">{{
+            (currentRecord.LocnVO | prLocation)?.full
+          }}</span>
           <span *ngIf="!currentRecord.LocnVO">No location</span>
         </td>
       </tr>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.scss
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.scss
@@ -1,3 +1,4 @@
+/* @format */
 @import 'variables';
 
 $toolbar-height: 30px;
@@ -60,7 +61,6 @@ $button-size: 2rem;
     display: flex;
     justify-content: center;
     align-items: center;
-
   }
 }
 
@@ -76,14 +76,19 @@ $button-size: 2rem;
   font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
-  transform: translateY(0)
+  transform: translateY(0);
 }
 
-.file-viewer-name, .file-viewer-close {
+.file-viewer-name,
+.file-viewer-close {
   transition: transform $transition-length ease-in-out;
 }
 
-.file-viewer-image, pr-thumbnail, pr-video, pr-audio .thumb-preview, iframe {
+.file-viewer-image,
+pr-thumbnail,
+pr-video,
+pr-audio .thumb-preview,
+iframe {
   position: absolute;
   top: 0px;
   bottom: 0px;
@@ -143,7 +148,6 @@ $button-size: 2rem;
     display: none;
   }
 
-
   &.file-viewer-control-previous {
     left: 10px;
   }
@@ -179,18 +183,18 @@ $button-size: 2rem;
   display: none;
 }
 
-.editing-date pr-inline-value-edit[type="date"] {
+.editing-date pr-inline-value-edit[type='date'] {
   left: -20%;
   top: 3em;
   margin-bottom: 3em;
 }
 
 .can-edit {
-  pr-tags, .location-container {
+  pr-tags,
+  .location-container {
     cursor: pointer;
   }
 }
-
 
 // Desktop tweaks
 @media screen and (min-width: 801px) {
@@ -214,6 +218,12 @@ $button-size: 2rem;
     td:first-child {
       font-weight: bold;
       padding-right: 5px;
+    }
+
+    .metadata-table {
+      table-layout: fixed;
+      width: $metadata-width;
+      block-size: border-box;
     }
   }
 

--- a/src/app/shared/components/tags/tags.component.html
+++ b/src/app/shared/components/tags/tags.component.html
@@ -1,9 +1,19 @@
-<div class="empty" *ngIf="!tags?.length">{{ canEdit && !isEditing ? 'Click to add' : 'No tags'}}</div>
+<!-- @format -->
+<div class="empty" *ngIf="!tags?.length">
+  {{ canEdit && !isEditing ? 'Click to add' : 'No tags' }}
+</div>
 <ng-container *ngIf="tags?.length">
-  <div class="tag" *ngFor="let tag of orderedTags; trackBy: tagTrackByFn"
-  [@ngIfScaleAnimationDynamic]="animate ? 'animate' : 'static'">
-    <span class="keyword" *ngIf="!tag.name.includes(':')">{{tag.name}}</span>
-    <span class="customMetadataField" *ngIf="tag.name.includes(':')">{{tag.name.split(':')[0]}}</span>
-    <span class="customMetadataValue" *ngIf="tag.name.includes(':')">{{tag.name.slice(tag.name.indexOf(':')+1)}}</span>
+  <div
+    class="tag"
+    *ngFor="let tag of orderedTags; trackBy: tagTrackByFn"
+    [@ngIfScaleAnimationDynamic]="animate ? 'animate' : 'static'"
+  >
+    <p class="keyword" *ngIf="!tag.name.includes(':')">{{ tag.name }}</p>
+    <p class="customMetadataField" *ngIf="tag.name.includes(':')">
+      {{ tag.name.split(':')[0] }}
+    </p>
+    <p class="customMetadataValue" *ngIf="tag.name.includes(':')">
+      {{ tag.name.slice(tag.name.indexOf(':') + 1) }}
+    </p>
   </div>
 </ng-container>

--- a/src/app/shared/components/tags/tags.component.scss
+++ b/src/app/shared/components/tags/tags.component.scss
@@ -1,3 +1,4 @@
+/* @format */
 @import 'variables';
 $gutter-size: 0.25rem;
 :host {
@@ -24,21 +25,30 @@ $gutter-size: 0.25rem;
     margin-bottom: $gutter-size;
     user-select: none;
     color: $gray-900;
-    .keyword, .customMetadataField, .customMetadataValue {
+    display: flex;
+    .keyword,
+    .customMetadataField,
+    .customMetadataValue {
       border-radius: 0.5rem;
       padding: 0.5rem 1rem;
+      overflow-wrap: break-word;
+      hyphens: auto;
     }
     .keyword {
       background: rgba($PR-purple, 0.2);
     }
     .customMetadataField {
+      float: left;
       border-radius: 0.5rem 0rem 0rem 0.5rem;
       color: #ffffff;
       background: #5261b7;
+      max-width: 6.5rem;
     }
     .customMetadataValue {
+      float: left;
       border-radius: 0rem 0.5rem 0.5rem 0rem;
       background: rgba(#5261b7, 0.2);
+      max-width: 6.5rem;
     }
   }
 


### PR DESCRIPTION
Currently, when tags or custom metadata are very long they wrap, causing their colored background padding to overlap in an odd-looking way. This commit resolves the issue by using `<p>` elements instead of `<span>`s, so the text wraps within a taller block of background padding if it is long enough to wrap.

