### PR TITLE
Run Prettier on files with pragma

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -83,12 +83,13 @@ const routes: RoutesWithData = [
       {
         path: 'app/fa-reset',
         loadChildren: () =>
-        new Promise( () => {
-          const url = window.location.href;
-          const keyAndTenant = url.split('fa-reset')[1];
-          window.location.href = fusionauthHost + '/password/change' + keyAndTenant;
-        }),
-        pathMatch: 'prefix'
+          new Promise(() => {
+            const url = window.location.href;
+            const keyAndTenant = url.split('fa-reset')[1];
+            window.location.href =
+              fusionauthHost + '/password/change' + keyAndTenant;
+          }),
+        pathMatch: 'prefix',
       },
       {
         path: 'app/signupEmbed',

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -169,7 +169,7 @@ export class CoreModule {
     {
       token: 'ArchiveTypeChangeDialogComponent',
       component: ArchiveTypeChangeDialogComponent,
-    }
+    },
   ];
 
   constructor(

--- a/src/app/core/guards/myfiles.guard.spec.ts
+++ b/src/app/core/guards/myfiles.guard.spec.ts
@@ -17,7 +17,7 @@ describe('MyfilesGuard', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule]
+      imports: [RouterTestingModule],
     });
     guard = TestBed.inject(MyfilesGuard);
   });

--- a/src/app/core/guards/myfiles.guard.ts
+++ b/src/app/core/guards/myfiles.guard.ts
@@ -26,6 +26,8 @@ export class MyfilesGuard implements CanActivate {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this.router.parseUrl(state.url.replace(/^\/app\/myfiles/, '/app/private'));
+    return this.router.parseUrl(
+      state.url.replace(/^\/app\/myfiles/, '/app/private')
+    );
   }
 }

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -76,7 +76,7 @@ export class EditTagsComponent
     private api: ApiService,
     private dataService: DataService,
     private elementRef: ElementRef,
-    private dialog: Dialog,
+    private dialog: Dialog
   ) {
     this.subscriptions.push(
       this.tagsService.getTags$().subscribe((tags) => {

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.scss
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.scss
@@ -32,9 +32,9 @@
 .btn {
   background-color: #5261b7;
   width: 16.25rem;
-  padding: .65625rem .75rem;
+  padding: 0.65625rem 0.75rem;
   text-align: center;
-  border: 0rem
+  border: 0rem;
 }
 
 .dialog-body {

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.ts
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.ts
@@ -1,4 +1,4 @@
-/* @format */ 
+/* @format */
 import { Component, OnInit, Input, Inject } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
 import { DeviceService } from '@shared/services/device/device.service';

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -41,7 +41,7 @@ export class AccountRepo extends BaseRepo {
       password: password,
       passwordVerify: passwordConfirm,
       inviteCode: inviteCode,
-      createArchive: createDefaultArchive
+      createArchive: createDefaultArchive,
     };
 
     return this.http.sendV2Request<AccountVO>(

--- a/src/app/shared/services/api/auth.repo.spec.ts
+++ b/src/app/shared/services/api/auth.repo.spec.ts
@@ -120,5 +120,4 @@ describe('AuthRepo', () => {
     );
     req.flush(expected);
   });
-
 });

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -139,7 +139,6 @@ export class AuthRepo extends BaseRepo {
       AuthResponse
     );
   }
-
 }
 
 export class AuthResponse extends BaseResponse {


### PR DESCRIPTION
Even though we have Prettier enabled in CI, somehow some formatting issues have snuck into the main branch. Run prettier to fix these formatting issues.

Prettier was run with the following command: `npx prettier --write --require-pragma .`

I believe this issue is currently causing #209 to fail the formatting check in CI, since we have merged some pull requests since the PR went up that may have included broken formatting. We should probably investigate how formatting issues made it through the CI.