### PR TITLE
Per 9157 reset redirect

### DIFF
--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -24,6 +24,7 @@ jobs:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_PROD }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_LIVE_KEY }}
           RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY }}
+          FUSIONAUTH_HOST: ${{ secrets.FUSIONAUTH_PROD_HOST }}
         run: npm run build
       - name: Archive `dist`
         uses: actions/upload-artifact@v2

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -78,6 +78,16 @@ const routes: RoutesWithData = [
       { path: 'app/forgot', redirectTo: 'app/auth/forgot', pathMatch: 'full' },
       { path: 'app/reset', redirectTo: 'app/auth/reset', pathMatch: 'full' },
       {
+        path: 'app/fa-reset',
+        loadChildren: () =>
+        new Promise( () => {
+          const url = window.location.href;
+          const keyAndTenant = url.split('fa-reset')[1];
+          window.location.href = 'https://permanent-dev.fusionauth.io/password/change' + keyAndTenant;
+        }),
+        pathMatch: 'prefix'
+      },
+      {
         path: 'app/signupEmbed',
         redirectTo: 'app/embed/signup',
         pathMatch: 'full',

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { DialogComponentToken } from './dialog/dialog.module';
 import { DialogOptions } from './dialog/dialog.service';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
 import { FolderVO, RecordVO } from './models';
+import { SecretsService } from '@shared/services/secrets/secrets.service';
 
 export interface RouteData {
   title?: string;
@@ -39,6 +40,8 @@ export interface RouteWithData extends Route {
 }
 
 export type RoutesWithData = RouteWithData[];
+
+const fusionauthHost = SecretsService.getStatic('FUSIONAUTH_HOST');
 
 const routes: RoutesWithData = [
   {
@@ -83,7 +86,7 @@ const routes: RoutesWithData = [
         new Promise( () => {
           const url = window.location.href;
           const keyAndTenant = url.split('fa-reset')[1];
-          window.location.href = 'https://permanent-dev.fusionauth.io/password/change' + keyAndTenant;
+          window.location.href = fusionauthHost + '/password/change' + keyAndTenant;
         }),
         pathMatch: 'prefix'
       },

--- a/src/optional-secrets.js
+++ b/src/optional-secrets.js
@@ -6,7 +6,11 @@ const optionalSecrets = [
   {
     name: 'RECAPTCHA_API_KEY',
     default: '',
-  }
+  },
+  {
+    name: 'FUSIONAUTH_HOST',
+    default: 'https://permanent-dev.fusionauth.io',
+  },
 ];
 
 module.exports = optionalSecrets;


### PR DESCRIPTION
Redirect from the web app to FusionAuth, instead of linking directly to FA from "forgot password" emails. To test, click "forgot password" on local, see that the email you receive has an "ng.permanent.org:4200" link in it but redirects to FusionAuth for you to type in a new password.

I also need to update the FA template repo. This doesn't need to block on that, though, because the existing direct-to-FusionAuth link will not be affected by this change.