### PR TITLE
Fix unclickable breadcrumbs on public archive

### DIFF
--- a/src/app/public/components/public-archive/public-archive.component.scss
+++ b/src/app/public/components/public-archive/public-archive.component.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import 'variables';
 
 :host {
@@ -9,9 +10,15 @@
 $photo-desktop: pxToGrid(300px);
 $photo-mobile: pxToGrid(80px);
 $profile-max-width: 1200px;
+$desktop-size: pxToGrid(200px);
 
 @mixin sidebarMargin {
   margin-right: $profile-sidebar-width + 3 * $grid-unit;
+}
+
+@mixin banner-margin-offset {
+  position: relative;
+  top: math.div(-$desktop-size * 2, 3) + $grid-unit;
 }
 
 .banner-section {
@@ -29,15 +36,17 @@ $profile-max-width: 1200px;
 }
 
 .profile-photo {
-  @include profilePhoto(pxToGrid(200px), $photo-mobile);
+  @include profilePhoto($desktop-size, $photo-mobile);
   cursor: initial;
 }
 
 .profile-about {
   margin-bottom: $grid-unit * 2;
+
   @include desktop {
     padding-left: $grid-unit;
     @include sidebarMargin;
+    @include banner-margin-offset;
   }
 }
 
@@ -119,9 +128,11 @@ $profile-max-width: 1200px;
 
 .profile-contents {
   min-height: 100vh;
+
   @include desktop {
     padding-left: $grid-unit;
     @include sidebarMargin;
+    @include banner-margin-offset;
   }
 
   @include beforeDesktop {

--- a/src/styles/_profile.scss
+++ b/src/styles/_profile.scss
@@ -28,7 +28,6 @@ $profile-sidebar-width: pxToGrid(360px);
   background-position: 50% 50%;
   position: relative;
   margin-left: 2 * $grid-unit;
-  margin-bottom: math.div(-$desktop-size * 2, 3) + $grid-unit;
   transform: translateY(-(math.div(2, 3) * 100%));
   cursor: pointer;
 


### PR DESCRIPTION
The Profile Photo element was set up with some margins that made the breadcrumb links on public archives unclickable unless you hovered near the bottom of the link. Fix this by manually offsetting the elements which be moved around by the negative margins so that they remain on top and clickable.

Resolves PER-8827: "Public" button breadcrumb does not appear clickable