### PR TITLE
Restrict tag service cache to tags from the current archive

### DIFF
--- a/src/app/core/services/tags/tags.service.spec.ts
+++ b/src/app/core/services/tags/tags.service.spec.ts
@@ -1,16 +1,40 @@
-// import { TestBed } from '@angular/core/testing';
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import { Shallow } from 'shallow-render';
+import { Subscription } from 'rxjs';
 
-// import { TagsService } from './tags.service';
+import { TagsService } from './tags.service';
+import { AccountService } from '@shared/services/account/account.service';
+import { AppModule } from '../../../app.module';
+import { ArchiveVO, RecordVO } from '@models';
 
-// describe('TagsService', () => {
-//   let service: TagsService;
+describe('TagsService', () => {
+  let shallow: Shallow<TagsService>;
 
-//   beforeEach(() => {
-//     TestBed.configureTestingModule({});
-//     service = TestBed.inject(TagsService);
-//   });
+  beforeEach(() => {
+    shallow = new Shallow(TagsService, AppModule).mock(AccountService, {
+      getArchive: () => new ArchiveVO({ archiveId: 1 }),
+      archiveChange: {
+        subscribe: (callback) => new Subscription(),
+      },
+    });
+  });
 
-//   it('should be created', () => {
-//     expect(service).toBeTruthy();
-//   });
-// });
+  it('should be created', () => {
+    const { instance } = shallow.createService();
+    expect(instance).toBeTruthy();
+  });
+
+  it('should only cache tags from the current archive', () => {
+    const { instance } = shallow.createService();
+    const item = new RecordVO({
+      TagVOs: [
+        { tagId: 1, name: 'testOne', archiveId: 1 },
+        { tagId: 2, name: 'testTwo', archiveId: 2 },
+      ],
+    });
+    instance.checkTagsOnItem(item);
+
+    expect(instance.getTags().length).toEqual(1);
+  });
+});

--- a/src/app/core/services/tags/tags.service.ts
+++ b/src/app/core/services/tags/tags.service.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Injectable } from '@angular/core';
 import { TagVOData } from '@models/tag-vo';
 import debug from 'debug';
@@ -9,16 +10,13 @@ import { debugSubscribable } from '@shared/utilities/debug';
 import { ApiService } from '@shared/services/api/api.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class TagsService {
   private tags: Map<number, TagVOData> = new Map();
   private tagsSubject: Subject<TagVOData[]> = new Subject();
   private debug = debug('service:tagsService');
-  constructor(
-    private account: AccountService,
-    private api: ApiService
-  ) {
+  constructor(private account: AccountService, private api: ApiService) {
     this.refreshTags();
 
     this.account.archiveChange.subscribe(() => {
@@ -37,8 +35,10 @@ export class TagsService {
 
   async refreshTags() {
     if (this.account.getArchive()) {
-      const response = await this.api.tag.getTagsByArchive(this.account.getArchive());
-      const tags = response.getTagVOsData().filter(t => t.name);
+      const response = await this.api.tag.getTagsByArchive(
+        this.account.getArchive()
+      );
+      const tags = response.getTagVOsData().filter((t) => t.name);
       for (const tag of tags) {
         this.tags.set(tag.tagId, tag);
       }
@@ -57,7 +57,11 @@ export class TagsService {
     let hasNew = false;
 
     for (const itemTag of item.TagVOs) {
-      if (!this.tags.has(itemTag.tagId) && itemTag.name) {
+      if (
+        !this.tags.has(itemTag.tagId) &&
+        itemTag.name &&
+        itemTag.archiveId === this.account.getArchive().archiveId
+      ) {
         this.tags.set(itemTag.tagId, itemTag);
         hasNew = true;
         this.debug('new tag seen %o', itemTag);

--- a/src/app/models/tag-vo.ts
+++ b/src/app/models/tag-vo.ts
@@ -6,6 +6,7 @@ export interface TagVOData extends BaseVOData {
   name?: string;
   status?: string;
   type?: string;
+  archiveId?: number;
 }
 
 export interface TagLinkVOData extends BaseVOData {


### PR DESCRIPTION
The TagsService is intended to keep track of all tags that exist in the current archive of a logged-in user. It updates its cache of tags when a new item is viewed in case that item has a recently added tag. However, this update also happens when viewing items in a public archive, and tags from such items are added to TagsService cache of tags. This will cause those tags to appear as options when a user subsequently returns to their own archive and tries to add a tag to an item, even though those tags don't actually exist in that archive. This commit fixes that bug by updating TagsService to check the archiveId of tags before adding them to its cache, and not add them if they don't match the current archive.

Resolves: https://permanent.atlassian.net/browse/PER-9082