### PR TITLE
Add giveaway banner in app to match marketing site

### DIFF
--- a/src/app/announcement/data/events.ts
+++ b/src/app/announcement/data/events.ts
@@ -2,9 +2,9 @@ import { AnnouncementEvent } from '../models/announcement-event';
 
 export const ANNOUNCEMENT_EVENTS: AnnouncementEvent[] = [
   {
-    start: new Date('2022-10-18T20:00:00-05:00').getTime(),
-    end: new Date('2022-10-25T20:10:00-05:00').getTime(),
+    start: new Date('2023-01-31T20:00:00-05:00').getTime(),
+    end: new Date('2023-02-15T23:59:00-05:00').getTime(),
     message:
-      'We will be performing scheduled maintenance on <time datetime="2022-10-25 18:00:00 PDT"><strong>Tuesday, October 25th</strong> between <strong> 9pm - 12am ET / 6pm - 9pm PT.</strong></time> During this time, members will be unable to log into Permanent.org.',
+      'Enter the <strong>2023 Share to Win! Giveaway</strong> for a chance to win prizes up to $450 in value. <a href="https://www.permanent.org/blog/sharetowin/">Click here for details.</a>',
   },
 ];


### PR DESCRIPTION
Tagging @Fenn-CS as a reviewer since @meisekimiu is out today and ideally this would get deployed tomorrow morning.

Natalie, I'm not totally sure I got the timezone right on the end date. I followed what you used for our previous banner. Thanks so much for setting that up! @k8lyn6 asked if I could put this up so that people who navigate directly into the app still see the announcement.