### PR TITLE
Remove createCredentials; do signup in one API call

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -475,22 +475,15 @@ export class AccountService {
     }
 
     try {
-      const credentials = await this.api.auth.createCredentials(
-        fullName,
-        email,
-        password,
-        passwordConfirm,
-        phone
-      );
-
       return this.api.account
         .signUp(
           email,
           fullName,
+          password,
+          passwordConfirm,
           agreed,
           optIn,
           createDefaultArchive,
-          credentials.user.id,
           phone,
           inviteCode
         )

--- a/src/app/shared/services/api/account.repo.spec.ts
+++ b/src/app/shared/services/api/account.repo.spec.ts
@@ -38,10 +38,11 @@ describe('AccountRepo', () => {
       .signUp(
         'test@permanent.org',
         'Test User',
+        'password123',
+        'password123',
         true,
         true,
-        true,
-        'test-subject'
+        true
       )
       .subscribe((response) =>
         expect(response.primaryEmail).toEqual('test@permanent.org')

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -24,10 +24,11 @@ export class AccountRepo extends BaseRepo {
   public signUp(
     email: string,
     fullName: string,
+    password: string,
+    passwordConfirm: string,
     agreed: boolean,
     optIn: boolean,
     createDefaultArchive: boolean,
-    subject: string,
     phone?: string,
     inviteCode?: string
   ) {
@@ -37,9 +38,10 @@ export class AccountRepo extends BaseRepo {
       fullName: fullName,
       agreed: agreed,
       optIn: optIn,
+      password: password,
+      passwordVerify: passwordConfirm,
       inviteCode: inviteCode,
-      createArchive: createDefaultArchive,
-      subject: subject,
+      createArchive: createDefaultArchive
     };
 
     return this.http.sendV2Request<AccountVO>(

--- a/src/app/shared/services/api/auth.repo.spec.ts
+++ b/src/app/shared/services/api/auth.repo.spec.ts
@@ -121,20 +121,4 @@ describe('AuthRepo', () => {
     req.flush(expected);
   });
 
-  it('should create credentials', () => {
-    const expected = {
-      user: { id: 'test-subject' },
-    };
-
-    repo.createCredentials(
-      'Test User',
-      'test@permanent.org',
-      'password123',
-      'password123'
-    );
-    const req = httpMock.expectOne(
-      `${environment.apiUrl}/auth/createCredentials`
-    );
-    req.flush(expected);
-  });
 });

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -140,29 +140,6 @@ export class AuthRepo extends BaseRepo {
     );
   }
 
-  public createCredentials(
-    fullName: string,
-    email: string,
-    password: string,
-    passwordConfirm: string,
-    phone?: string
-  ): Promise<CreateCredentialsResponse> {
-    const requestBody = {
-      fullName: fullName,
-      primaryEmail: email,
-      password: password,
-      passwordVerify: passwordConfirm,
-      primaryPhone: phone,
-    };
-    return this.http.sendV2RequestPromise<CreateCredentialsResponse>(
-      '/auth/createCredentials',
-      requestBody
-    );
-  }
-}
-
-export interface CreateCredentialsResponse {
-  user: { id: string };
 }
 
 export class AuthResponse extends BaseResponse {


### PR DESCRIPTION
I put this together quickly so it's very possible I missed something, but the tests passed for me locally and I was able to sign up from the web app, so fingers crossed. This should be the front end counterpart to https://github.com/PermanentOrg/back-end/pull/406. 