### PR TITLE
Add note to phone verification about US numbers

### DIFF
--- a/src/app/auth/components/verify/verify.component.html
+++ b/src/app/auth/components/verify/verify.component.html
@@ -11,7 +11,7 @@
       {{formTitle}}
     </h1>
     <p>
-      A verification code has been sent to your {{verifyingEmail ? 'email address' : 'mobile device'}}.
+      A verification code has been sent to your {{verifyingEmail ? 'email address' : 'mobile device'}}. <span *ngIf="!verifyingEmail">Permanent only supports US and Canada numbers.</span>
       <br>
       <br>
       Enter it below to continue.

--- a/src/app/core/components/account-settings/account-settings.component.html
+++ b/src/app/core/components/account-settings/account-settings.component.html
@@ -21,7 +21,7 @@
 <div class="settings-group">
   <div class="settings-item">
     <label>Mobile Phone
-      <i class="material-icons" [ngbTooltip]="'A mobile phone number that can recieve verification codes via text message'">help</i>
+      <i class="material-icons" [ngbTooltip]="'A mobile phone number that can receive verification codes via text message. Permanent only supports US and Canada numbers.'">help</i>
     </label>
     <div class="settings-item-content">
       <pr-inline-value-edit [displayValue]="account.primaryPhone" [noScroll]="true" [emptyMessage]="'Mobile Phone Number'"


### PR DESCRIPTION
Update the helptext tooltip about the fact that Permanent only supports US and Canadian phone numbers right now. Also add it to the phone verification screen too.

Resolves PER-9091: Add helptext to phone verification about US numbers only