### PR TITLE
Directive edit screen

### DIFF
--- a/src/app/directive/components/directive-display/directive-display.component.html
+++ b/src/app/directive/components/directive-display/directive-display.component.html
@@ -67,7 +67,7 @@
     </div>
   </div>
   <button class="btn btn-primary" [disabled]="error || noPlan">
-    Assign Archive Steward
+    {{ directive?.stewardEmail ? 'Edit' : 'Assign' }} Archive Steward
   </button>
   <div>&nbsp;</div>
 </div>

--- a/src/app/directive/components/directive-display/directive-display.component.spec.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.spec.ts
@@ -111,4 +111,17 @@ describe('DirectiveDisplayComponent', () => {
     expect(find('.no-plan-warning').length).toBe(0);
     expect(find('button').nativeElement.disabled).toBeFalsy();
   });
+
+  it('should say "Assign" for new directive', async () => {
+    MockDirectiveRepo.mockStewardEmail = null;
+    MockDirectiveRepo.mockNote = null;
+    const { find } = await shallow.render();
+    expect(find('button').nativeElement.innerText).toContain('Assign');
+    expect(find('button').nativeElement.innerText).not.toContain('Edit');
+  });
+
+  it('should say "Edit" for existing directive', async () => {
+    const { find } = await shallow.render();
+    expect(find('button').nativeElement.innerText).toContain('Edit');
+  });
 });

--- a/src/app/directive/components/directive-display/test-utils.ts
+++ b/src/app/directive/components/directive-display/test-utils.ts
@@ -37,10 +37,7 @@ export class MockDirectiveRepo {
     MockDirectiveRepo.legacyContactEmail = null;
   }
 
-  public async get(): Promise<Directive> {
-    if (MockDirectiveRepo.failRequest) {
-      throw new Error('Unit Testing: Forced Request Failure');
-    }
+  public createDirective(): Directive {
     const testDirectiveId = '39b2a5fa-3508-4030-91b6-21dc6ec7a1ab';
     return {
       directiveId: testDirectiveId,
@@ -59,6 +56,13 @@ export class MockDirectiveRepo {
       note: MockDirectiveRepo.mockNote,
       executionDt: null,
     };
+  }
+
+  public async get(): Promise<Directive> {
+    if (MockDirectiveRepo.failRequest) {
+      throw new Error('Unit Testing: Forced Request Failure');
+    }
+    return this.createDirective();
   }
 
   public async getLegacyContact(): Promise<LegacyContact> {

--- a/src/app/directive/components/directive-edit/directive-edit.component.html
+++ b/src/app/directive/components/directive-edit/directive-edit.component.html
@@ -1,0 +1,51 @@
+<div>
+  <div class="panel-title">Designate an Archive Steward: {{ archiveName }}</div>
+  <p>
+    Who should be the owner of this archive in the event of your death or
+    incapacitation? This person, your Archive Steward, must have a Permanent.org
+    account in order for you to designate that user. If they do not yet have a
+    Permanent account, you can invite them using your referral link.
+  </p>
+  <div class="steward-email-section">
+    <label>
+      <strong>Archive Steward Email</strong>
+      <small>Must match email associated with a Permanent.org account</small>
+    </label>
+    <input
+      [(ngModel)]="email"
+      type="text"
+      class="archive-steward-email input form-control"
+      [attr.disabled]="waiting || null"
+      #emailInput="ngModel"
+      required
+      pattern="\S+@\S+"
+      placeholder="Legacy contact email address"
+    />
+  </div>
+  <span *ngIf="!accountExists" class="account-not-found"
+    >User not found in Permanent database - invite user to create account</span
+  >
+  <p>
+    Your Archive Steward will receive an email with instructions from Permanent,
+    however, we strongly recommend that you also discuss your Legacy Plan with
+    this person. They will receive another email when your Legacy Plan is
+    activated with steps to accept the ownership of your archive. You may also
+    choose to write the Steward a note below with further instructions on what
+    to do with your archive when they assume ownership.
+  </p>
+  <strong>Note to Archive Steward of {{ archiveName }} (optional)</strong><br />
+  <textarea
+    [(ngModel)]="note"
+    class="archive-steward-note form-control"
+    [readonly]="waiting"
+    #noteInput="ngModel"
+    rows="6"
+  ></textarea>
+  <button
+    (click)="submitForm()"
+    class="btn btn-primary save-btn"
+    [disabled]="waiting || emailInput.invalid || noteInput.invalid"
+  >
+    Confirm
+  </button>
+</div>

--- a/src/app/directive/components/directive-edit/directive-edit.component.scss
+++ b/src/app/directive/components/directive-edit/directive-edit.component.scss
@@ -1,0 +1,25 @@
+@import '../directive-display/directive-display.component.scss';
+
+.steward-email-section {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0.5em 2em;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    small {
+      font-style: italic;
+      color: #444;
+    }
+  }
+}
+
+.account-not-found {
+  display: block;
+  color: #f00;
+  text-align: center;
+  margin: 0.5em auto;
+}

--- a/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
@@ -1,0 +1,271 @@
+import { DebugElement, Type } from '@angular/core';
+import { Directive } from '@models/directive';
+import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { Shallow } from 'shallow-render';
+import { QueryMatch } from 'shallow-render/dist/lib/models/query-match';
+
+import { DirectiveModule } from '../../directive.module';
+import { MockAccountService } from '../directive-display/test-utils';
+import { DirectiveEditComponent } from './directive-edit.component';
+
+import {
+  MockDirectiveRepo,
+  MockMessageService,
+  createDirective,
+} from './test-utils';
+import { MessageService } from '@shared/services/message/message.service';
+
+class MockApiService {
+  public directive = new MockDirectiveRepo();
+}
+
+type Find = (
+  cssOrDirective: string | Type<any>,
+  options?: {
+    query?: string;
+  }
+) => QueryMatch<DebugElement>;
+
+describe('DirectiveEditComponent', () => {
+  let shallow: Shallow<DirectiveEditComponent>;
+
+  const fillOutForm = (find: Find, email: string, note: string) => {
+    const emailInput = find('.archive-steward-email')[0]
+      .nativeElement as HTMLInputElement;
+    const noteInput = find('.archive-steward-note')[0]
+      .nativeElement as HTMLTextAreaElement;
+
+    emailInput.value = email;
+    emailInput.dispatchEvent(new Event('input'));
+    noteInput.value = note;
+    noteInput.dispatchEvent(new Event('input'));
+  };
+
+  beforeEach(() => {
+    MockDirectiveRepo.reset();
+    MockMessageService.reset();
+    shallow = new Shallow<DirectiveEditComponent>(
+      DirectiveEditComponent,
+      DirectiveModule
+    )
+      .provideMock([
+        {
+          provide: ApiService,
+          useClass: MockApiService,
+        },
+      ])
+      .provideMock([
+        {
+          provide: AccountService,
+          useClass: MockAccountService,
+        },
+      ])
+      .provideMock([
+        {
+          provide: MessageService,
+          useClass: MockMessageService,
+        },
+      ]);
+  });
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+    expect(instance).not.toBeNull();
+  });
+
+  it('should be able to fill out the directive form', async () => {
+    const { instance, find } = await shallow.render();
+    expect(find('.archive-steward-email').length).toBe(1);
+    expect(find('.archive-steward-note').length).toBe(1);
+
+    fillOutForm(find, 'test@example.com', 'Unit Testing!');
+
+    expect(instance.email).toBe('test@example.com');
+    expect(instance.note).toBe('Unit Testing!');
+  });
+
+  it('should be able to save a new directive', async () => {
+    const { instance, find, fixture } = await shallow.render();
+
+    fillOutForm(find, 'test@example.com', 'Test Memo');
+
+    expect(find('.save-btn').length).toBe(1);
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+
+    expect(find('*[disabled], *[readonly]').length).toBe(3);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(find('*[disabled], *[readonly]').length).toBe(0);
+
+    expect(find('.account-not-found').length).toBe(0);
+    expect(MockDirectiveRepo.createdDirective).not.toBeNull();
+  });
+
+  it('should be able to have existing directive data passed in', async () => {
+    const directive = await createDirective(
+      'existing@example.com',
+      'already existing directive'
+    );
+    const { instance } = await shallow.render({
+      bind: {
+        directive,
+      },
+    });
+
+    expect(instance.email).toBe('existing@example.com');
+    expect(instance.note).toBe('already existing directive');
+  });
+
+  it('should send an edit call if the directive already exists', async () => {
+    const directive = await createDirective(
+      'existing@example.com',
+      'already existing directive'
+    );
+
+    const { find, fixture } = await shallow.render({
+      bind: {
+        directive,
+      },
+    });
+
+    fillOutForm(find, 'test@example.com', 'Test Memo');
+
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    expect(find('*[disabled], *[readonly]').length).toBe(3);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(find('*[disabled], *[readonly]').length).toBe(0);
+    expect(MockDirectiveRepo.createdDirective).toBeNull();
+    expect(MockDirectiveRepo.editedDirective).not.toBeNull();
+  });
+
+  it('should handle API errors on creation', async () => {
+    MockDirectiveRepo.failRequest = true;
+    const { instance, find, fixture } = await shallow.render();
+
+    fillOutForm(find, 'test@example.com', 'Test Memo');
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(MockDirectiveRepo.createdDirective).toBeNull();
+    expect(find('.account-not-found').length).toBe(0);
+    expect(MockMessageService.errorShown).toBeTrue();
+  });
+  it('should handle API errors on editing', async () => {
+    MockDirectiveRepo.failRequest = true;
+    const directive = await createDirective(
+      'existing@example.com',
+      'already existing directive'
+    );
+    const { find, fixture } = await shallow.render({
+      bind: {
+        directive,
+      },
+    });
+
+    fillOutForm(find, 'test@example.com', 'Test Memo');
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(MockDirectiveRepo.editedDirective).toBeNull();
+    expect(find('.account-not-found').length).toBe(0);
+    expect(MockMessageService.errorShown).toBeTrue();
+  });
+  it('should emit an output when a directive is created', async () => {
+    const { find, fixture, instance } = await shallow.render();
+    let savedDirective: Directive;
+    instance.savedDirective.emit = jasmine
+      .createSpy()
+      .and.callFake((dir: Directive) => {
+        savedDirective = dir;
+      });
+    fillOutForm(find, 'test@example.com', 'Test Memo');
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(instance.savedDirective.emit).toHaveBeenCalled();
+    expect(savedDirective).not.toBeUndefined();
+  });
+  it('should emit an output when a directive is edited', async () => {
+    const directive = await createDirective(
+      'existing@example.com',
+      'already existing directive'
+    );
+    const { instance, find, fixture } = await shallow.render({
+      bind: {
+        directive,
+      },
+    });
+    let savedDirective: Directive;
+    instance.savedDirective.emit = jasmine
+      .createSpy()
+      .and.callFake((dir: Directive) => {
+        savedDirective = dir;
+      });
+    fillOutForm(find, 'test@example.com', 'Test Memo');
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(instance.savedDirective.emit).toHaveBeenCalled();
+    expect(savedDirective).not.toBeUndefined();
+  });
+  it('should not allow submitting a form until email is filled out', async () => {
+    const { find, fixture } = await shallow.render();
+    fillOutForm(find, '  ', 'Test Memo');
+    fixture.detectChanges();
+    expect(find('.save-btn').nativeElement.disabled).toBeTruthy();
+    fillOutForm(find, 'email@example.com', '');
+    fixture.detectChanges();
+    expect(find('.save-btn').nativeElement.disabled).toBeFalsy();
+    fillOutForm(find, 'email@example.com', 'memo');
+    fixture.detectChanges();
+    expect(find('.save-btn').nativeElement.disabled).toBeFalsy();
+  });
+  it('should show an error message if a user with the given email does not exist when creating a directive', async () => {
+    MockDirectiveRepo.accountExists = false;
+    const { find, fixture, outputs } = await shallow.render();
+    fillOutForm(find, 'notfound@example.com', 'Test Memo');
+    expect(find('.account-not-found').length).toBe(0);
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(MockDirectiveRepo.createdDirective).toBeNull();
+    expect(outputs.savedDirective.emit).not.toHaveBeenCalled();
+    expect(find('.account-not-found').length).toBe(1);
+    MockDirectiveRepo.accountExists = true;
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(MockDirectiveRepo.createdDirective).not.toBeNull();
+    expect(outputs.savedDirective.emit).toHaveBeenCalled();
+    expect(find('.account-not-found').length).toBe(0);
+  });
+  it('should show an error message if a user with the given email does not exist when editing', async () => {
+    MockDirectiveRepo.accountExists = false;
+    const directive = await createDirective(
+      'existing@example.com',
+      'already existing directive'
+    );
+    const { find, fixture, outputs } = await shallow.render({
+      bind: { directive },
+    });
+    fillOutForm(find, 'notfound@example.com', 'Test Memo');
+    expect(find('.account-not-found').length).toBe(0);
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(MockDirectiveRepo.editedDirective).toBeNull();
+    expect(outputs.savedDirective.emit).not.toHaveBeenCalled();
+    expect(find('.account-not-found').length).toBe(1);
+    MockDirectiveRepo.accountExists = true;
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(MockDirectiveRepo.editedDirective).not.toBeNull();
+    expect(outputs.savedDirective.emit).toHaveBeenCalled();
+    expect(find('.account-not-found').length).toBe(0);
+  });
+});

--- a/src/app/directive/components/directive-edit/directive-edit.component.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.ts
@@ -1,0 +1,88 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Directive } from '@models/directive';
+import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
+
+@Component({
+  selector: 'pr-directive-edit',
+  templateUrl: './directive-edit.component.html',
+  styleUrls: ['./directive-edit.component.scss'],
+})
+export class DirectiveEditComponent implements OnInit {
+  @Output() public savedDirective = new EventEmitter<Directive>();
+  @Input() public directive: Directive;
+  public email: string;
+  public note: string;
+  public waiting = false;
+  public archiveName: string;
+  public accountExists = true;
+
+  constructor(
+    private api: ApiService,
+    private account: AccountService,
+    private message: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    if (this.directive) {
+      this.email = this.directive.stewardEmail;
+      this.note = this.directive.note;
+    }
+    this.archiveName = this.account.getArchive().fullName;
+  }
+
+  public async submitForm(): Promise<void> {
+    this.waiting = true;
+    this.accountExists = true;
+    try {
+      if (this.directive) {
+        const directive = Object.assign({}, this.directive);
+        directive.stewardEmail = this.email;
+        directive.note = this.note;
+        const response = await this.api.directive.update(directive);
+        this.catchNotFoundError(response);
+        this.directive = response;
+        this.savedDirective.emit(this.directive);
+      } else {
+        const savedDirective = await this.api.directive.create({
+          archiveId: this.account.getArchive().archiveId,
+          type: 'transfer',
+          trigger: {
+            type: 'admin',
+          },
+          stewardEmail: this.email,
+          note: this.note,
+        });
+        this.catchNotFoundError(savedDirective);
+        this.savedDirective.emit(savedDirective);
+      }
+    } catch {
+      if (this.accountExists) {
+        this.message.showError(
+          'There was an error trying to save the Archive Steward information. Please try again.'
+        );
+      }
+    } finally {
+      this.waiting = false;
+    }
+  }
+
+  protected catchNotFoundError(response: any): void {
+    if (response.name === 'HttpErrorResponse') {
+      const error = response as HttpErrorResponse;
+      if (error.status === 0) {
+        throw new Error('Network/Client Error');
+      } else {
+        this.accountExists = false;
+        this.message.showError(
+          'The given e-mail address, "' +
+            this.email +
+            '", is not currently registered to a user on Permanent'
+        );
+        throw new Error(error.error.message);
+      }
+    }
+  }
+}

--- a/src/app/directive/components/directive-edit/directive-edit.component.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.ts
@@ -69,8 +69,8 @@ export class DirectiveEditComponent implements OnInit {
     }
   }
 
-  protected catchNotFoundError(response: any): void {
-    if (response.name === 'HttpErrorResponse') {
+  protected catchNotFoundError(response: unknown): void {
+    if (response instanceof HttpErrorResponse) {
       const error = response as HttpErrorResponse;
       if (error.status === 0) {
         throw new Error('Network/Client Error');

--- a/src/app/directive/components/directive-edit/directive-edit.stories.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.stories.ts
@@ -1,0 +1,143 @@
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { action } from '@storybook/addon-actions';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { DirectiveModule } from '../../directive.module';
+import { DirectiveEditComponent } from './directive-edit.component';
+
+import { MockDirectiveRepo, createDirective } from './test-utils';
+import { MockAccountService } from '../directive-display/test-utils';
+import { ApiService } from '@shared/services/api/api.service';
+import { AccountService } from '@shared/services/account/account.service';
+import { MessageService } from '@shared/services/message/message.service';
+import { ArchiveVO } from '@models/index';
+import { Directive } from '@angular/core';
+
+const savedAction = action('savedDirective');
+const errorAction = action('Error Message in UI');
+
+class MockApiService {
+  public directive = new MockDirectiveRepo();
+}
+
+class MockMessageService {
+  public showError(err: string): void {
+    errorAction(err);
+  }
+}
+
+export default {
+  title: 'Directive Edit',
+  decorators: [
+    moduleMetadata({
+      declarations: [],
+      imports: [DirectiveModule, HttpClientTestingModule],
+      providers: [
+        {
+          provide: ApiService,
+          useClass: MockApiService,
+        },
+        {
+          provide: AccountService,
+          useClass: MockAccountService,
+        },
+        {
+          provide: MessageService,
+          useClass: MockMessageService,
+        },
+      ],
+    }),
+  ],
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'archiveSettingsDesktop',
+    },
+  },
+  component: DirectiveEditComponent,
+  argTypes: {
+    accountExists: {
+      description:
+        'Controls whether the mocked Directive API returns successfully or with a "Steward Account Not Found" error',
+      defaultValue: true,
+      control: 'boolean',
+    },
+    editingExistingDirective: {
+      defaultValue: false,
+      control: 'boolean',
+    },
+    existingDirectiveSteward: {
+      defaultValue: null,
+      control: 'text',
+    },
+    existingDirectiveNote: {
+      defaultValue: null,
+      control: 'text',
+    },
+    failSaveRequest: {
+      description:
+        'Simulates a backend/network error when saving the Directive.',
+      defaultValue: false,
+      control: 'boolean',
+    },
+    savedDirective: { action: 'savedDirective' },
+  },
+} as Meta;
+
+const Template: Story = (args) => {
+  MockAccountService.mockArchive = new ArchiveVO({
+    fullName: 'The Storybook Archive',
+    archiveId: 1,
+  });
+  MockDirectiveRepo.reset();
+  MockDirectiveRepo.errorDelay = 3000;
+  MockDirectiveRepo.failRequest = args.failSaveRequest;
+  MockDirectiveRepo.accountExists = args.accountExists;
+  const directive = args.editingExistingDirective
+    ? createDirective(args.existingDirectiveSteward, args.existingDirectiveNote)
+    : null;
+  return {
+    moduleMetadata: {
+      providers: [
+        {
+          provide: '__force_rerender_on_propschange__',
+          useValue: JSON.stringify(args),
+        },
+      ],
+    },
+    props: {
+      directive,
+      savedDirective: savedAction,
+    },
+  };
+};
+
+export const Create: Story = Template.bind({});
+Create.args = {
+  editingExistingDirective: false,
+  failSaveRequest: false,
+  accountExists: true,
+};
+
+export const Edit: Story = Template.bind({});
+Edit.args = {
+  editingExistingDirective: true,
+  existingDirectiveSteward: 'test@example.com',
+  existingDirectiveNote:
+    'Hello,\n\nI have designated you as the steward of my Storybook archive. ' +
+    'I hope that you will be able to share these photos with the others and ' +
+    'make sure they can hang on to them. Thank you.\n\nStorybook',
+  failSaveRequest: false,
+  accountExists: true,
+};
+
+export const Error: Story = Template.bind({});
+Error.args = Object.assign(Edit.args, {
+  failSaveRequest: true,
+});
+
+export const NoAccountForEmail: Story = Template.bind({});
+NoAccountForEmail.args = Object.assign(Edit.args, {
+  accountExists: false,
+});

--- a/src/app/directive/components/directive-edit/test-utils.ts
+++ b/src/app/directive/components/directive-edit/test-utils.ts
@@ -1,0 +1,100 @@
+import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { Directive, DirectiveCreateRequest } from '@models/directive';
+import { MockDirectiveRepo as DirectiveGetRepo } from '../directive-display/test-utils';
+
+export const createDirective = (email: string, note: string) => {
+  DirectiveGetRepo.reset();
+  const repo = new DirectiveGetRepo();
+  DirectiveGetRepo.mockStewardEmail = email;
+  DirectiveGetRepo.mockNote = note;
+
+  return repo.createDirective();
+};
+
+export class MockMessageService {
+  public static errorShown: boolean = false;
+
+  public static reset(): void {
+    MockMessageService.errorShown = false;
+  }
+
+  public showError(_msg: string): void {
+    MockMessageService.errorShown = true;
+  }
+}
+
+export class MockDirectiveRepo {
+  public static createdDirective: Directive = null;
+  public static editedDirective: Partial<Directive> = null;
+  public static failRequest: boolean = false;
+  public static errorDelay: number = 0;
+  public static accountExists: boolean = true;
+
+  public static reset(): void {
+    MockDirectiveRepo.createdDirective = null;
+    MockDirectiveRepo.editedDirective = null;
+    MockDirectiveRepo.failRequest = false;
+    MockDirectiveRepo.errorDelay = 0;
+    MockDirectiveRepo.accountExists = true;
+  }
+
+  public async create(directive: DirectiveCreateRequest): Promise<Directive> {
+    if (MockDirectiveRepo.failRequest) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, MockDirectiveRepo.errorDelay)
+      );
+      throw new Error('Forced Unit Test Error');
+    }
+    if (!MockDirectiveRepo.accountExists) {
+      return new HttpErrorResponse({
+        error: {
+          message: 'Steward account not found',
+        },
+        status: 404,
+        statusText: 'Steward account not found',
+      }) as any as Directive;
+      // Simulate returning an unexpected error from the HttpClient
+    }
+    const testDirectiveId = '39b2a5fa-3508-4030-91b6-21dc6ec7a1ab';
+    const newDirective: Directive = {
+      directiveId: testDirectiveId,
+      archiveId: directive.archiveId,
+      type: directive.type,
+      createdDt: new Date(),
+      updatedDt: new Date(),
+      trigger: {
+        directiveTriggerId: testDirectiveId,
+        directiveId: testDirectiveId,
+        type: directive.trigger.type,
+        createdDt: new Date(),
+        updatedDt: new Date(),
+      },
+      stewardEmail: directive.stewardEmail,
+      note: directive.note,
+      executionDt: null,
+    };
+    MockDirectiveRepo.createdDirective = newDirective;
+    return newDirective;
+  }
+
+  public async update(directive: Partial<Directive>): Promise<Directive> {
+    if (MockDirectiveRepo.failRequest) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, MockDirectiveRepo.errorDelay)
+      );
+      throw new Error('Forced Unit Test Error');
+    }
+    if (!MockDirectiveRepo.accountExists) {
+      return new HttpErrorResponse({
+        error: {
+          message: 'Steward account not found',
+        },
+        status: 404,
+        statusText: 'Steward account not found',
+      }) as any as Directive;
+      // Simulate returning an unexpected error from the HttpClient
+    }
+    MockDirectiveRepo.editedDirective = directive;
+    return directive as Directive;
+  }
+}

--- a/src/app/directive/directive.module.ts
+++ b/src/app/directive/directive.module.ts
@@ -6,10 +6,12 @@ import {
   FaIconLibrary,
 } from '@fortawesome/angular-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { DirectiveEditComponent } from './components/directive-edit/directive-edit.component';
+import { FormsModule } from '@angular/forms';
 @NgModule({
-  exports: [DirectiveDisplayComponent],
-  declarations: [DirectiveDisplayComponent],
-  imports: [CommonModule, FontAwesomeModule],
+  exports: [DirectiveDisplayComponent, DirectiveEditComponent],
+  declarations: [DirectiveDisplayComponent, DirectiveEditComponent],
+  imports: [CommonModule, FontAwesomeModule, FormsModule],
 })
 export class DirectiveModule {
   constructor(private library: FaIconLibrary) {

--- a/src/app/models/directive.ts
+++ b/src/app/models/directive.ts
@@ -22,3 +22,13 @@ export interface LegacyContact {
   name: string;
   email: string;
 }
+
+export interface DirectiveCreateRequest {
+  archiveId: number;
+  type: string;
+  trigger: {
+    type: string;
+  };
+  stewardEmail?: string;
+  note?: string;
+}

--- a/src/app/shared/services/api/directive.repo.ts
+++ b/src/app/shared/services/api/directive.repo.ts
@@ -1,4 +1,10 @@
-import { AccountVO, ArchiveVO, Directive, LegacyContact } from '@models/index';
+import {
+  AccountVO,
+  ArchiveVO,
+  Directive,
+  DirectiveCreateRequest,
+  LegacyContact,
+} from '@models/index';
 import { BaseRepo } from './base';
 
 export class DirectiveRepo extends BaseRepo {
@@ -10,5 +16,15 @@ export class DirectiveRepo extends BaseRepo {
   public async getLegacyContact(account: AccountVO): Promise<LegacyContact> {
     console.warn('Directive API is currently unimplemented.');
     return {} as LegacyContact;
+  }
+
+  public async create(directive: DirectiveCreateRequest): Promise<Directive> {
+    console.warn('Directive API is currently unimplemented.');
+    return {} as Directive;
+  }
+
+  public async update(directive: Partial<Directive>): Promise<Directive> {
+    console.warn('Directive API is currently unimplemented.');
+    return {} as Directive;
   }
 }


### PR DESCRIPTION
This PR adds the screen to edit/create an archive steward for the current archive. Currently the edit/create component is not implemented into the web-app or a complete flow yet. It can only be tested in isolation in Storybook or Karma. Upcoming tickets that adds API functionality and integration into the web-app will connect the edit and display screens into a proper flow running against the actual API.

A saved Directive will currently trigger an output in Angular. When the full flow is implemented, triggering this output will send the user back to the main Directive display screen.

**Steps to Test:**
1. Run `npm run storybook`
2. View the "Directive Edit" stories
3. To confirm created/edited directives after hitting "Confirm", you can view the "Actions" tab in Storybook.
4. To confirm error messages that would be displayed by the MessageService, you can also view the "Actions" tab in Storybook.