### PR TITLE
Added a way to clear the date in the sidebar

### DIFF
--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -64,7 +64,10 @@
         emptyMessage="Click to add date"
         [readOnlyEmptyMessage]="selectedItem.isFolder ? 'No start date' : 'No date'"
         (doneEditing)="onFinishEditing('displayDT', $event)"
-        type='date'></pr-inline-value-edit>
+        type='date'
+        (clearedDate)="onFinishEditing('displayDT', null)"
+        [isFolder]="selectedItem.isFolder"
+        ></pr-inline-value-edit>
     </div>
     <div class="sidebar-item" *ngIf="selectedItem.isFolder">
       <label>End date</label>
@@ -76,7 +79,10 @@
         emptyMessage="Click to add date"
         readOnlyEmptyMessage="No end date"
         (doneEditing)="onFinishEditing('displayEndDT', $event)"
-        type='date'></pr-inline-value-edit>
+        (clearedDate)="onFinishEditing('displayEndDT', null)"
+        type='date'
+        [isFolder]="selectedItem.isFolder"
+       ></pr-inline-value-edit>
     </div>
     <div class="sidebar-item">
       <label>Location</label>

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
@@ -136,8 +136,11 @@
       <button class="btn btn-primary btn-sm" (click)="save()" type="submit">
         Save
       </button>
-      <button class="btn btn-secondary btn-sm" (click)="cancel()" type="button">
+      <button [ngClass]="{'with-margin':!isFolder}" class="btn btn-secondary btn-sm" (click)="cancel()" type="button">
         Cancel
+      </button>
+      <button [disabled]="!displayValue" *ngIf="!isFolder" class="btn btn-secondary btn-sm" (click)="clearDate()" type="button">
+        Clear
       </button>
     </div>
   </ng-template>

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
@@ -213,3 +213,6 @@ input, select, textarea {
     }
   }
 }
+.with-margin{
+  margin-right: 4rem;
+}

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.ts
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.ts
@@ -63,6 +63,7 @@ export class InlineValueEditComponent implements OnInit, OnChanges {
   @Input() selectOptions: FormInputSelectOption[];
   @Input() dateOnly = false;
   @Input() class: string;
+  @Input() isFolder: boolean;
 
   @HostBinding('class.horizontal-controls') @Input() horizontalControls = false;
   @HostBinding('class.always-show') @Input() alwaysShow = false;
@@ -74,6 +75,8 @@ export class InlineValueEditComponent implements OnInit, OnChanges {
     new EventEmitter<boolean>();
 
   formControl: UntypedFormControl;
+  @Output() clearedDate: EventEmitter<boolean> = new EventEmitter<boolean>();
+
   @ViewChild('input') inputElementRef: ElementRef;
   @ViewChild(NgModel) ngModel: NgModel;
   @ViewChild('datePicker') datePicker: NgbDatepicker;
@@ -271,5 +274,12 @@ export class InlineValueEditComponent implements OnInit, OnChanges {
     if (event.keyCode === ENTER) {
       this.save();
     }
+  }
+
+  clearDate(){
+   this.clearedDate.emit(true);
+   this.isEditing = false;
+   this.toggledDatePicker.emit(false);
+   this.blurInput();
   }
 }


### PR DESCRIPTION
I have added a new button beneath each date picker (file or folder) and when the user clicks on it the date gets updated through an update request to the backend with a null value

It works but when I refresh the previous date is set back again, maybe the date is protected again just like the archive type was? 