### PR TITLE
Show "No Plan" Warning on Directives Display

### DIFF
--- a/src/app/directive/components/directive-display/directive-display.component.html
+++ b/src/app/directive/components/directive-display/directive-display.component.html
@@ -21,7 +21,19 @@
     <a href="#">here.</a>
   </p>
   <div class="archive-steward-header">Archive Steward: {{ archiveName }}</div>
-  <!--no plan warning will go here-->
+  <div class="no-plan-warning" *ngIf="noPlan">
+    <div class="warning-icon">
+      <fa-icon [icon]="['fas', 'exclamation-triangle']"></fa-icon>
+    </div>
+    <div class="text-contents">
+      You must designate a Legacy Contact before you can establish a Legacy Plan
+      for this archive. Go to
+      <a class="breadcrumb-link" href="#"
+        >Account Settings &gt; Legacy Planning</a
+      >
+      to designate a Legacy Contact. <a href="#">Learn more.</a>
+    </div>
+  </div>
   <p class="archive-steward-description">
     The Archive Steward for this archive will receive your note when your Legacy
     Plan is activated.
@@ -54,7 +66,7 @@
       </div>
     </div>
   </div>
-  <button class="btn btn-primary" [disabled]="error">
+  <button class="btn btn-primary" [disabled]="error || noPlan">
     Assign Archive Steward
   </button>
   <div>&nbsp;</div>

--- a/src/app/directive/components/directive-display/directive-display.component.scss
+++ b/src/app/directive/components/directive-display/directive-display.component.scss
@@ -53,3 +53,26 @@
   margin: 1em;
   font-style: italic;
 }
+
+.no-plan-warning {
+  @extend .error;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .warning-icon {
+    padding-right: 1em;
+    fa-icon {
+      font-size: 2.5em;
+    }
+  }
+
+  .breadcrumb-link {
+    font-weight: bold;
+    color: #000;
+  }
+
+  a {
+    white-space: nowrap;
+  }
+}

--- a/src/app/directive/components/directive-display/directive-display.component.spec.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './test-utils';
 import { ApiService } from '@shared/services/api/api.service';
 
-describe('DirectiveDisplayComponent', () => {
+fdescribe('DirectiveDisplayComponent', () => {
   let shallow: Shallow<DirectiveDisplayComponent>;
 
   beforeEach(() => {

--- a/src/app/directive/components/directive-display/directive-display.component.spec.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './test-utils';
 import { ApiService } from '@shared/services/api/api.service';
 
-fdescribe('DirectiveDisplayComponent', () => {
+describe('DirectiveDisplayComponent', () => {
   let shallow: Shallow<DirectiveDisplayComponent>;
 
   beforeEach(() => {
@@ -33,6 +33,8 @@ fdescribe('DirectiveDisplayComponent', () => {
     MockDirectiveRepo.reset();
     MockDirectiveRepo.mockStewardEmail = 'test@example.com';
     MockDirectiveRepo.mockNote = 'Unit Testing!';
+    MockDirectiveRepo.legacyContactName = 'Test User';
+    MockDirectiveRepo.legacyContactEmail = 'test@example.com';
   });
 
   it('should create', async () => {
@@ -76,5 +78,37 @@ fdescribe('DirectiveDisplayComponent', () => {
     expect(find('.error').length).toBe(1);
     expect(find('.archive-steward-table').length).toBe(0);
     expect(find('button').nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should show the "No Plan" warning if the user does not have a legacy contact', async () => {
+    MockDirectiveRepo.legacyContactName = null;
+    MockDirectiveRepo.legacyContactEmail = null;
+    const { find } = await shallow.render();
+    expect(find('.no-plan-warning').length).toBe(1);
+    expect(find('button').nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should not show the "No Plan" warning if the user does have a legacy contact', async () => {
+    const { find } = await shallow.render();
+    expect(find('.no-plan-warning').length).toBe(0);
+    expect(find('button').nativeElement.disabled).toBeFalsy();
+  });
+
+  it('should be able to handle API errors when fetching Legacy Contact', async () => {
+    MockDirectiveRepo.failLegacyRequest = true;
+    const { find } = await shallow.render();
+    expect(find('.error').length).toBe(1);
+    expect(find('.archive-steward-table').length).toBe(0);
+    expect(find('button').nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should be able to disable the Legacy Contact check through an input', async () => {
+    MockDirectiveRepo.legacyContactName = null;
+    MockDirectiveRepo.legacyContactEmail = null;
+    const { find } = await shallow.render(
+      '<pr-directive-display [checkLegacyContact]="false"></pr-directive-display>'
+    );
+    expect(find('.no-plan-warning').length).toBe(0);
+    expect(find('button').nativeElement.disabled).toBeFalsy();
   });
 });

--- a/src/app/directive/components/directive-display/directive-display.component.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { AccountVO, Directive } from '@models/index';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
@@ -9,17 +9,37 @@ import { ApiService } from '@shared/services/api/api.service';
   styleUrls: ['./directive-display.component.scss'],
 })
 export class DirectiveDisplayComponent implements OnInit {
+  @Input() public checkLegacyContact: boolean = true;
   public archiveName: string;
   public directive: Directive;
   public error: boolean;
+  public noPlan: boolean;
 
   constructor(private account: AccountService, private api: ApiService) {
     this.error = false;
+    this.noPlan = false;
   }
 
   async ngOnInit(): Promise<void> {
     this.archiveName = this.account.getArchive().fullName;
+    if (this.checkLegacyContact) {
+      await this.getLegacyContact();
+    }
     await this.getDirective();
+  }
+
+  protected async getLegacyContact(): Promise<void> {
+    try {
+      const legacyContact = await this.api.directive.getLegacyContact(
+        this.account.getAccount()
+      );
+      if (!legacyContact?.name || !legacyContact?.email) {
+        this.noPlan = true;
+      }
+    } catch {
+      this.error = true;
+      return;
+    }
   }
 
   protected async getDirective(): Promise<void> {

--- a/src/app/directive/components/directive-display/directive-display.stories.ts
+++ b/src/app/directive/components/directive-display/directive-display.stories.ts
@@ -46,6 +46,16 @@ export default {
       defaultValue: true,
       control: 'boolean',
     },
+    hasLegacyContact: {
+      defaultValue: true,
+      control: 'boolean',
+    },
+    checkLegacyContact: {
+      defaultValue: true,
+      control: 'boolean',
+      description:
+        'If the UI should check for the presence of a Legacy Contact and show the "No Plan" warning if the account does not have one assigned.',
+    },
     archiveStewardEmail: {
       defaultValue: 'test@example.com',
       control: 'text',
@@ -70,10 +80,15 @@ const storyTemplate: Story = (args) => {
   });
   MockDirectiveRepo.reset();
   MockDirectiveRepo.failRequest = args.failDirectivesFetch;
-  MockDirectiveRepo.mockStewardId = args.hasArchiveSteward ? 1 : null;
-  MockDirectiveRepo.mockNote = args.hasArchiveSteward ? args.note : null;
   MockDirectiveRepo.mockStewardEmail = args.hasArchiveSteward
     ? args.archiveStewardEmail
+    : null;
+  MockDirectiveRepo.mockNote = args.hasArchiveSteward ? args.note : null;
+  MockDirectiveRepo.legacyContactEmail = args.hasLegacyContact
+    ? 'test@example.com'
+    : null;
+  MockDirectiveRepo.legacyContactName = args.hasLegacyContact
+    ? 'Unit Test'
     : null;
   return {
     moduleMetadata: {
@@ -85,21 +100,33 @@ const storyTemplate: Story = (args) => {
             args.hasArchiveSteward +
             args.note +
             args.archiveStewardEmail +
-            args.failDirectivesFetch,
+            args.failDirectivesFetch +
+            args.hasLegacyContact +
+            args.checkLegacyContact,
         },
       ],
+    },
+    props: {
+      checkLegacyContact: args.checkLegacyContact,
     },
   };
 };
 
-export const Default: Story = storyTemplate.bind({});
+export const WithDirective: Story = storyTemplate.bind({});
 
-export const NoPlan: Story = storyTemplate.bind({});
-NoPlan.args = {
+export const WithoutDirective: Story = storyTemplate.bind({});
+WithoutDirective.args = {
   archiveName: 'The Volunteer Firefighter Archive',
   hasArchiveSteward: false,
   archiveStewardEmail: 'test@example.com',
   note: 'Test note for Archive Steward',
+};
+
+export const NoPlan: Story = storyTemplate.bind({});
+NoPlan.args = {
+  hasArchiveSteward: false,
+  checkLegacyContact: true,
+  hasLegacyContact: false,
 };
 
 export const ApiError: Story = storyTemplate.bind({});

--- a/src/app/directive/components/directive-display/test-utils.ts
+++ b/src/app/directive/components/directive-display/test-utils.ts
@@ -1,6 +1,9 @@
-import { AccountVO, ArchiveVO, Directive } from '@models/index';
+import { AccountVO, ArchiveVO, Directive, LegacyContact } from '@models/index';
 
 export class MockAccountService {
+  public static mockAccount: AccountVO = new AccountVO({
+    accountId: 1,
+  });
   public static mockArchive: ArchiveVO = new ArchiveVO({
     archiveId: 1,
     fullName: 'The Testing Archive',
@@ -9,10 +12,17 @@ export class MockAccountService {
   public getArchive(): ArchiveVO {
     return MockAccountService.mockArchive;
   }
+
+  public getAccount(): AccountVO {
+    return MockAccountService.mockAccount;
+  }
 }
 
 export class MockDirectiveRepo {
   public static failRequest: boolean = false;
+  public static failLegacyRequest: boolean = false;
+  public static legacyContactName: string = null;
+  public static legacyContactEmail: string = null;
   public static mockStewardId: number = null;
   public static mockStewardEmail: string = null;
   public static mockNote: string = null;
@@ -22,6 +32,9 @@ export class MockDirectiveRepo {
     MockDirectiveRepo.mockStewardId = null;
     MockDirectiveRepo.mockNote = null;
     MockDirectiveRepo.mockStewardEmail = null;
+    MockDirectiveRepo.failLegacyRequest = false;
+    MockDirectiveRepo.legacyContactName = null;
+    MockDirectiveRepo.legacyContactEmail = null;
   }
 
   public async get(): Promise<Directive> {
@@ -45,6 +58,16 @@ export class MockDirectiveRepo {
       stewardEmail: MockDirectiveRepo.mockStewardEmail,
       note: MockDirectiveRepo.mockNote,
       executionDt: null,
+    };
+  }
+
+  public async getLegacyContact(): Promise<LegacyContact> {
+    if (MockDirectiveRepo.failLegacyRequest) {
+      throw new Error('Unit Testing: Forced Request Failure');
+    }
+    return {
+      name: MockDirectiveRepo.legacyContactName,
+      email: MockDirectiveRepo.legacyContactEmail,
     };
   }
 }

--- a/src/app/directive/directive.module.ts
+++ b/src/app/directive/directive.module.ts
@@ -1,12 +1,18 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { CoreModule } from '@core/core.module';
-import { SharedModule } from '@shared/shared.module';
 import { DirectiveDisplayComponent } from './components/directive-display/directive-display.component';
-
+import {
+  FontAwesomeModule,
+  FaIconLibrary,
+} from '@fortawesome/angular-fontawesome';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 @NgModule({
   exports: [DirectiveDisplayComponent],
   declarations: [DirectiveDisplayComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, FontAwesomeModule],
 })
-export class DirectiveModule {}
+export class DirectiveModule {
+  constructor(private library: FaIconLibrary) {
+    this.library.addIcons(faExclamationTriangle);
+  }
+}

--- a/src/app/models/directive.ts
+++ b/src/app/models/directive.ts
@@ -17,3 +17,8 @@ export interface Directive {
   note?: string;
   executionDt?: Date;
 }
+
+export interface LegacyContact {
+  name: string;
+  email: string;
+}

--- a/src/app/shared/services/api/directive.repo.ts
+++ b/src/app/shared/services/api/directive.repo.ts
@@ -1,9 +1,14 @@
-import { ArchiveVO, Directive } from '@models/index';
+import { AccountVO, ArchiveVO, Directive, LegacyContact } from '@models/index';
 import { BaseRepo } from './base';
 
 export class DirectiveRepo extends BaseRepo {
   public async get(archive: ArchiveVO): Promise<Directive> {
     console.warn('Directive API is currently unimplemented.');
     return {} as Directive;
+  }
+
+  public async getLegacyContact(account: AccountVO): Promise<LegacyContact> {
+    console.warn('Directive API is currently unimplemented.');
+    return {} as LegacyContact;
   }
 }


### PR DESCRIPTION
This PR is building off of the work from #187.

In the design for the Directives Display screen, there is a warning that shows up and prohibits the user from continuing if the current account does not have a Legacy Contact set up. This commit includes the code to show that warning.

We've decided that this UI functionality may end up disabled when the feature goes live. As a result, all of this functionality can be switched on or off with an input in the `DirectiveDisplayComponent`.

**Steps to Test:**
1. Run `npm run storybook`
2. Check the "No Plan" story, and verify that the warning displays properly.
4. Toggle the **checkLegacyContact** property and verify that enables/disables the warning.
5. Verify the warning does not display in other stories.