### PR TITLE
Remove custom metadata from tag manager

### DIFF
--- a/src/app/core/components/manage-tags/manage-tags.component.html
+++ b/src/app/core/components/manage-tags/manage-tags.component.html
@@ -1,6 +1,6 @@
 <div>
   <div *ngIf="tags.length > 0; else noTags">
-    <p>There are {{tags.length}} tags defined in the current archive.</p>
+    <p>There are {{getTagCount()}} tags defined in the current archive.</p>
     <input type="text" class="filter" placeholder="Search Tags..." (change)="filter = $event.target.value" (keyup)="filter = $event.target.value" />
     <div class="tagsList" *ngIf="getFilteredTags().length > 0; else noMatchedTags">
       <ng-container *ngFor="let tag of getFilteredTags();">

--- a/src/app/core/components/manage-tags/manage-tags.component.spec.ts
+++ b/src/app/core/components/manage-tags/manage-tags.component.spec.ts
@@ -84,6 +84,11 @@ describe('ManageTagsComponent #manage-tags', () => {
         name: 'Potato',
         tagId: 1,
       }),
+      new TagVO({
+        name: 'vegetable:potato',
+        tagId: 3,
+        type: 'type.tag.metadata.customField',
+      })
     ];
     shallow = new Shallow(ManageTagsComponent, DummyModule).mock(ApiService, mockApiService).mock(PromptService, mockPromptService);
   });
@@ -124,7 +129,7 @@ describe('ManageTagsComponent #manage-tags', () => {
     } catch {
       // Catch error!
     } finally {
-      expect(element.componentInstance.tags.length).toBe(2);
+      expect(element.componentInstance.getFilteredTags().length).toBe(2);
     }
   });
 

--- a/src/app/core/components/manage-tags/manage-tags.component.ts
+++ b/src/app/core/components/manage-tags/manage-tags.component.ts
@@ -28,8 +28,12 @@ export class ManageTagsComponent implements OnInit {
     return this.tags.filter((t) =>
       t.name.toLocaleLowerCase().includes(
         this.filter.trim().toLocaleLowerCase()
-      )
+      ) && !t.isCustomMetadata()
     ).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  public getTagCount(): number {
+    return this.tags.filter((t) => !t.isCustomMetadata()).length;
   }
 
   public onTagChange(tag: TagVO, newName: string): void {

--- a/src/app/models/tag-vo.ts
+++ b/src/app/models/tag-vo.ts
@@ -26,6 +26,6 @@ export class TagVO extends BaseVO implements TagVOData {
   }
 
   public isCustomMetadata(): boolean {
-    return this.type.includes('type.tag.metadata');
+    return this.type?.includes('type.tag.metadata');
   }
 }


### PR DESCRIPTION
Keep tags and custom metadata separate from each other in the archive settings dialog.