### PR TITLE
Added an extra route param

### DIFF
--- a/src/app/core/components/left-menu/left-menu.component.html
+++ b/src/app/core/components/left-menu/left-menu.component.html
@@ -132,7 +132,7 @@
         Invitations
       </a>
       <a class="menu-item hide-desktop"
-        [routerLink]="[{ outlets: { dialog: ['storage']}}]">
+        [routerLink]="[{ outlets: { dialog: ['storage','add']}}]">
         <i class="ion-md-add-circle"></i>
         Add Storage
       </a>

--- a/src/app/core/components/nav/nav.component.html
+++ b/src/app/core/components/nav/nav.component.html
@@ -13,7 +13,7 @@
     <i class="material-icons" [class.has-badge]="notificationService?.newNotificationCount" (click)="showNotificationMenu()">
       notifications
     </i>
-    <a [routerLink]="[{ outlets: { dialog: ['storage']}}]" [ngbTooltip]="'nav.addStorage' | prTooltip">
+    <a [routerLink]="[{ outlets: { dialog: ['storage','add']}}]" [ngbTooltip]="'nav.addStorage' | prTooltip">
       +
     </a>
     <a href="https://desk.zoho.com/portal/permanent/home" target="_blank"  [ngbTooltip]="'nav.help' | prTooltip">

--- a/src/app/core/components/storage-dialog/storage-dialog.component.ts
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.ts
@@ -1,3 +1,5 @@
+import { ActivatedRoute, ParamMap } from '@angular/router';
+// import { RouterStateSnapshot } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { IsTabbedDialog, DialogRef } from '@root/app/dialog/dialog.module';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
@@ -28,6 +30,7 @@ export class StorageDialogComponent implements OnInit, IsTabbedDialog {
     private account: AccountService,
     private api: ApiService,
     private message: MessageService,
+    private route: ActivatedRoute,
   ) {
     this.promoForm = this.fb.group({
       code: ['', [ Validators.required ]]
@@ -35,6 +38,14 @@ export class StorageDialogComponent implements OnInit, IsTabbedDialog {
   }
 
   ngOnInit(): void {
+     this.route.paramMap.subscribe((params: ParamMap) => {
+      const path = params.get('path') as StorageDialogTab;
+      
+      if(path) {
+      this.activeTab = path;
+      }
+
+     });
   }
 
   setTab(tab: StorageDialogTab) {

--- a/src/app/core/components/storage-dialog/storage-dialog.component.ts
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.ts
@@ -1,5 +1,4 @@
 import { ActivatedRoute, ParamMap } from '@angular/router';
-// import { RouterStateSnapshot } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { IsTabbedDialog, DialogRef } from '@root/app/dialog/dialog.module';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';

--- a/src/app/core/core.routes.ts
+++ b/src/app/core/core.routes.ts
@@ -44,8 +44,8 @@ export const routes: RoutesWithData = [
           {
             path: '**',
             canActivate: [MyfilesGuard],
-          }
-        ]
+          },
+        ],
       },
       {
         path: 'private',
@@ -245,7 +245,7 @@ export const routes: RoutesWithData = [
         redirectTo: '/app/(private//dialog:welcomeinvitation)',
       },
       {
-        path: 'storage',
+        path: 'storage/:path',
         component: RoutedDialogWrapperComponent,
         outlet: 'dialog',
         data: {
@@ -255,8 +255,12 @@ export const routes: RoutesWithData = [
         },
       },
       {
+        path: 'storage/:path',
+        redirectTo: '/app/(private//dialog:storage/:path)',
+      },
+      {
         path: 'storage',
-        redirectTo: '/app/(private//dialog:storage)',
+        redirectTo: '/app/(private//dialog:storage/)',
       },
       {
         path: 'search',

--- a/src/app/shared/components/account-dropdown/account-dropdown.component.html
+++ b/src/app/shared/components/account-dropdown/account-dropdown.component.html
@@ -7,7 +7,7 @@
 <div class="account-dropdown-menu" *ngIf="showMenu" [@dropdownMenuAnimation]>
   <div *ngIf="showMenu" [@ngIfFadeInAnimationSlow]>
     <pr-storage-meter></pr-storage-meter>
-    <a [routerLink]="[{ outlets: { dialog: ['storage']}}]">Storage</a>
+    <a [routerLink]="[{ outlets: { dialog: ['storage','add']}}]">Storage</a>
     <a [routerLink]="[{ outlets: { dialog: ['account']}}]">
       <i class="material-icons text-warning" [ngbTooltip]="badgeTooltip" *ngIf="accountService.isEmailOrPhoneUnverified()">{{badgeIcon}}</i>
       Account


### PR DESCRIPTION
Added an extra route param so when the user hits for example storage/promo then the promo tab will be selected, but if the route hits only storage then the first tab will be selected by default, this case also works with storage/add

The new tabs are:

/storage => storage with first tab open
/storage/add => same as above
/storage/promo => the redeem code tab
/storage/transaction => transaction history
/storage/file => file history.