### PR TITLE
File viewer style fixes

### DIFF
--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -54,93 +54,98 @@
     </div>
   </div>
   <div class="file-viewer-name">{{ currentRecord.displayName }}</div>
-  <div class="file-viewer-metadata">
-    <pr-inline-value-edit
-      [displayValue]="currentRecord.displayName"
-      [itemId]="currentRecord.folder_linkId"
-      [canEdit]="canEdit"
-      [required]="true"
-      (doneEditing)="onFinishEditing('displayName', $event)"
-      emptyMessage="Click to add name"
-      readOnlyEmptyMessage="No name"
-      type="text"
-      class="h5"
-    ></pr-inline-value-edit>
-    <div class="file-viewer-description">
+  <div class="file-viewer-metadata-wrapper">
+    <div class="file-viewer-metadata">
       <pr-inline-value-edit
-        *ngIf="canEdit || currentRecord.description"
-        [displayValue]="currentRecord.description"
+        [displayValue]="currentRecord.displayName"
         [itemId]="currentRecord.folder_linkId"
         [canEdit]="canEdit"
-        (doneEditing)="onFinishEditing('description', $event)"
-        emptyMessage="Click to add description"
-        readOnlyEmptyMessage="No description"
-        type="description-textarea"
+        [required]="true"
+        (doneEditing)="onFinishEditing('displayName', $event)"
+        emptyMessage="Click to add name"
+        readOnlyEmptyMessage="No name"
+        type="text"
+        class="h5"
       ></pr-inline-value-edit>
+      <div class="file-viewer-description">
+        <pr-inline-value-edit
+          *ngIf="canEdit || currentRecord.description"
+          [displayValue]="currentRecord.description"
+          [itemId]="currentRecord.folder_linkId"
+          [canEdit]="canEdit"
+          (doneEditing)="onFinishEditing('description', $event)"
+          emptyMessage="Click to add description"
+          readOnlyEmptyMessage="No description"
+          type="description-textarea"
+        ></pr-inline-value-edit>
+      </div>
+      <div
+        class="file-viewer-download"
+        *ngIf="isPublicArchive && allowDownloads"
+      >
+        <button class="btn btn-primary" (click)="onDownloadClick()">
+          Download
+        </button>
+      </div>
+      <table class="metadata-table">
+        <tr>
+          <td>Date</td>
+          <td>
+            <pr-inline-value-edit
+              [displayValue]="currentRecord.displayDT"
+              [canEdit]="canEdit"
+              [item]="currentRecord"
+              [itemId]="currentRecord.folder_linkId"
+              emptyMessage="Click to add date"
+              readOnlyEmptyMessage="No date"
+              (doneEditing)="onFinishEditing('displayDT', $event)"
+              (toggledDatePicker)="onDateToggle($event)"
+              type="date"
+              class="no-padding"
+            ></pr-inline-value-edit>
+          </td>
+        </tr>
+        <tr>
+          <td>Uploaded</td>
+          <td>{{ currentRecord.createdDT | date }}</td>
+        </tr>
+        <tr>
+          <td>Size</td>
+          <td>{{ currentRecord.size | dsFileSize }}</td>
+        </tr>
+        <tr>
+          <td>Type</td>
+          <td>{{ currentRecord.type | prConstants | titlecase }}</td>
+        </tr>
+        <tr>
+          <td>Tags</td>
+          <td (click)="onTagsClick()">
+            <pr-tags [tags]="keywords"></pr-tags>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Custom <br />
+            Metadata
+          </td>
+          <td (click)="onTagsClick()">
+            <pr-tags [tags]="customMetadata"></pr-tags>
+          </td>
+        </tr>
+        <tr>
+          <td>Location</td>
+          <td class="location-container" (click)="onLocationClick()">
+            <pr-static-map
+              [location]="currentRecord.LocnVO"
+              *ngIf="currentRecord.LocnVO"
+            ></pr-static-map>
+            <span *ngIf="currentRecord.LocnVO">{{
+              (currentRecord.LocnVO | prLocation)?.full
+            }}</span>
+            <span *ngIf="!currentRecord.LocnVO">No location</span>
+          </td>
+        </tr>
+      </table>
     </div>
-    <div class="file-viewer-download" *ngIf="isPublicArchive && allowDownloads">
-      <button class="btn btn-primary" (click)="onDownloadClick()">
-        Download
-      </button>
-    </div>
-    <table class="metadata-table">
-      <tr>
-        <td>Date</td>
-        <td>
-          <pr-inline-value-edit
-            [displayValue]="currentRecord.displayDT"
-            [canEdit]="canEdit"
-            [item]="currentRecord"
-            [itemId]="currentRecord.folder_linkId"
-            emptyMessage="Click to add date"
-            readOnlyEmptyMessage="No date"
-            (doneEditing)="onFinishEditing('displayDT', $event)"
-            (toggledDatePicker)="onDateToggle($event)"
-            type="date"
-            class="no-padding"
-          ></pr-inline-value-edit>
-        </td>
-      </tr>
-      <tr>
-        <td>Uploaded</td>
-        <td>{{ currentRecord.createdDT | date }}</td>
-      </tr>
-      <tr>
-        <td>Size</td>
-        <td>{{ currentRecord.size | dsFileSize }}</td>
-      </tr>
-      <tr>
-        <td>Type</td>
-        <td>{{ currentRecord.type | prConstants | titlecase }}</td>
-      </tr>
-      <tr>
-        <td>Tags</td>
-        <td (click)="onTagsClick()">
-          <pr-tags [tags]="keywords"></pr-tags>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Custom <br />
-          Metadata
-        </td>
-        <td (click)="onTagsClick()">
-          <pr-tags [tags]="customMetadata"></pr-tags>
-        </td>
-      </tr>
-      <tr>
-        <td>Location</td>
-        <td class="location-container" (click)="onLocationClick()">
-          <pr-static-map
-            [location]="currentRecord.LocnVO"
-            *ngIf="currentRecord.LocnVO"
-          ></pr-static-map>
-          <span *ngIf="currentRecord.LocnVO">{{
-            (currentRecord.LocnVO | prLocation)?.full
-          }}</span>
-          <span *ngIf="!currentRecord.LocnVO">No location</span>
-        </td>
-      </tr>
-    </table>
   </div>
 </div>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -124,7 +124,7 @@
           </td>
         </tr>
         <tr>
-          <td>
+          <td class="top-align">
             Custom <br />
             Metadata
           </td>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.scss
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.scss
@@ -179,7 +179,8 @@ iframe {
   }
 }
 
-.file-viewer-metadata {
+.file-viewer-metadata,
+.file-viewer-metadata-wrapper {
   display: none;
 }
 
@@ -203,7 +204,7 @@ iframe {
     overflow: hidden;
   }
 
-  .file-viewer-metadata {
+  .file-viewer-metadata-wrapper {
     top: $toolbar-height;
     bottom: $toolbar-height;
     width: $metadata-width;
@@ -211,9 +212,11 @@ iframe {
     position: absolute;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: stretch;
     padding: 10px;
+    overflow-y: auto;
+    overflow-x: hidden;
 
     td:first-child {
       font-weight: bold;
@@ -222,9 +225,15 @@ iframe {
 
     .metadata-table {
       table-layout: fixed;
-      width: $metadata-width;
-      block-size: border-box;
+      width: calc($metadata-width - 20px);
     }
+  }
+
+  .file-viewer-metadata {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    margin: auto 0;
   }
 
   .file-viewer-name {

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.scss
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.scss
@@ -220,11 +220,9 @@ iframe {
 
     td:first-child {
       font-weight: bold;
-      padding-right: 5px;
     }
 
     .metadata-table {
-      table-layout: fixed;
       width: calc($metadata-width - 20px);
     }
   }
@@ -247,7 +245,13 @@ iframe {
     vertical-align: top;
 
     &:first-child {
-      padding-right: 5px;
+      padding-right: 15px;
+      vertical-align: middle;
+
+      &.top-align {
+        vertical-align: top;
+        padding-top: 0.5rem;
+      }
     }
   }
 

--- a/src/app/shared/components/tags/tags.component.scss
+++ b/src/app/shared/components/tags/tags.component.scss
@@ -26,29 +26,36 @@ $gutter-size: 0.25rem;
     user-select: none;
     color: $gray-900;
     display: flex;
+
     .keyword,
     .customMetadataField,
     .customMetadataValue {
       border-radius: 0.5rem;
-      padding: 0.5rem 1rem;
+      padding: 0.5rem 0.5rem;
       overflow-wrap: break-word;
       hyphens: auto;
+      margin-bottom: 0;
     }
     .keyword {
       background: rgba($PR-purple, 0.2);
     }
     .customMetadataField {
       float: left;
+      padding: 0 0.5rem;
       border-radius: 0.5rem 0rem 0rem 0.5rem;
       color: #ffffff;
       background: #5261b7;
       max-width: 6.5rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
     }
     .customMetadataValue {
       float: left;
       border-radius: 0rem 0.5rem 0.5rem 0rem;
       background: rgba(#5261b7, 0.2);
       max-width: 6.5rem;
+      margin-right: 0.25em;
     }
   }
 

--- a/src/app/shared/services/account/account.service.spec.ts
+++ b/src/app/shared/services/account/account.service.spec.ts
@@ -10,6 +10,7 @@ import { AuthResponse } from '@shared/services/api/index.repo';
 import { CreateCredentialsResponse } from '@shared/services/api/auth.repo';
 import { AppModule } from '../../../app.module';
 import { AccountVO, ArchiveVO } from '@root/app/models';
+import { StorageService } from '../storage/storage.service';
 
 describe('AccountService', () => {
   let shallow: Shallow<AccountService>;
@@ -57,6 +58,12 @@ describe('AccountService', () => {
       })
       .mock(Router, {
         navigate: (route: string[]) => Promise.resolve(true),
+      })
+      .mock(StorageService, {
+        local: {
+          get: () => {},
+          set: () => {},
+        },
       });
   });
 


### PR DESCRIPTION
This PR includes fixes for both PER-9128 and PER-9136. Since they are a bit dependent on each other, and they're both small changes, I decided just to put them both in one PR.

This includes the following changes:
- Fix scrolling on public file viewer
- Fix spacing of tags/custom metadata so they don't overflow off the screen

As part of this fix, the padding around tags/custom metadata values has been shrunk to hopefully allow tags to fit onto the screen better.

Bonus fix in this PR: Fixes the random AccountService test that sometimes breaks.

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/9145247/214944993-9e1e6663-7a13-4bda-9937-a4532ca45ff4.png" alt="A screenshot" />
</details>