### PR TITLE
Run Unit Tests on all PRs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,6 @@ name: Unit tests
 
 on:
   pull_request:
-    branches: [ main ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
The unit tests in #189 are not running since it's not currently set up to merge into `main`. But I'd still like to have unit tests run on this PR. This PR updates the workflow to run on all unit tests.

This PR is set up to merge into `directives-display` so we can test the functionality, but it also might be useful to merge it in that branch anyways so that the changes can make their way to #189.