### PR TITLE
Create FusionAuth and Permanent accounts as separate steps on signup

### DIFF
--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -1,16 +1,26 @@
+/* @format */
 import { Component, OnInit } from '@angular/core';
-import { FormGroup, FormBuilder, Validators, FormControl } from '@angular/forms';
+import {
+  FormGroup,
+  FormBuilder,
+  Validators,
+  FormControl,
+} from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 
 import APP_CONFIG from '@root/app/app.config';
 import { matchControlValidator, trimWhitespace } from '@shared/utilities/forms';
 
 import { AccountService } from '@shared/services/account/account.service';
-import { AuthResponse } from '@shared/services/api/auth.repo';
 import { MessageService } from '@shared/services/message/message.service';
-import { AccountResponse, InviteResponse } from '@shared/services/api/index.repo';
 import { ApiService } from '@shared/services/api/api.service';
-import { RecordVO, FolderVO, RecordVOData, FolderVOData, AccountVO } from '@models';
+import {
+  RecordVO,
+  FolderVO,
+  RecordVOData,
+  FolderVOData,
+  AccountVO,
+} from '@models';
 import { DeviceService } from '@shared/services/device/device.service';
 import { GoogleAnalyticsService } from '@shared/services/google-analytics/google-analytics.service';
 
@@ -21,7 +31,7 @@ const NEW_ONBOARDING_CHANCE = 1;
   selector: 'pr-signup',
   templateUrl: './signup.component.html',
   styleUrls: ['./signup.component.scss'],
-  host: {'class': 'pr-auth-form'}
+  host: { class: 'pr-auth-form' },
 })
 export class SignupComponent implements OnInit {
   signupForm: FormGroup;
@@ -75,35 +85,41 @@ export class SignupComponent implements OnInit {
           archiveNbr: responseData.recArchiveNbr,
           folder_linkId: responseData.folder_linkId,
           displayName: responseData.sharedItem,
-          thumbURL500: responseData.sharedThumb
+          thumbURL500: responseData.sharedThumb,
         };
 
         this.shareFromName = responseData.ShareArcName;
 
         this.shareItemIsRecord = params.tp === 'r';
-        this.shareItem = this.shareItemIsRecord ? new RecordVO(itemData) : new FolderVO(itemData);
+        this.shareItem = this.shareItemIsRecord
+          ? new RecordVO(itemData)
+          : new FolderVO(itemData);
       }
     }
 
     this.signupForm = fb.group({
       invitation: [inviteCode || ''],
-      email: [email || '', [trimWhitespace, Validators.required, Validators.email]],
+      email: [
+        email || '',
+        [trimWhitespace, Validators.required, Validators.email],
+      ],
       name: [name || '', Validators.required],
-      password: ['', [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)]],
+      password: [
+        '',
+        [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)],
+      ],
       agreed: [false, [Validators.requiredTrue]],
-      optIn: [true]
+      optIn: [true],
     });
 
-    const confirmPasswordControl = new FormControl('',
-    [
+    const confirmPasswordControl = new FormControl('', [
       Validators.required,
-      matchControlValidator(this.signupForm.controls['password'])
+      matchControlValidator(this.signupForm.controls['password']),
     ]);
     this.signupForm.addControl('confirm', confirmPasswordControl);
   }
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   shouldCreateDefaultArchive() {
     if (window.location.search.includes('createArchive')) {
@@ -121,50 +137,61 @@ export class SignupComponent implements OnInit {
   onSubmit(formValue: any) {
     this.waiting = true;
 
-    this.accountService.signUp(
-      formValue.email,
-      formValue.name,
-      formValue.password,
-      formValue.confirm,
-      formValue.agreed,
-      formValue.optIn,
-      null,
-      formValue.invitation,
-      this.shouldCreateDefaultArchive(),
-    ).then((response: AccountResponse) => {
-        const account = response.getAccountVO();
+    this.accountService
+      .signUp(
+        formValue.email,
+        formValue.name,
+        formValue.password,
+        formValue.confirm,
+        formValue.agreed,
+        formValue.optIn,
+        null,
+        formValue.invitation,
+        this.shouldCreateDefaultArchive()
+      )
+      .then((account: AccountVO) => {
         if (account.needsVerification()) {
-          this.message.showMessage(`Verify to continue as ${account.primaryEmail}.`, 'warning');
-          this.router.navigate(['..', 'verify'], {relativeTo: this.route});
+          this.message.showMessage(
+            `Verify to continue as ${account.primaryEmail}.`,
+            'warning'
+          );
+          this.router.navigate(['..', 'verify'], { relativeTo: this.route });
         } else {
-          this.accountService.logIn(formValue.email, formValue.password, true, true)
+          this.accountService
+            .logIn(formValue.email, formValue.password, true, true)
             .then(() => {
               this.redirectUserFromSignup();
             });
         }
       })
-      .catch((response: AccountResponse) => {
-        this.message.showError(response.getMessage(), true);
+      .catch((err) => {
+        this.message.showError(err.error.message, true);
         this.waiting = false;
       });
   }
 
   public redirectUserFromSignup() {
-    this.message.showMessage(`Logged in as ${this.accountService.getAccount().primaryEmail}.`, 'success');
+    this.message.showMessage(
+      `Logged in as ${this.accountService.getAccount().primaryEmail}.`,
+      'success'
+    );
 
     if (this.route.snapshot.queryParams.eventCategory) {
       this.ga.sendEvent({
         hitType: 'event',
         eventCategory: this.route.snapshot.queryParams.eventCategory,
-        eventAction: 'signup'
+        eventAction: 'signup',
       });
     }
 
     if (this.route.snapshot.queryParams.shareByUrl) {
-      this.router.navigate(['/share', this.route.snapshot.queryParams.shareByUrl]);
+      this.router.navigate([
+        '/share',
+        this.route.snapshot.queryParams.shareByUrl,
+      ]);
     } else if (this.route.snapshot.queryParams.cta === 'timeline') {
       if (this.device.isMobile() || !this.device.didOptOut()) {
-        this.router.navigate(['/public'], { queryParams: { cta: 'timeline' }});
+        this.router.navigate(['/public'], { queryParams: { cta: 'timeline' } });
       } else {
         window.location.assign(`/app/public?cta=timeline`);
       }
@@ -180,7 +207,12 @@ export class SignupComponent implements OnInit {
       }, 500);
     } else {
       setTimeout(() => {
-        this.router.navigate(['/shares', 'withme', this.shareItem.archiveNbr, this.shareItem.folder_linkId]);
+        this.router.navigate([
+          '/shares',
+          'withme',
+          this.shareItem.archiveNbr,
+          this.shareItem.folder_linkId,
+        ]);
       }, 500);
     }
   }

--- a/src/app/embed/components/newsletter-signup/newsletter-signup.component.ts
+++ b/src/app/embed/components/newsletter-signup/newsletter-signup.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Component, OnInit, HostBinding } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
@@ -5,21 +6,22 @@ import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import APP_CONFIG from '@root/app/app.config';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AccountService } from '@shared/services/account/account.service';
-import { AccountResponse } from '@shared/services/api/index.repo';
 import { MessageService } from '@shared/services/message/message.service';
 import { IFrameService } from '@shared/services/iframe/iframe.service';
+import { AccountVO } from '@models';
 
 @Component({
   selector: 'pr-newsletter-signup',
   templateUrl: './newsletter-signup.component.html',
-  styleUrls: ['./newsletter-signup.component.scss']
+  styleUrls: ['./newsletter-signup.component.scss'],
 })
 export class NewsletterSignupComponent implements OnInit {
   @HostBinding('class.for-light-bg') forLightBg = true;
   @HostBinding('class.for-dark-bg') forDarkBg = false;
   @HostBinding('class.visible') visible = false;
 
-  mailchimpEndpoint = 'https://permanent.us12.list-manage.com/subscribe/post-json?u=2948a82c4a163d7ab43a13356&amp;id=487bd863fb&';
+  mailchimpEndpoint =
+    'https://permanent.us12.list-manage.com/subscribe/post-json?u=2948a82c4a163d7ab43a13356&amp;id=487bd863fb&';
   mailchimpForm: FormGroup;
   mailchimpError: string;
   mailchimpSent = false;
@@ -40,20 +42,25 @@ export class NewsletterSignupComponent implements OnInit {
     private message: MessageService,
     private accountService: AccountService
   ) {
-
     const queryParams = route.snapshot.queryParams;
 
     this.mailchimpForm = fb.group({
-      email: ['', [ Validators.required, Validators.email ]]
+      email: ['', [Validators.required, Validators.email]],
     });
 
     this.signupForm = fb.group({
       invitation: [queryParams.inviteCode || null],
       email: ['', [Validators.required, Validators.email]],
       name: ['', Validators.required],
-      password: ['', [Validators.required, Validators.minLength(APP_CONFIG.passwordMinLength)]],
+      password: [
+        '',
+        [
+          Validators.required,
+          Validators.minLength(APP_CONFIG.passwordMinLength),
+        ],
+      ],
       agreed: [true, [Validators.requiredTrue]],
-      optIn: [true]
+      optIn: [true],
     });
 
     this.forLightBg = this.route.snapshot.queryParams.theme === 'forLightBg';
@@ -80,10 +87,11 @@ export class NewsletterSignupComponent implements OnInit {
       .set('b_2948a82c4a163d7ab43a13356_487bd863fb', '');
 
     const url = this.mailchimpEndpoint + params.toString().replace('+', '%2B');
-    this.http.jsonp(url, 'c').subscribe((response: any) => {
+    this.http.jsonp(url, 'c').subscribe(
+      (response: any) => {
         this.waiting = false;
         this.signupForm.patchValue({
-          email: formValue.email
+          email: formValue.email,
         });
         if (response.msg.includes('already')) {
           this.mailchimpSent = true;
@@ -94,10 +102,12 @@ export class NewsletterSignupComponent implements OnInit {
           this.mailchimpError = null;
           this.mailchimpSent = true;
         }
-      }, error => {
+      },
+      (error) => {
         this.waiting = false;
         this.mailchimpSent = true;
-      });
+      }
+    );
   }
 
   onSignupSubmit(formValue) {
@@ -107,29 +117,30 @@ export class NewsletterSignupComponent implements OnInit {
 
     this.waiting = true;
 
-    this.accountService.signUp(
-      formValue.email,
-      formValue.name,
-      formValue.password,
-      formValue.password,
-      formValue.agreed,
-      false,
-      null,
-      formValue.invitation,
-      true,
-    ).then((response: AccountResponse) => {
-        return this.accountService.logIn(formValue.email, formValue.password, true, true)
+    this.accountService
+      .signUp(
+        formValue.email,
+        formValue.name,
+        formValue.password,
+        formValue.password,
+        formValue.agreed,
+        false,
+        null,
+        formValue.invitation,
+        true
+      )
+      .then((response: AccountVO) => {
+        return this.accountService
+          .logIn(formValue.email, formValue.password, true, true)
           .then(() => {
             this.waiting = false;
             this.done = true;
             window.location.assign('/app');
-            // this.message.showMessage(`Logged in as ${this.accountService.getAccount().primaryEmail}.`, 'success');
           });
       })
-      .catch((response: AccountResponse) => {
-        this.message.showError(response.getMessage(), true);
+      .catch((err) => {
+        this.message.showError(err.error.message, true);
         this.waiting = false;
       });
   }
-
 }

--- a/src/app/embed/components/signup-embed/signup-embed.component.ts
+++ b/src/app/embed/components/signup-embed/signup-embed.component.ts
@@ -1,14 +1,19 @@
+/* @format */
 import { Component, OnInit } from '@angular/core';
-import { FormGroup, FormBuilder, Validators, FormControl } from '@angular/forms';
+import {
+  FormGroup,
+  FormBuilder,
+  Validators,
+  FormControl,
+} from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 
 import APP_CONFIG from '@root/app/app.config';
+import { AccountVO } from '@root/app/models';
 import { matchControlValidator, trimWhitespace } from '@shared/utilities/forms';
 
 import { AccountService } from '@shared/services/account/account.service';
-import { AuthResponse } from '@shared/services/api/auth.repo';
 import { MessageService } from '@shared/services/message/message.service';
-import { AccountResponse } from '@shared/services/api/index.repo';
 
 import * as FormUtilities from '@shared/utilities/forms';
 
@@ -18,7 +23,7 @@ const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
   selector: 'pr-signup',
   templateUrl: './signup-embed.component.html',
   styleUrls: ['./signup-embed.component.scss'],
-  host: {'class': 'pr-auth-form'}
+  host: { class: 'pr-auth-form' },
 })
 export class SignupEmbedComponent implements OnInit {
   signupForm: FormGroup;
@@ -30,7 +35,7 @@ export class SignupEmbedComponent implements OnInit {
     invitation: false,
     email: false,
     password: false,
-    confirm: false
+    confirm: false,
   };
 
   constructor(
@@ -49,50 +54,55 @@ export class SignupEmbedComponent implements OnInit {
       invitation: [this.inviteCode ? this.inviteCode : ''],
       email: ['', [trimWhitespace, Validators.required, Validators.email]],
       name: ['', Validators.required],
-      password: ['', [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)]],
+      password: [
+        '',
+        [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)],
+      ],
       agreed: [false, [Validators.requiredTrue]],
-      optIn: [true]
+      optIn: [true],
     });
 
-    const confirmPasswordControl = new FormControl('',
-    [
+    const confirmPasswordControl = new FormControl('', [
       Validators.required,
-      matchControlValidator(this.signupForm.controls['password'])
+      matchControlValidator(this.signupForm.controls['password']),
     ]);
     this.signupForm.addControl('confirm', confirmPasswordControl);
   }
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;
 
-    this.accountService.signUp(
-      formValue.email,
-      formValue.name,
-      formValue.password,
-      formValue.confirm,
-      formValue.agreed,
-      formValue.optIn,
-      null,
-      formValue.invitation,
-      true,
-    ).then((response: AccountResponse) => {
-        const account = response.getAccountVO();
+    this.accountService
+      .signUp(
+        formValue.email,
+        formValue.name,
+        formValue.password,
+        formValue.confirm,
+        formValue.agreed,
+        formValue.optIn,
+        null,
+        formValue.invitation,
+        true
+      )
+      .then((account: AccountVO) => {
         if (account.needsVerification()) {
           this.router.navigate(['..', 'verify'], { relativeTo: this.route });
         } else {
-          this.accountService.logIn(formValue.email, formValue.password, true, true)
-          .then(() => {
-            this.router.navigate(['..', 'done'], { relativeTo: this.route, queryParams: { inviteCode: this.inviteCode } });
-          });
+          this.accountService
+            .logIn(formValue.email, formValue.password, true, true)
+            .then(() => {
+              this.router.navigate(['..', 'done'], {
+                relativeTo: this.route,
+                queryParams: { inviteCode: this.inviteCode },
+              });
+            });
         }
       })
-      .catch((response: AccountResponse) => {
-        this.message.showError(response.getMessage(), true);
+      .catch((err) => {
+        this.message.showError(err.error.message, true);
         this.waiting = false;
       });
   }
-
 }

--- a/src/app/pledge/components/claim-storage/claim-storage.component.ts
+++ b/src/app/pledge/components/claim-storage/claim-storage.component.ts
@@ -1,10 +1,11 @@
+/* @format */
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 
 import APP_CONFIG from '@root/app/app.config';
+import { AccountVO } from '@root/app/models';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AccountService } from '@shared/services/account/account.service';
-import { AccountResponse } from '@shared/services/api/index.repo';
 import { PledgeService } from '@pledge/services/pledge.service';
 import { PledgeData } from '../new-pledge/new-pledge.component';
 import { ApiService } from '@shared/services/api/api.service';
@@ -14,7 +15,7 @@ const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
 @Component({
   selector: 'pr-claim-storage',
   templateUrl: './claim-storage.component.html',
-  styleUrls: ['./claim-storage.component.scss']
+  styleUrls: ['./claim-storage.component.scss'],
 })
 export class ClaimStorageComponent implements OnInit {
   public signupForm: FormGroup;
@@ -32,10 +33,10 @@ export class ClaimStorageComponent implements OnInit {
     private pledgeService: PledgeService
   ) {
     if (!pledgeService.currentPledgeData) {
-      this.router.navigate(['..'], {relativeTo: this.route});
+      this.router.navigate(['..'], { relativeTo: this.route });
       return this;
     } else if (!pledgeService.currentPledgeData.timestamp) {
-      this.router.navigate(['..', 'missing'], {relativeTo: this.route});
+      this.router.navigate(['..', 'missing'], { relativeTo: this.route });
       return this;
     }
 
@@ -44,48 +45,56 @@ export class ClaimStorageComponent implements OnInit {
     this.signupForm = fb.group({
       email: [this.pledge.email || '', [Validators.required, Validators.email]],
       name: [this.pledge.name || '', Validators.required],
-      password: ['', [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)]],
+      password: [
+        '',
+        [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)],
+      ],
       agreed: [false, [Validators.requiredTrue]],
-      optIn: [true]
+      optIn: [true],
     });
   }
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   async onSubmit(formValue: any) {
     this.waiting = true;
 
-    this.accountService.signUp(
-      formValue.email,
-      formValue.name,
-      formValue.password,
-      formValue.password,
-      formValue.agreed,
-      formValue.optIn,
-      null,
-      null,
-      true,
-    ).then(async (response: AccountResponse) => {
-        const account = response.getAccountVO();
+    this.accountService
+      .signUp(
+        formValue.email,
+        formValue.name,
+        formValue.password,
+        formValue.password,
+        formValue.agreed,
+        formValue.optIn,
+        null,
+        null,
+        true
+      )
+      .then(async (account: AccountVO) => {
         await this.pledgeService.linkAccount(account);
-        await this.accountService.logIn(formValue.email, formValue.password, true, true);
+        await this.accountService.logIn(
+          formValue.email,
+          formValue.password,
+          true,
+          true
+        );
 
         const billingVo = this.pledgeService.createBillingPaymentVo(account);
 
-        const billingResponse = await this.api.billing.claimPledge(billingVo, this.pledgeService.getPledgeId());
+        const billingResponse = await this.api.billing.claimPledge(
+          billingVo,
+          this.pledgeService.getPledgeId()
+        );
 
         this.waiting = false;
 
         if (billingResponse.isSuccessful) {
-          this.router.navigate(['..', 'done'], {relativeTo: this.route});
+          this.router.navigate(['..', 'done'], { relativeTo: this.route });
         }
-
       })
-      .catch((response: AccountResponse) => {
-        // this.message.showError(response.getMessage(), true);
+      .catch((err) => {
         this.waiting = false;
       });
   }
-
 }

--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -513,7 +513,7 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
         formValue.invitation,
         true
       )
-      .then((response: AccountResponse) => {
+      .then((account: AccountVO) => {
         this.sendGaEvent('signup');
         return this.accountService.logIn(
           formValue.email,
@@ -521,6 +521,10 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
           true,
           true
         );
+      })
+      .catch((err) => {
+        this.message.showError(err.error.message, true);
+        this.waiting = false;
       })
       .then(() => {
         // check if invite and show preview mode, or send access request
@@ -538,8 +542,8 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
           this.onRequestAccessClick();
         }
       })
-      .catch((response: AccountResponse) => {
-        this.message.showError(response.getMessage(), true);
+      .catch((err) => {
+        this.message.showError(err, true);
         this.waiting = false;
       });
   }

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Injectable, EventEmitter } from '@angular/core';
 import { map, min } from 'rxjs/operators';
 import { find, debounce } from 'lodash';
@@ -6,10 +7,19 @@ import { CookieService } from 'ngx-cookie-service';
 import { ApiService } from '@shared/services/api/api.service';
 import { StorageService } from '@shared/services/storage/storage.service';
 import { ArchiveVO, AccountVO, FolderVO } from '@root/app/models';
-import { AuthResponse, AccountResponse, ArchiveResponse, FolderResponse } from '@shared/services/api/index.repo';
+import {
+  AuthResponse,
+  AccountResponse,
+  ArchiveResponse,
+  FolderResponse,
+} from '@shared/services/api/index.repo';
 import { Router } from '@angular/router';
 import { Dialog } from '@root/app/dialog/dialog.module';
-import { AccessRole, AccessRoleType, checkMinimumAccess } from '@models/access-role';
+import {
+  AccessRole,
+  AccessRoleType,
+  checkMinimumAccess,
+} from '@models/access-role';
 
 import * as Sentry from '@sentry/browser';
 
@@ -18,7 +28,7 @@ const ARCHIVE_KEY = 'archive';
 const ROOT_KEY = 'root';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AccountService {
   private account: AccountVO;
@@ -70,8 +80,8 @@ export class AccountService {
     this.storage.local.set(ACCOUNT_KEY, this.account);
 
     // set account data on Sentry scope
-    Sentry.configureScope(scope => {
-      scope.setUser({id: this.account.accountId});
+    Sentry.configureScope((scope) => {
+      scope.setUser({ id: this.account.accountId });
     });
   }
 
@@ -80,8 +90,11 @@ export class AccountService {
     this.storage.local.set(ARCHIVE_KEY, this.archive);
 
     // set archive data as 'archive' context on Sentry scope
-    Sentry.configureScope(scope => {
-      scope.setContext('archive', { archiveNbr: newArchive.archiveNbr, archiveId: newArchive.archiveId });
+    Sentry.configureScope((scope) => {
+      scope.setContext('archive', {
+        archiveNbr: newArchive.archiveNbr,
+        archiveId: newArchive.archiveId,
+      });
     });
   }
 
@@ -137,22 +150,27 @@ export class AccountService {
     this.clearArchive();
     this.clearRootFolder();
 
-    Sentry.configureScope(scope => {
+    Sentry.configureScope((scope) => {
       scope.setUser(null);
       scope.setContext('archive', null);
     });
   }
 
   public getPrivateRoot() {
-    return find(this.rootFolder.ChildItemVOs, { type: 'type.folder.root.private'}) as FolderVO;
+    return find(this.rootFolder.ChildItemVOs, {
+      type: 'type.folder.root.private',
+    }) as FolderVO;
   }
 
   public getPublicRoot() {
-    return find(this.rootFolder.ChildItemVOs, { type: 'type.folder.root.public'}) as FolderVO;
+    return find(this.rootFolder.ChildItemVOs, {
+      type: 'type.folder.root.public',
+    }) as FolderVO;
   }
 
   public refreshAccount() {
-    return this.api.account.get(this.account)
+    return this.api.account
+      .get(this.account)
       .then((response: AccountResponse) => {
         if (!response.isSuccessful) {
           throw response;
@@ -174,7 +192,8 @@ export class AccountService {
       return Promise.resolve();
     }
 
-    return this.api.archive.get([this.archive])
+    return this.api.archive
+      .get([this.archive])
       .then((response: ArchiveResponse) => {
         if (!response.isSuccessful) {
           throw response;
@@ -191,7 +210,8 @@ export class AccountService {
   }
 
   public refreshArchives() {
-    return this.api.archive.getAllArchives(this.account)
+    return this.api.archive
+      .getAllArchives(this.account)
       .then((response: ArchiveResponse) => {
         const archives = response.getArchiveVOs();
         this.setArchives(archives);
@@ -201,9 +221,7 @@ export class AccountService {
 
   public async hasOwnArchives() {
     const archives = await this.refreshArchives();
-    const ownArchives = archives.filter(
-      (archive) => !archive.isPending()
-    );
+    const ownArchives = archives.filter((archive) => !archive.isPending());
     return ownArchives.length > 0;
   }
 
@@ -217,7 +235,8 @@ export class AccountService {
     const updated = new AccountVO(this.account);
     updated.update(accountChanges);
 
-    return this.api.account.update(updated)
+    return this.api.account
+      .update(updated)
       .then((response: AccountResponse) => {
         const newAccount = response.getAccountVO();
         this.account.update(newAccount);
@@ -226,7 +245,8 @@ export class AccountService {
   }
 
   public changeArchive(archive: ArchiveVO) {
-    return this.api.archive.change(archive)
+    return this.api.archive
+      .change(archive)
       .then((response: ArchiveResponse) => {
         archive = response.getArchiveVO();
         this.setArchive(archive);
@@ -248,13 +268,12 @@ export class AccountService {
       return Promise.resolve(true);
     }
 
-    return this.api.auth.isLoggedIn()
-      .then((response: AuthResponse) => {
-        if (!response.isSuccessful) {
-          throw response;
-        }
-        return response.getSimpleVO().value;
-      });
+    return this.api.auth.isLoggedIn().then((response: AuthResponse) => {
+      if (!response.isSuccessful) {
+        throw response;
+      }
+      return response.getSimpleVO().value;
+    });
   }
 
   public isLoggedIn(): boolean {
@@ -262,10 +281,18 @@ export class AccountService {
   }
 
   public isEmailOrPhoneUnverified(): boolean {
-    return this.account?.emailStatus === 'status.auth.unverified' || this.account?.phoneStatus === 'status.auth.unverified';
+    return (
+      this.account?.emailStatus === 'status.auth.unverified' ||
+      this.account?.phoneStatus === 'status.auth.unverified'
+    );
   }
 
-  public logIn(email: string, password: string, rememberMe: boolean, keepLoggedIn: boolean): Promise<any> {
+  public logIn(
+    email: string,
+    password: string,
+    rememberMe: boolean,
+    keepLoggedIn: boolean
+  ): Promise<any> {
     this.skipSessionCheck = false;
 
     if (rememberMe) {
@@ -278,85 +305,114 @@ export class AccountService {
 
     const currentAccount = this.account;
 
-    return this.api.auth.logIn(email, password, rememberMe, keepLoggedIn)
-      .pipe(map((response: AuthResponse) => {
-        if (response.isSuccessful) {
-          const newAccount = response.getAccountVO();
-          if (currentAccount && newAccount.accountId === currentAccount.accountId) {
-            newAccount.isNew = currentAccount.isNew;
-          }
-          this.setAccount(newAccount);
-          if (response.getArchiveVO()?.archiveId) {
+    return this.api.auth
+      .logIn(email, password, rememberMe, keepLoggedIn)
+      .pipe(
+        map((response: AuthResponse) => {
+          if (response.isSuccessful) {
+            const newAccount = response.getAccountVO();
+            if (
+              currentAccount &&
+              newAccount.accountId === currentAccount.accountId
+            ) {
+              newAccount.isNew = currentAccount.isNew;
+            }
+            this.setAccount(newAccount);
+            if (response.getArchiveVO()?.archiveId) {
               this.setArchive(response.getArchiveVO());
-          }
-          this.skipSessionCheck = true;
+            }
+            this.skipSessionCheck = true;
 
-          this.accountChange.emit(this.account);
-        } else if (response.needsMFA() || response.needsVerification()) {
-          this.setAccount(new AccountVO({primaryEmail: email}));
-        } else {
-          throw response;
-        }
-        return response;
-      })).toPromise();
+            this.accountChange.emit(this.account);
+          } else if (response.needsMFA() || response.needsVerification()) {
+            this.setAccount(new AccountVO({ primaryEmail: email }));
+          } else {
+            throw response;
+          }
+          return response;
+        })
+      )
+      .toPromise();
   }
 
   public checkForMFAWithLogin(oldPassword: string): Promise<AuthResponse> {
-    return this.api.auth.logIn(this.account.primaryEmail, oldPassword, this.account.rememberMe, this.account.keepLoggedIn)
+    return this.api.auth
+      .logIn(
+        this.account.primaryEmail,
+        oldPassword,
+        this.account.rememberMe,
+        this.account.keepLoggedIn
+      )
       .toPromise();
   }
 
   public logOut(): Promise<AuthResponse> {
-    return this.api.auth.logOut()
-      .pipe(map((response: AuthResponse) => {
-        if ( response.isSuccessful) {
-          this.clearAccount();
-          this.clearArchive();
-          this.clearRootFolder();
+    return this.api.auth
+      .logOut()
+      .pipe(
+        map((response: AuthResponse) => {
+          if (response.isSuccessful) {
+            this.clearAccount();
+            this.clearArchive();
+            this.clearRootFolder();
 
-          this.accountChange.emit(null);
-        }
+            this.accountChange.emit(null);
+          }
 
-        return response;
-      })).toPromise();
+          return response;
+        })
+      )
+      .toPromise();
   }
 
   public verifyMfa(token: string): Promise<AuthResponse> {
-    return this.api.auth.verify(this.account, token, 'type.auth.mfaValidation')
-      .pipe(map((response: AuthResponse) => {
-        if (response.isSuccessful) {
-          this.setAccount(response.getAccountVO());
+    return this.api.auth
+      .verify(this.account, token, 'type.auth.mfaValidation')
+      .pipe(
+        map((response: AuthResponse) => {
+          if (response.isSuccessful) {
+            this.setAccount(response.getAccountVO());
 
-          this.accountChange.emit(this.account);
-          return response;
-        } else {
-          throw response;
-        }
-      })).toPromise();
+            this.accountChange.emit(this.account);
+            return response;
+          } else {
+            throw response;
+          }
+        })
+      )
+      .toPromise();
   }
 
   public verifyEmail(token: string): Promise<AuthResponse> {
-    return this.api.auth.verify(this.account, token, 'type.auth.email')
-      .pipe(map((response: AuthResponse) => {
-        if (response.isSuccessful) {
-          this.setAccount(response.getAccountVO());
-          return response;
-        } else {
-          throw response;
-        }
-      })).toPromise();
+    return this.api.auth
+      .verify(this.account, token, 'type.auth.email')
+      .pipe(
+        map((response: AuthResponse) => {
+          if (response.isSuccessful) {
+            this.setAccount(response.getAccountVO());
+            return response;
+          } else {
+            throw response;
+          }
+        })
+      )
+      .toPromise();
   }
 
   public verifyPhone(token: string): Promise<AuthResponse> {
-    return this.api.auth.verify(this.account, token, 'type.auth.phone')
-      .pipe(map((response: AuthResponse) => {
-        if (response.isSuccessful) {
-          this.setAccount(response.getAccountVO());
-          return response;
-        } else {
-          throw response;
-        }
-      })).toPromise();
+    return this.api.auth
+      .verify(this.account, token, 'type.auth.phone')
+      .pipe(
+        map((response: AuthResponse) => {
+          if (response.isSuccessful) {
+            this.setAccount(response.getAccountVO());
+            return response;
+          } else {
+            throw response;
+          }
+        })
+      )
+      .toPromise();
   }
 
   public resendEmailVerification(): Promise<AuthResponse> {
@@ -368,22 +424,35 @@ export class AccountService {
   }
 
   public switchToDefaultArchive(): Promise<ArchiveResponse> {
-    return this.api.archive.getAllArchives(this.account)
+    return this.api.archive
+      .getAllArchives(this.account)
       .then((response: ArchiveResponse) => {
         const archives = response.getArchiveVOs();
-        const defaultArchiveData = find(archives, {archiveId: this.account.defaultArchiveId});
+        const defaultArchiveData = find(archives, {
+          archiveId: this.account.defaultArchiveId,
+        });
         this.setArchive(new ArchiveVO(defaultArchiveData));
         this.archiveChange.emit(this.archive);
         return response;
       });
   }
 
-  public checkMinimumAccess(itemAccessRole: AccessRoleType, minimumAccess: AccessRole) {
-    return this.checkMinimumArchiveAccess(minimumAccess) && checkMinimumAccess(itemAccessRole, minimumAccess);
+  public checkMinimumAccess(
+    itemAccessRole: AccessRoleType,
+    minimumAccess: AccessRole
+  ) {
+    return (
+      this.checkMinimumArchiveAccess(minimumAccess) &&
+      checkMinimumAccess(itemAccessRole, minimumAccess)
+    );
   }
 
   public checkMinimumArchiveAccess(minimumAccess: AccessRole) {
-    return this.archive && this.isLoggedIn() && checkMinimumAccess(this.archive.accessRole, minimumAccess);
+    return (
+      this.archive &&
+      this.isLoggedIn() &&
+      checkMinimumAccess(this.archive.accessRole, minimumAccess)
+    );
   }
 
   public async signUp(
@@ -395,8 +464,8 @@ export class AccountService {
     optIn: boolean,
     phone: string,
     inviteCode: string,
-    createDefaultArchive: boolean,
-  ) {
+    createDefaultArchive: boolean
+  ): Promise<AccountVO> {
     this.skipSessionCheck = false;
 
     if (this.isLoggedIn()) {
@@ -405,27 +474,38 @@ export class AccountService {
       } catch (err) {}
     }
 
-    return this.api.account.signUp(
-      email,
-      fullName,
-      password,
-      passwordConfirm,
-      agreed,
-      optIn,
-      phone,
-      inviteCode,
-      createDefaultArchive,
-    )
-      .pipe(map((response: AccountResponse) => {
-        if (response.isSuccessful) {
-          const newAccount = response.getAccountVO();
-          newAccount.isNew = true;
-          this.setAccount(newAccount);
-          return response;
-        } else {
-          throw response;
-        }
-      })).toPromise();
+    try {
+      const credentials = await this.api.auth.createCredentials(
+        fullName,
+        email,
+        password,
+        passwordConfirm,
+        phone
+      );
+
+      return this.api.account
+        .signUp(
+          email,
+          fullName,
+          agreed,
+          optIn,
+          createDefaultArchive,
+          credentials.user.id,
+          phone,
+          inviteCode
+        )
+        .pipe(
+          map((response: AccountVO) => {
+            const newAccount = response;
+            newAccount.isNew = true;
+            this.setAccount(newAccount);
+            return newAccount;
+          })
+        )
+        .toPromise();
+    } catch (err) {
+      return new Promise((resolve, reject) => reject(err));
+    }
   }
 
   public setRedirect(path: string[], params?: any) {
@@ -452,8 +532,12 @@ export class AccountService {
 
   public async promptForArchiveChange(promptText = 'Choose archive:') {
     await this.refreshArchives();
-    if (this.archives.length > 1 ) {
-      return this.dialog.open('ArchiveSwitcherDialogComponent',  {promptText}, { height: 'auto', width: 'fullscreen' });
+    if (this.archives.length > 1) {
+      return this.dialog.open(
+        'ArchiveSwitcherDialogComponent',
+        { promptText },
+        { height: 'auto', width: 'fullscreen' }
+      );
     }
   }
 }

--- a/src/app/shared/services/api/account.repo.spec.ts
+++ b/src/app/shared/services/api/account.repo.spec.ts
@@ -1,0 +1,52 @@
+/* @format */
+import { TestBed, inject } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { environment } from '@root/environments/environment';
+
+import { HttpService } from '@shared/services/http/http.service';
+import { AccountRepo } from '@shared/services/api/account.repo';
+import { AccountVO } from '@root/app/models';
+
+describe('AccountRepo', () => {
+  let repo: AccountRepo;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [HttpService],
+    });
+
+    repo = new AccountRepo(TestBed.get(HttpService));
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('signUp should call /account/post', () => {
+    const expected = new AccountVO({
+      primaryEmail: 'test@permanent.org',
+      fullName: 'Test User',
+    });
+
+    repo
+      .signUp(
+        'test@permanent.org',
+        'Test User',
+        true,
+        true,
+        true,
+        'test-subject'
+      )
+      .subscribe((response) =>
+        expect(response.primaryEmail).toEqual('test@permanent.org')
+      );
+    const req = httpMock.expectOne(`${environment.apiUrl}/account/post`);
+    req.flush(expected);
+  });
+});

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -1,78 +1,100 @@
-import { AccountVO, AccountPasswordVO, ArchiveVO, SimpleVO } from '@root/app/models';
+/* @format */
+import {
+  AccountVO,
+  AccountPasswordVO,
+  ArchiveVO,
+  SimpleVO,
+} from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { Observable } from 'rxjs';
 
 export class AccountRepo extends BaseRepo {
   public get(accountVO: AccountVO) {
     const account = {
-      accountId: accountVO.accountId
+      accountId: accountVO.accountId,
     };
 
-    return this.http.sendRequestPromise<AccountResponse>('/account/get', [account], AccountResponse);
+    return this.http.sendRequestPromise<AccountResponse>(
+      '/account/get',
+      [account],
+      AccountResponse
+    );
   }
 
   public signUp(
     email: string,
     fullName: string,
-    password: string,
-    passwordConfirm: string,
     agreed: boolean,
     optIn: boolean,
-    phone: string,
-    inviteCode: string,
     createDefaultArchive: boolean,
+    subject: string,
+    phone?: string,
+    inviteCode?: string
   ) {
-    const accountVO = new AccountVO({
+    const requestBody = {
       primaryEmail: email,
       primaryPhone: phone,
       fullName: fullName,
       agreed: agreed,
       optIn: optIn,
-      inviteCode: inviteCode
-    });
+      inviteCode: inviteCode,
+      createArchive: createDefaultArchive,
+      subject: subject,
+    };
 
-    const accountPasswordVO = new AccountPasswordVO({
-      password: password,
-      passwordVerify: passwordConfirm
-    });
-
-    const data = [{
-      AccountVO: accountVO,
-      AccountPasswordVO: accountPasswordVO,
-      SimpleVO: new SimpleVO({key: 'createArchive', value: createDefaultArchive}),
-    }];
-
-    return this.http.sendRequest<AccountResponse>('/account/post', data, AccountResponse);
+    return this.http.sendV2Request<AccountVO>(
+      '/account/post',
+      requestBody,
+      AccountVO
+    );
   }
 
   public update(accountVO: AccountVO) {
     const clone = new AccountVO(accountVO);
     delete clone.notificationPreferences;
 
-    const data = [{
-      AccountVO: clone
-    }];
+    const data = [
+      {
+        AccountVO: clone,
+      },
+    ];
 
-    return this.http.sendRequestPromise<AccountResponse>('/account/update', data, AccountResponse);
+    return this.http.sendRequestPromise<AccountResponse>(
+      '/account/update',
+      data,
+      AccountResponse
+    );
   }
 
   public delete(accountVO: AccountVO) {
     const clone = new AccountVO(accountVO);
     delete clone.notificationPreferences;
 
-    const data = [{
-      AccountVO: clone
-    }];
+    const data = [
+      {
+        AccountVO: clone,
+      },
+    ];
 
-    return this.http.sendRequestPromise<AccountResponse>('/account/delete', data, AccountResponse);
+    return this.http.sendRequestPromise<AccountResponse>(
+      '/account/delete',
+      data,
+      AccountResponse
+    );
   }
 
   public updateNotificationPreference(preferencePath: string, value: boolean) {
-    const data = [{
-      SimpleVO: new SimpleVO({key: preferencePath, value})
-    }];
+    const data = [
+      {
+        SimpleVO: new SimpleVO({ key: preferencePath, value }),
+      },
+    ];
 
-    return this.http.sendRequestPromise<AccountResponse>('/account/updatePreference', data, AccountResponse);
+    return this.http.sendRequestPromise<AccountResponse>(
+      '/account/updatePreference',
+      data,
+      AccountResponse
+    );
   }
 }
 

--- a/src/app/shared/services/api/auth.repo.spec.ts
+++ b/src/app/shared/services/api/auth.repo.spec.ts
@@ -1,10 +1,19 @@
+/* @format */
 import { TestBed, inject } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { environment } from '@root/environments/environment';
 
 import { HttpService } from '@shared/services/http/http.service';
 import { AuthRepo, AuthResponse } from '@shared/services/api/auth.repo';
-import { SimpleVO, AccountPasswordVO, AccountVO, ArchiveVO } from '@root/app/models';
+import {
+  SimpleVO,
+  AccountPasswordVO,
+  AccountVO,
+  ArchiveVO,
+} from '@root/app/models';
 
 describe('AuthRepo', () => {
   let repo: AuthRepo;
@@ -14,26 +23,24 @@ describe('AuthRepo', () => {
     email: 'tstr@permanent.org',
     password: 'Abc123!!!',
     name: 'Test Account',
-    rememberMe: true
+    rememberMe: true,
   };
 
   const testAccount = {
     accountId: 1,
     primaryEmail: testUser.email,
-    fullName: testUser.name
+    fullName: testUser.name,
   };
 
   const testArchive = {
     archiveId: 1,
-    fullName: testUser.name
+    fullName: testUser.name,
   };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule
-      ],
-      providers: [HttpService]
+      imports: [HttpClientTestingModule],
+      providers: [HttpService],
     });
 
     repo = new AuthRepo(TestBed.get(HttpService));
@@ -45,58 +52,89 @@ describe('AuthRepo', () => {
   });
 
   it('should check logged in status', () => {
-    const returnData = [{
-      SimpleVO: new SimpleVO({
-        key: 'bool',
-        value: true
-      })
-    }];
+    const returnData = [
+      {
+        SimpleVO: new SimpleVO({
+          key: 'bool',
+          value: true,
+        }),
+      },
+    ];
 
-    const expected = new AuthResponse({isSuccessful: true});
+    const expected = new AuthResponse({ isSuccessful: true });
     expected.setData(returnData);
 
-    repo.isLoggedIn()
-      .then(response => {
-        expect(response).toEqual(expected);
-      });
+    repo.isLoggedIn().then((response) => {
+      expect(response).toEqual(expected);
+    });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/auth/loggedIn`);
     req.flush(expected);
   });
 
   it('should log in', () => {
-    const data = [{
-      AccountPasswordVO: new AccountPasswordVO({password: testUser.password}),
-      AccountVO: new AccountVO({primaryEmail: testUser.email, rememberMe: testUser.rememberMe})
-    }];
+    const data = [
+      {
+        AccountPasswordVO: new AccountPasswordVO({
+          password: testUser.password,
+        }),
+        AccountVO: new AccountVO({
+          primaryEmail: testUser.email,
+          rememberMe: testUser.rememberMe,
+        }),
+      },
+    ];
 
-    const returnData = [{
-      AccountVO: new AccountVO(testAccount),
-      ArchiveVO: new ArchiveVO(testArchive)
-    }];
+    const returnData = [
+      {
+        AccountVO: new AccountVO(testAccount),
+        ArchiveVO: new ArchiveVO(testArchive),
+      },
+    ];
 
-    const expected = new AuthResponse({isSuccessful: true});
+    const expected = new AuthResponse({ isSuccessful: true });
     expected.setData(returnData);
 
-    repo.logIn(testUser.email, testUser.password, testUser.rememberMe, true)
-    .subscribe(response => {
-      expect(response).toEqual(expected);
-    });
+    repo
+      .logIn(testUser.email, testUser.password, testUser.rememberMe, true)
+      .subscribe((response) => {
+        expect(response).toEqual(expected);
+      });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
     req.flush(expected);
   });
 
   it('should send a forgot password email', () => {
-    const expected = require ('@root/test/responses/auth.forgotPassword.success.json');
+    const expected = require('@root/test/responses/auth.forgotPassword.success.json');
 
-    repo.forgotPassword(testUser.email)
-    .subscribe((response: AuthResponse) => {
+    repo.forgotPassword(testUser.email).subscribe((response: AuthResponse) => {
       expect(response.isSuccessful).toBeTruthy();
-      expect(response.getMessage()).toEqual('Change Password URL sent to email address provided');
+      expect(response.getMessage()).toEqual(
+        'Change Password URL sent to email address provided'
+      );
     });
 
-    const req = httpMock.expectOne(`${environment.apiUrl}/auth/sendEmailForgotPassword`);
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/auth/sendEmailForgotPassword`
+    );
+    req.flush(expected);
+  });
+
+  it('should create credentials', () => {
+    const expected = {
+      user: { id: 'test-subject' },
+    };
+
+    repo.createCredentials(
+      'Test User',
+      'test@permanent.org',
+      'password123',
+      'password123'
+    );
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/auth/createCredentials`
+    );
     req.flush(expected);
   });
 });

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -1,59 +1,97 @@
-import { AccountVO, AccountPasswordVO, ArchiveVO, AuthVO, AccountPasswordVOData, SimpleVO } from '@root/app/models';
-import { BaseResponse, BaseRepo, CSRFResponse } from '@shared/services/api/base';
+/* @format */
+import {
+  AccountVO,
+  AccountPasswordVO,
+  ArchiveVO,
+  AuthVO,
+  AccountPasswordVOData,
+  SimpleVO,
+} from '@root/app/models';
+import {
+  BaseResponse,
+  BaseRepo,
+  CSRFResponse,
+} from '@shared/services/api/base';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 export class AuthRepo extends BaseRepo {
   public isLoggedIn(): Promise<AuthResponse> {
-    return this.http.sendRequestPromise('/auth/loggedIn', undefined, AuthResponse);
+    return this.http.sendRequestPromise(
+      '/auth/loggedIn',
+      undefined,
+      AuthResponse
+    );
   }
 
-  public logIn(email: string, password: string, rememberMe: boolean, keepLoggedIn: boolean): Observable<AuthResponse> {
+  public logIn(
+    email: string,
+    password: string,
+    rememberMe: boolean,
+    keepLoggedIn: boolean
+  ): Observable<AuthResponse> {
     const accountVO = new AccountVO({
       primaryEmail: email,
       rememberMe: rememberMe,
-      keepLoggedIn: keepLoggedIn
+      keepLoggedIn: keepLoggedIn,
     });
 
     const accountPasswordVO = new AccountPasswordVO({
-      password: password
+      password: password,
     });
 
-    return this.http.sendRequest<AuthResponse>('/auth/login', [{AccountVO: accountVO, AccountPasswordVO: accountPasswordVO}], AuthResponse);
+    return this.http.sendRequest<AuthResponse>(
+      '/auth/login',
+      [{ AccountVO: accountVO, AccountPasswordVO: accountPasswordVO }],
+      AuthResponse
+    );
   }
 
   public logOut() {
     return this.http.sendRequest<AuthResponse>('/auth/logout');
-
   }
 
   public verify(account: AccountVO, token: string, type: string) {
     const accountVO = new AccountVO({
       primaryEmail: account.primaryEmail,
-      accountId: account.accountId
+      accountId: account.accountId,
     });
 
     const authVO = new AuthVO({
       token: token,
-      type: type
+      type: type,
     });
 
-    return this.http.sendRequest<AuthResponse>('/auth/verify', [{AccountVO: accountVO, AuthVO: authVO}], AuthResponse);
+    return this.http.sendRequest<AuthResponse>(
+      '/auth/verify',
+      [{ AccountVO: accountVO, AuthVO: authVO }],
+      AuthResponse
+    );
   }
 
   public forgotPassword(email: string) {
     const accountVO = new AccountVO({
-      primaryEmail: email
+      primaryEmail: email,
     });
 
-    return this.http.sendRequest<AuthResponse>('/auth/sendEmailForgotPassword', [{AccountVO: accountVO}], AuthResponse);
+    return this.http.sendRequest<AuthResponse>(
+      '/auth/sendEmailForgotPassword',
+      [{ AccountVO: accountVO }],
+      AuthResponse
+    );
   }
 
-  public updatePassword(account: AccountVO, passwordVo: AccountPasswordVOData, trustToken?: string) {
-    const data = [{
-      AccountVO: account,
-      AccountPasswordVO: passwordVo,
-    }];
+  public updatePassword(
+    account: AccountVO,
+    passwordVo: AccountPasswordVOData,
+    trustToken?: string
+  ) {
+    const data = [
+      {
+        AccountVO: account,
+        AccountPasswordVO: passwordVo,
+      },
+    ];
 
     if (trustToken) {
       const v2data = {
@@ -61,32 +99,70 @@ export class AuthRepo extends BaseRepo {
         passwordOld: passwordVo.passwordOld,
         password: passwordVo.password,
         passwordVerify: passwordVo.passwordVerify,
-        trustToken
+        trustToken,
       };
-      return this.http.sendV2RequestPromise<CSRFResponse>('/account/changePassword', v2data);
+      return this.http.sendV2RequestPromise<CSRFResponse>(
+        '/account/changePassword',
+        v2data
+      );
     }
 
-    return this.http.sendRequestPromise<AuthResponse>('/account/changePassword', data, AuthResponse);
+    return this.http.sendRequestPromise<AuthResponse>(
+      '/account/changePassword',
+      data,
+      AuthResponse
+    );
   }
 
   public resendEmailVerification(accountVO: AccountVO) {
     const account = {
       primaryEmail: accountVO.primaryEmail,
-      accountId: accountVO.accountId
+      accountId: accountVO.accountId,
     };
 
-    return this.http.sendRequestPromise<AuthResponse>('/auth/resendMailCreatedAccount', [account], AuthResponse);
+    return this.http.sendRequestPromise<AuthResponse>(
+      '/auth/resendMailCreatedAccount',
+      [account],
+      AuthResponse
+    );
   }
 
   public resendPhoneVerification(accountVO: AccountVO) {
     const account = {
       primaryEmail: accountVO.primaryEmail,
-      accountId: accountVO.accountId
+      accountId: accountVO.accountId,
     };
 
-    return this.http.sendRequestPromise<AuthResponse>('/auth/resendTextCreatedAccount', [account], AuthResponse);
+    return this.http.sendRequestPromise<AuthResponse>(
+      '/auth/resendTextCreatedAccount',
+      [account],
+      AuthResponse
+    );
   }
 
+  public createCredentials(
+    fullName: string,
+    email: string,
+    password: string,
+    passwordConfirm: string,
+    phone?: string
+  ): Promise<CreateCredentialsResponse> {
+    const requestBody = {
+      fullName: fullName,
+      primaryEmail: email,
+      password: password,
+      passwordVerify: passwordConfirm,
+      primaryPhone: phone,
+    };
+    return this.http.sendV2RequestPromise<CreateCredentialsResponse>(
+      '/auth/createCredentials',
+      requestBody
+    );
+  }
+}
+
+export interface CreateCredentialsResponse {
+  user: { id: string };
 }
 
 export class AuthResponse extends BaseResponse {

--- a/src/app/shared/services/http/http.service.ts
+++ b/src/app/shared/services/http/http.service.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
@@ -8,26 +9,27 @@ import { RequestVO } from '@models/request-vo';
 import { BaseResponse } from '@shared/services/api/base';
 import { StorageService } from '@shared/services/storage/storage.service';
 
-
 const CSRF_KEY = 'CSRF';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class HttpService {
   private apiUrl = environment.apiUrl;
   private defaultResponseClass = BaseResponse;
 
-  constructor(private http: HttpClient, private storage: StorageService) {
-  }
+  constructor(private http: HttpClient, private storage: StorageService) {}
 
-  public sendRequest<T = BaseResponse>(endpoint: string, data: any = [{}], responseClass ?: any): Observable<T> {
+  public sendRequest<T = BaseResponse>(
+    endpoint: string,
+    data: any = [{}],
+    responseClass?: any
+  ): Observable<T> {
     const requestVO = new RequestVO(this.storage.session.get(CSRF_KEY), data);
     const url = this.apiUrl + endpoint;
 
-    return this.http
-      .post(url, {RequestVO: requestVO})
-      .pipe(map((response: any) => {
+    return this.http.post(url, { RequestVO: requestVO }).pipe(
+      map((response: any) => {
         if (response) {
           this.storage.session.set(CSRF_KEY, JSON.stringify(response.csrf));
         }
@@ -36,37 +38,56 @@ export class HttpService {
         } else {
           return new this.defaultResponseClass(response);
         }
-      }));
+      })
+    );
   }
 
-  public sendRequestPromise<T = BaseResponse>(endpoint: string, data: any = [{}], responseClass ?: any): Promise<T> {
+  public sendRequestPromise<T = BaseResponse>(
+    endpoint: string,
+    data: any = [{}],
+    responseClass?: any
+  ): Promise<T> {
     return this.sendRequest(endpoint, data, responseClass)
-      .pipe(map((response: any | BaseResponse) => {
-        if (!response.isSuccessful) {
-          throw response;
-        }
+      .pipe(
+        map((response: any | BaseResponse) => {
+          if (!response.isSuccessful) {
+            throw response;
+          }
 
-        return response;
-      })).toPromise();
+          return response;
+        })
+      )
+      .toPromise();
   }
 
-  public sendV2Request<T>(endpoint: string, data: any = {}): Observable<T> {
+  public sendV2Request<T>(
+    endpoint: string,
+    data: any = {},
+    responseClass?: any
+  ): Observable<T> {
     const requestBody = {
       ...data,
-      csrf: this.storage.session.get(CSRF_KEY)
+      csrf: this.storage.session.get(CSRF_KEY),
     };
     const url = this.apiUrl + endpoint;
-    return this.http.post(url, requestBody, {
-      headers: {
-        'Request-Version': '2',
-        'Content-Type': 'application/json',
-      }
-    }).pipe(map((response: any) => {
-      if (response?.csrf) {
-        this.storage.session.set(CSRF_KEY, JSON.stringify(response.csrf));
-      }
-      return response as T;
-    }));
+    return this.http
+      .post(url, requestBody, {
+        headers: {
+          'Request-Version': '2',
+          'Content-Type': 'application/json',
+        },
+      })
+      .pipe(
+        map((response: any) => {
+          if (response?.csrf) {
+            this.storage.session.set(CSRF_KEY, JSON.stringify(response.csrf));
+          }
+          if (responseClass) {
+            return new responseClass(response);
+          }
+          return response as T;
+        })
+      );
   }
 
   public sendV2RequestPromise<T>(endpoint: string, data: any = {}): Promise<T> {


### PR DESCRIPTION
Currently, this project creates Permanent accounts by calling /account/post with a V1 request. This causes /account/post to create both a FusionAuth account and a Permanent account. Handling these in a combined endpoint can cause data integrity problems, however, so the backend now provides an /auth/createCredentials endpoint to create a FusionAuth account, and creates only a Permanent account on receiving a V2 request to /account/post. This commit updates signup functionality to use these new features to decouple FusionAuth and Permanent account creation.

Resolves: https://permanent.atlassian.net/browse/PER-8812
Do not merge without https://github.com/PermanentOrg/back-end/pull/353