### PR TITLE
 Implement Directive API

### DIFF
--- a/src/app/directive/components/directive-display/directive-display.component.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { AccountVO, Directive } from '@models/index';
+import { AccountVO, DirectiveData } from '@models/index';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 
@@ -11,7 +11,7 @@ import { ApiService } from '@shared/services/api/api.service';
 export class DirectiveDisplayComponent implements OnInit {
   @Input() public checkLegacyContact: boolean = true;
   public archiveName: string;
-  public directive: Directive;
+  public directive: DirectiveData;
   public error: boolean;
   public noPlan: boolean;
 

--- a/src/app/directive/components/directive-display/test-utils.ts
+++ b/src/app/directive/components/directive-display/test-utils.ts
@@ -1,4 +1,9 @@
-import { AccountVO, ArchiveVO, Directive, LegacyContact } from '@models/index';
+import {
+  AccountVO,
+  ArchiveVO,
+  DirectiveData,
+  LegacyContact,
+} from '@models/index';
 
 export class MockAccountService {
   public static mockAccount: AccountVO = new AccountVO({
@@ -37,7 +42,7 @@ export class MockDirectiveRepo {
     MockDirectiveRepo.legacyContactEmail = null;
   }
 
-  public createDirective(): Directive {
+  public createDirective(): DirectiveData {
     const testDirectiveId = '39b2a5fa-3508-4030-91b6-21dc6ec7a1ab';
     return {
       directiveId: testDirectiveId,
@@ -58,7 +63,7 @@ export class MockDirectiveRepo {
     };
   }
 
-  public async get(): Promise<Directive> {
+  public async get(): Promise<DirectiveData> {
     if (MockDirectiveRepo.failRequest) {
       throw new Error('Unit Testing: Forced Request Failure');
     }

--- a/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
@@ -1,5 +1,5 @@
 import { DebugElement, Type } from '@angular/core';
-import { Directive } from '@models/directive';
+import { DirectiveData } from '@models/directive';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { Shallow } from 'shallow-render';
@@ -176,10 +176,10 @@ describe('DirectiveEditComponent', () => {
   });
   it('should emit an output when a directive is created', async () => {
     const { find, fixture, instance } = await shallow.render();
-    let savedDirective: Directive;
+    let savedDirective: DirectiveData;
     instance.savedDirective.emit = jasmine
       .createSpy()
-      .and.callFake((dir: Directive) => {
+      .and.callFake((dir: DirectiveData) => {
         savedDirective = dir;
       });
     fillOutForm(find, 'test@example.com', 'Test Memo');
@@ -199,10 +199,10 @@ describe('DirectiveEditComponent', () => {
         directive,
       },
     });
-    let savedDirective: Directive;
+    let savedDirective: DirectiveData;
     instance.savedDirective.emit = jasmine
       .createSpy()
-      .and.callFake((dir: Directive) => {
+      .and.callFake((dir: DirectiveData) => {
         savedDirective = dir;
       });
     fillOutForm(find, 'test@example.com', 'Test Memo');

--- a/src/app/directive/components/directive-edit/directive-edit.component.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { Directive } from '@models/directive';
+import { DirectiveData } from '@models/directive';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -11,8 +11,8 @@ import { MessageService } from '@shared/services/message/message.service';
   styleUrls: ['./directive-edit.component.scss'],
 })
 export class DirectiveEditComponent implements OnInit {
-  @Output() public savedDirective = new EventEmitter<Directive>();
-  @Input() public directive: Directive;
+  @Output() public savedDirective = new EventEmitter<DirectiveData>();
+  @Input() public directive: DirectiveData;
   public email: string;
   public note: string;
   public waiting = false;

--- a/src/app/directive/components/directive-edit/test-utils.ts
+++ b/src/app/directive/components/directive-edit/test-utils.ts
@@ -60,7 +60,7 @@ export class MockDirectiveRepo {
     const testDirectiveId = '39b2a5fa-3508-4030-91b6-21dc6ec7a1ab';
     const newDirective: DirectiveData = {
       directiveId: testDirectiveId,
-      archiveId: directive.archiveId,
+      archiveId: parseInt(directive.archiveId.toString()),
       type: directive.type,
       createdDt: new Date(),
       updatedDt: new Date(),

--- a/src/app/directive/components/directive-edit/test-utils.ts
+++ b/src/app/directive/components/directive-edit/test-utils.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
-import { Directive, DirectiveCreateRequest } from '@models/directive';
+import { DirectiveData, DirectiveCreateRequest } from '@models/directive';
 import { MockDirectiveRepo as DirectiveGetRepo } from '../directive-display/test-utils';
 
 export const createDirective = (email: string, note: string) => {
@@ -24,8 +24,8 @@ export class MockMessageService {
 }
 
 export class MockDirectiveRepo {
-  public static createdDirective: Directive = null;
-  public static editedDirective: Partial<Directive> = null;
+  public static createdDirective: DirectiveData = null;
+  public static editedDirective: Partial<DirectiveData> = null;
   public static failRequest: boolean = false;
   public static errorDelay: number = 0;
   public static accountExists: boolean = true;
@@ -38,7 +38,9 @@ export class MockDirectiveRepo {
     MockDirectiveRepo.accountExists = true;
   }
 
-  public async create(directive: DirectiveCreateRequest): Promise<Directive> {
+  public async create(
+    directive: DirectiveCreateRequest
+  ): Promise<DirectiveData> {
     if (MockDirectiveRepo.failRequest) {
       await new Promise((resolve) =>
         setTimeout(resolve, MockDirectiveRepo.errorDelay)
@@ -52,11 +54,11 @@ export class MockDirectiveRepo {
         },
         status: 404,
         statusText: 'Steward account not found',
-      }) as any as Directive;
+      }) as any as DirectiveData;
       // Simulate returning an unexpected error from the HttpClient
     }
     const testDirectiveId = '39b2a5fa-3508-4030-91b6-21dc6ec7a1ab';
-    const newDirective: Directive = {
+    const newDirective: DirectiveData = {
       directiveId: testDirectiveId,
       archiveId: directive.archiveId,
       type: directive.type,
@@ -77,7 +79,9 @@ export class MockDirectiveRepo {
     return newDirective;
   }
 
-  public async update(directive: Partial<Directive>): Promise<Directive> {
+  public async update(
+    directive: Partial<DirectiveData>
+  ): Promise<DirectiveData> {
     if (MockDirectiveRepo.failRequest) {
       await new Promise((resolve) =>
         setTimeout(resolve, MockDirectiveRepo.errorDelay)
@@ -91,10 +95,10 @@ export class MockDirectiveRepo {
         },
         status: 404,
         statusText: 'Steward account not found',
-      }) as any as Directive;
+      }) as any as DirectiveData;
       // Simulate returning an unexpected error from the HttpClient
     }
     MockDirectiveRepo.editedDirective = directive;
-    return directive as Directive;
+    return directive as DirectiveData;
   }
 }

--- a/src/app/models/directive.ts
+++ b/src/app/models/directive.ts
@@ -44,7 +44,7 @@ export interface LegacyContact {
 }
 
 export interface DirectiveCreateRequest {
-  archiveId: number;
+  archiveId: string | number;
   type: string;
   trigger: {
     type: string;

--- a/src/app/models/directive.ts
+++ b/src/app/models/directive.ts
@@ -6,7 +6,7 @@ export interface DirectiveTrigger {
   updatedDt: Date;
 }
 
-export interface Directive {
+export interface DirectiveData {
   directiveId: string;
   archiveId: number;
   type: string;
@@ -16,6 +16,26 @@ export interface Directive {
   stewardEmail?: string;
   note?: string;
   executionDt?: Date;
+}
+
+export class Directive implements DirectiveData {
+  public directiveId: string = '';
+  public archiveId: number;
+  public type: string;
+  public createdDt: Date;
+  public updatedDt: Date;
+  public trigger: DirectiveTrigger;
+  public stewardEmail: string;
+  public note: string;
+  public executionDt: Date | null;
+
+  constructor(data: any) {
+    for (const key in data) {
+      if (data[key] !== undefined && typeof data[key] !== 'function') {
+        this[key] = data[key];
+      }
+    }
+  }
 }
 
 export interface LegacyContact {

--- a/src/app/shared/services/api/account.repo.spec.ts
+++ b/src/app/shared/services/api/account.repo.spec.ts
@@ -9,6 +9,7 @@ import { environment } from '@root/environments/environment';
 import { HttpService } from '@shared/services/http/http.service';
 import { AccountRepo } from '@shared/services/api/account.repo';
 import { AccountVO } from '@root/app/models';
+import { HttpV2Service } from '../http-v2/http-v2.service';
 
 describe('AccountRepo', () => {
   let repo: AccountRepo;
@@ -20,8 +21,11 @@ describe('AccountRepo', () => {
       providers: [HttpService],
     });
 
-    repo = new AccountRepo(TestBed.get(HttpService));
-    httpMock = TestBed.get(HttpTestingController);
+    repo = new AccountRepo(
+      TestBed.inject(HttpService),
+      TestBed.inject(HttpV2Service)
+    );
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
@@ -48,6 +52,8 @@ describe('AccountRepo', () => {
         expect(response.primaryEmail).toEqual('test@permanent.org')
       );
     const req = httpMock.expectOne(`${environment.apiUrl}/account/post`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
     req.flush(expected);
   });
 });

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -6,7 +6,7 @@ import {
   SimpleVO,
 } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
-import { Observable } from 'rxjs';
+import { getFirst } from '../http-v2/http-v2.service';
 
 export class AccountRepo extends BaseRepo {
   public get(accountVO: AccountVO) {
@@ -44,7 +44,13 @@ export class AccountRepo extends BaseRepo {
       createArchive: createDefaultArchive,
     };
 
-    return this.httpV2.post<AccountVO>('/account/post', requestBody, AccountVO);
+    this.httpV2.clearAuthToken();
+
+    return getFirst(
+      this.httpV2.post<AccountVO>('/account/post', requestBody, AccountVO, {
+        csrf: true,
+      })
+    );
   }
 
   public update(accountVO: AccountVO) {

--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -44,11 +44,7 @@ export class AccountRepo extends BaseRepo {
       createArchive: createDefaultArchive,
     };
 
-    return this.http.sendV2Request<AccountVO>(
-      '/account/post',
-      requestBody,
-      AccountVO
-    );
+    return this.httpV2.post<AccountVO>('/account/post', requestBody, AccountVO);
   }
 
   public update(accountVO: AccountVO) {

--- a/src/app/shared/services/api/api.service.ts
+++ b/src/app/shared/services/api/api.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpService } from '@shared/services/http/http.service';
+import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
 import * as Repo from '@shared/services/api/index.repo';
 
 @Injectable({
@@ -24,23 +25,23 @@ export class ApiService {
   public system: Repo.SystemRepo;
   public tag: Repo.TagRepo;
 
-  constructor(private http: HttpService) {
-    this.auth = new Repo.AuthRepo(this.http);
-    this.account = new Repo.AccountRepo(this.http);
-    this.archive = new Repo.ArchiveRepo(this.http);
-    this.billing = new Repo.BillingRepo(this.http);
-    this.connector = new Repo.ConnectorRepo(this.http);
-    this.directive = new Repo.DirectiveRepo(this.http);
-    this.folder = new Repo.FolderRepo(this.http);
-    this.invite = new Repo.InviteRepo(this.http);
-    this.locn = new Repo.LocnRepo(this.http);
-    this.notification = new Repo.NotificationRepo(this.http);
-    this.publish = new Repo.PublishRepo(this.http);
-    this.record = new Repo.RecordRepo(this.http);
-    this.relation = new Repo.RelationRepo(this.http);
-    this.search = new Repo.SearchRepo(this.http);
-    this.share = new Repo.ShareRepo(this.http);
-    this.system = new Repo.SystemRepo(this.http);
-    this.tag = new Repo.TagRepo(this.http);
+  constructor(private http: HttpService, private httpV2: HttpV2Service) {
+    this.auth = new Repo.AuthRepo(this.http, this.httpV2);
+    this.account = new Repo.AccountRepo(this.http, this.httpV2);
+    this.archive = new Repo.ArchiveRepo(this.http, this.httpV2);
+    this.billing = new Repo.BillingRepo(this.http, this.httpV2);
+    this.connector = new Repo.ConnectorRepo(this.http, this.httpV2);
+    this.directive = new Repo.DirectiveRepo(this.http, this.httpV2);
+    this.folder = new Repo.FolderRepo(this.http, this.httpV2);
+    this.invite = new Repo.InviteRepo(this.http, this.httpV2);
+    this.locn = new Repo.LocnRepo(this.http, this.httpV2);
+    this.notification = new Repo.NotificationRepo(this.http, this.httpV2);
+    this.publish = new Repo.PublishRepo(this.http, this.httpV2);
+    this.record = new Repo.RecordRepo(this.http, this.httpV2);
+    this.relation = new Repo.RelationRepo(this.http, this.httpV2);
+    this.search = new Repo.SearchRepo(this.http, this.httpV2);
+    this.share = new Repo.ShareRepo(this.http, this.httpV2);
+    this.system = new Repo.SystemRepo(this.http, this.httpV2);
+    this.tag = new Repo.TagRepo(this.http, this.httpV2);
   }
 }

--- a/src/app/shared/services/api/auth.repo.spec.ts
+++ b/src/app/shared/services/api/auth.repo.spec.ts
@@ -93,6 +93,7 @@ describe('AuthRepo', () => {
       {
         AccountVO: new AccountVO(testAccount),
         ArchiveVO: new ArchiveVO(testArchive),
+        SimpleVO: new SimpleVO({ value: 'test_token' }),
       },
     ];
 
@@ -103,6 +104,11 @@ describe('AuthRepo', () => {
       .logIn(testUser.email, testUser.password, testUser.rememberMe, true)
       .subscribe((response) => {
         expect(response).toEqual(expected);
+        repo.httpV2.get('/v2/health').toPromise();
+        const req2 = httpMock.expectOne(`${environment.apiUrl}/v2/health`);
+        expect(req2.request.headers.get('Authorization')).toBe(
+          'Bearer test_token'
+        );
       });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -40,11 +40,19 @@ export class AuthRepo extends BaseRepo {
       password: password,
     });
 
-    return this.http.sendRequest<AuthResponse>(
-      '/auth/login',
-      [{ AccountVO: accountVO, AccountPasswordVO: accountPasswordVO }],
-      AuthResponse
-    );
+    return this.http
+      .sendRequest<AuthResponse>(
+        '/auth/login',
+        [{ AccountVO: accountVO, AccountPasswordVO: accountPasswordVO }],
+        AuthResponse
+      )
+      .pipe(
+        map((resp) => {
+          const authToken = resp.getSimpleVO().value;
+          this.httpV2.setAuthToken(authToken);
+          return resp;
+        })
+      );
   }
 
   public logOut() {

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -109,7 +109,9 @@ export class AuthRepo extends BaseRepo {
         passwordVerify: passwordVo.passwordVerify,
         trustToken,
       };
-      return this.httpV2.post('/account/changePassword', v2data).toPromise();
+      return this.httpV2
+        .post('/account/changePassword', v2data, null, { csrf: true })
+        .toPromise();
     }
 
     return this.http.sendRequestPromise<AuthResponse>(

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -101,10 +101,7 @@ export class AuthRepo extends BaseRepo {
         passwordVerify: passwordVo.passwordVerify,
         trustToken,
       };
-      return this.http.sendV2RequestPromise<CSRFResponse>(
-        '/account/changePassword',
-        v2data
-      );
+      return this.httpV2.post('/account/changePassword', v2data).toPromise();
     }
 
     return this.http.sendRequestPromise<AuthResponse>(

--- a/src/app/shared/services/api/base.ts
+++ b/src/app/shared/services/api/base.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@shared/services/http/http.service';
 import { SimpleVO, ResponseMessageType } from '@root/app/models';
 import { compact } from 'lodash';
+import { HttpV2Service } from '../http-v2/http-v2.service';
 
 export interface CSRFResponse {
   csrf: string;
@@ -40,7 +41,7 @@ export class BaseResponse {
   }
 
   public getResultsData(): any[] {
-    return compact(this.Results.map(result => result.data));
+    return compact(this.Results.map((result) => result.data));
   }
 
   public getSimpleVO(): SimpleVO {
@@ -78,8 +79,7 @@ export class BaseResponse {
 }
 
 export class BaseRepo {
-  constructor(public http: HttpService) { }
-
+  constructor(public http: HttpService, public httpV2?: HttpV2Service) {}
 }
 
 export const LeanWhitelist = [

--- a/src/app/shared/services/api/directive.repo.spec.ts
+++ b/src/app/shared/services/api/directive.repo.spec.ts
@@ -1,0 +1,122 @@
+/* @format */
+import { TestBed, inject } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { environment } from '@root/environments/environment';
+
+import { HttpService } from '@shared/services/http/http.service';
+import { DirectiveRepo } from './directive.repo';
+import { HttpV2Service } from '../http-v2/http-v2.service';
+import {
+  ArchiveVO,
+  Directive,
+  DirectiveCreateRequest,
+  DirectiveData,
+} from '@models/index';
+
+const apiUrl = (endpoint: string) => `${environment.apiUrl}${endpoint}`;
+
+describe('DirectiveRepo', () => {
+  let repo: DirectiveRepo;
+  let httpMock: HttpTestingController;
+  const testArchive = new ArchiveVO({ archiveId: 1234 });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [HttpService],
+    });
+
+    repo = new DirectiveRepo(
+      TestBed.inject(HttpService),
+      TestBed.inject(HttpV2Service)
+    );
+    httpMock = TestBed.inject(HttpTestingController);
+
+    repo.httpV2.setAuthToken('test_token');
+  });
+
+  it('should exist', () => {
+    expect(repo).not.toBeNull();
+  });
+
+  it('can get a Directive from an Archive', (done) => {
+    repo.httpV2.setAuthToken('test_token');
+    repo.get(testArchive).then((directive) => {
+      expect(directive).not.toBeNull();
+      expect(directive.note).toBe('Test Note');
+      done();
+    });
+
+    const req = httpMock.expectOne(apiUrl('/v2/directive/archive/1234'));
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.has('Authorization')).toBeTrue();
+    req.flush([
+      {
+        directiveId: 'abcd1234',
+        archiveId: 1,
+        type: 'transfer',
+        createdDt: new Date(),
+        updatedDt: new Date(),
+        trigger: {
+          directiveTriggerId: '1234abcd',
+          directiveId: 'abcd1234',
+          type: 'admin',
+          createdDt: new Date(),
+          updatedDt: new Date(),
+        },
+        stewardAccountId: 2,
+        note: 'Test Note',
+        executionDt: null,
+      },
+    ]);
+  });
+
+  it('can create a new Directive for an archive', (done) => {
+    const newDirectiveData: DirectiveCreateRequest = {
+      archiveId: 1,
+      stewardEmail: 'test@test.test',
+      type: 'transfer',
+      note: 'Test Note',
+      trigger: {
+        type: 'admin',
+      },
+    };
+    repo.create(newDirectiveData).then((directive) => {
+      expect(directive instanceof Directive).toBeTrue();
+      expect(directive.archiveId).toBe(1);
+      done();
+    });
+
+    const req = httpMock.expectOne(apiUrl('/v2/directive'));
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.has('Authorization')).toBeTrue();
+    req.flush(new Directive(newDirectiveData));
+  });
+
+  it('can update an existing directive', (done) => {
+    const directiveUpdate: Partial<DirectiveData> = {
+      directiveId: 'test-id',
+      note: 'New Note',
+    };
+
+    repo.update(directiveUpdate).then((directive) => {
+      expect(directive instanceof Directive).toBeTrue();
+      expect(directive.directiveId).toBe('test-id');
+      expect(directive.note).toBe('New Note');
+      done();
+    });
+
+    const req = httpMock.expectOne(apiUrl('/v2/directive/test-id'));
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.headers.has('Authorization')).toBeTrue();
+    expect(req.request.body.directiveId).toBeUndefined();
+    req.flush(new Directive(directiveUpdate));
+  });
+
+  it('will throw an error if no directiveId is specified in update', async () => {
+    await expectAsync(repo.update({ note: 'New Note' })).toBeRejected();
+  });
+});

--- a/src/app/shared/services/api/directive.repo.ts
+++ b/src/app/shared/services/api/directive.repo.ts
@@ -1,30 +1,46 @@
 import {
   AccountVO,
   ArchiveVO,
-  Directive,
+  DirectiveData,
   DirectiveCreateRequest,
   LegacyContact,
+  Directive,
 } from '@models/index';
 import { BaseRepo } from './base';
+import { getFirst } from '../http-v2/http-v2.service';
 
 export class DirectiveRepo extends BaseRepo {
   public async get(archive: ArchiveVO): Promise<Directive> {
-    console.warn('Directive API is currently unimplemented.');
-    return {} as Directive;
+    return getFirst(
+      this.httpV2.get(
+        `/v2/directive/archive/${archive.archiveId}`,
+        {},
+        Directive
+      )
+    ).toPromise();
   }
 
   public async getLegacyContact(account: AccountVO): Promise<LegacyContact> {
-    console.warn('Directive API is currently unimplemented.');
+    console.warn('Legacy Contact API is currently unimplemented.');
     return {} as LegacyContact;
   }
 
   public async create(directive: DirectiveCreateRequest): Promise<Directive> {
-    console.warn('Directive API is currently unimplemented.');
-    return {} as Directive;
+    return getFirst(
+      this.httpV2.post('/v2/directive', directive, Directive)
+    ).toPromise();
   }
 
-  public async update(directive: Partial<Directive>): Promise<Directive> {
-    console.warn('Directive API is currently unimplemented.');
-    return {} as Directive;
+  public async update(directive: Partial<DirectiveData>): Promise<Directive> {
+    if (!directive.directiveId) {
+      throw new Error(
+        'directiveID is required to update an existing Directive.'
+      );
+    }
+    const data = Object.assign({}, directive);
+    delete data.directiveId;
+    return getFirst(
+      this.httpV2.put(`/v2/directive/${directive.directiveId}`, data, Directive)
+    ).toPromise();
   }
 }

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -1,0 +1,156 @@
+import { HttpClient } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { HttpV2Service } from './http-v2.service';
+import { environment } from '@root/environments/environment';
+import { StorageService } from '../storage/storage.service';
+
+const apiUrl = (endpoint: string) => `${environment.apiUrl}${endpoint}`;
+
+describe('HttpV2Service', () => {
+  let service: HttpV2Service;
+  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
+  let storage: StorageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(HttpV2Service);
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    storage = TestBed.inject(StorageService);
+
+    storage.session.set('CSRF', 'csrf_token');
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should be able to make a request as a promise', (done) => {
+    service
+      .post('/api/v2/health', {})
+      .toPromise()
+      .then((response: any) => {
+        expect(response.status).toBe('available');
+        done();
+      });
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    expect(request.request.method).toEqual('POST');
+    expect(request.request.headers.get('Request-Version')).toBe('2');
+    request.flush({ status: 'available' });
+  });
+
+  it('should be able to pass in CSRF token in POST requests', () => {
+    service.post('/api/v2/health', {}).toPromise();
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    expect(request.request.body.csrf).toBeDefined();
+    request.flush({ status: 'available' });
+  });
+
+  it('should be able to pass in a response class', (done) => {
+    class HealthResponse {
+      public status: 'unavailabe' | 'available';
+      public constructorCalled: boolean;
+
+      constructor(data: any) {
+        if (data?.status) {
+          this.status = data.status;
+        }
+        this.constructorCalled = true;
+      }
+    }
+    service
+      .post('/api/v2/health', {}, HealthResponse)
+      .toPromise()
+      .then((resp) => {
+        expect(resp instanceof HealthResponse).toBeTrue();
+        expect(resp.status).toBe('available');
+        expect(resp.constructorCalled).toBeTrue();
+        done();
+      });
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    request.flush({ status: 'available' });
+  });
+
+  it('should set the new csrf token', (done) => {
+    const response = {
+      status: 'available',
+      csrf: 'potato',
+    };
+
+    service
+      .post('/api/v2/health', {})
+      .toPromise()
+      .then(() => {
+        expect(storage.session.get('CSRF')).toBe('potato');
+        done();
+      });
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    request.flush(response);
+  });
+
+  it('should be able to make a GET request', (done) => {
+    service
+      .get('/api/v2/health', { test: 'potato' })
+      .toPromise()
+      .then(() => {
+        expect(storage.session.get('CSRF')).toBe('csrf_token');
+        done();
+      });
+
+    const request = httpTestingController.expectOne(
+      apiUrl('/api/v2/health?test=potato')
+    );
+    expect(request.request.method).toBe('GET');
+    expect(request.request.headers.get('Request-Version')).toBe('2');
+    expect(request.request.body).toBeNull();
+    request.flush({ status: 'available' });
+  });
+
+  it('should be able to make a DELETE request', (done) => {
+    service
+      .delete('/api/v2/health', { id: 32 })
+      .toPromise()
+      .then(() => {
+        expect(storage.session.get('CSRF')).toBe('csrf_token');
+        done();
+      });
+
+    const request = httpTestingController.expectOne(
+      apiUrl('/api/v2/health?id=32')
+    );
+    expect(request.request.method).toBe('DELETE');
+    expect(request.request.headers.get('Request-Version')).toBe('2');
+    expect(request.request.body).toBeNull();
+    request.flush({ status: 'available' });
+  });
+
+  it('should be able to make a PUT request', (done) => {
+    service
+      .put('/api/v2/health', { id: 32, test: 'potato' })
+      .toPromise()
+      .then(() => {
+        expect(storage.session.get('CSRF')).toBe('1234');
+        done();
+      });
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    expect(request.request.method).toBe('PUT');
+    expect(request.request.headers.get('Request-Version')).toBe('2');
+    expect(request.request.body).not.toBeNull();
+    request.flush({ status: 'available', csrf: '1234' });
+  });
+});

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -10,7 +10,7 @@ import { StorageService } from '../storage/storage.service';
 
 const apiUrl = (endpoint: string) => `${environment.apiUrl}${endpoint}`;
 
-describe('HttpV2Service', () => {
+fdescribe('HttpV2Service', () => {
   let service: HttpV2Service;
   let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
@@ -48,6 +48,7 @@ describe('HttpV2Service', () => {
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
     expect(request.request.method).toEqual('POST');
     expect(request.request.headers.get('Request-Version')).toBe('2');
+    expect(request.request.headers.has('Authorization')).toBeFalse();
     request.flush({ status: 'available' });
   });
 
@@ -152,5 +153,24 @@ describe('HttpV2Service', () => {
     expect(request.request.headers.get('Request-Version')).toBe('2');
     expect(request.request.body).not.toBeNull();
     request.flush({ status: 'available', csrf: '1234' });
+  });
+
+  it('should not add a ? to an empty GET request', () => {
+    service.get('/api/v2/health', {}).toPromise();
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    expect(request.request.method).toBe('GET');
+    request.flush({});
+  });
+
+  it('should be able to take in an authentication token', () => {
+    service.setAuthToken('auth_token');
+    service.get('/api/v2/health').toPromise();
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    expect(request.request.headers.get('Authorization')).toBe(
+      'Bearer auth_token'
+    );
+    request.flush({});
   });
 });

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -4,13 +4,25 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { HttpV2Service } from './http-v2.service';
+import { getFirst, HttpV2Service } from './http-v2.service';
 import { environment } from '@root/environments/environment';
 import { StorageService } from '../storage/storage.service';
 
 const apiUrl = (endpoint: string) => `${environment.apiUrl}${endpoint}`;
 
-fdescribe('HttpV2Service', () => {
+class HealthResponse {
+  public status: 'unavailable' | 'available';
+  public constructorCalled: boolean;
+
+  constructor(data: any) {
+    if (data?.status) {
+      this.status = data.status;
+    }
+    this.constructorCalled = true;
+  }
+}
+
+describe('HttpV2Service', () => {
   let service: HttpV2Service;
   let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
@@ -26,6 +38,7 @@ fdescribe('HttpV2Service', () => {
     storage = TestBed.inject(StorageService);
 
     storage.session.set('CSRF', 'csrf_token');
+    service.clearAuthToken();
   });
 
   afterEach(() => {
@@ -37,8 +50,7 @@ fdescribe('HttpV2Service', () => {
   });
 
   it('should be able to make a request as a promise', (done) => {
-    service
-      .post('/api/v2/health', {})
+    getFirst(service.post('/api/v2/health', {}))
       .toPromise()
       .then((response: any) => {
         expect(response.status).toBe('available');
@@ -53,7 +65,7 @@ fdescribe('HttpV2Service', () => {
   });
 
   it('should be able to pass in CSRF token in POST requests', () => {
-    service.post('/api/v2/health', {}).toPromise();
+    service.post('/api/v2/health', {}, null, { csrf: true }).toPromise();
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
     expect(request.request.body.csrf).toBeDefined();
@@ -61,21 +73,11 @@ fdescribe('HttpV2Service', () => {
   });
 
   it('should be able to pass in a response class', (done) => {
-    class HealthResponse {
-      public status: 'unavailabe' | 'available';
-      public constructorCalled: boolean;
-
-      constructor(data: any) {
-        if (data?.status) {
-          this.status = data.status;
-        }
-        this.constructorCalled = true;
-      }
-    }
     service
       .post('/api/v2/health', {}, HealthResponse)
       .toPromise()
-      .then((resp) => {
+      .then((response) => {
+        const resp = response[0];
         expect(resp instanceof HealthResponse).toBeTrue();
         expect(resp.status).toBe('available');
         expect(resp.constructorCalled).toBeTrue();
@@ -172,5 +174,25 @@ fdescribe('HttpV2Service', () => {
       'Bearer auth_token'
     );
     request.flush({});
+  });
+
+  it('should be able to handle being passed an array', (done) => {
+    service
+      .get('/api/v2/health', {}, HealthResponse)
+      .toPromise()
+      .then((resp) => {
+        expect(resp.length).toBe(2);
+        done();
+      });
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    request.flush([{ status: 'available' }, { status: 'unavailable' }]);
+  });
+
+  it('can prevent csrf from being sent', () => {
+    service.post('/api/v2/health', {}, HealthResponse).toPromise();
+
+    const req = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    expect(req.request.body.csrf).toBeUndefined();
   });
 });

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -1,0 +1,145 @@
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { StorageService } from '../storage/storage.service';
+import { environment } from '@root/environments/environment';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Location } from '@angular/common';
+
+const CSRF_KEY = 'CSRF';
+
+type HttpMethod = 'post' | 'get' | 'put' | 'delete';
+type ResponseClass<T> = new (data: any) => T;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HttpV2Service {
+  protected static readonly HttpHeaders: HttpHeaders = new HttpHeaders({
+    'Request-Version': '2',
+    'Content-Type': 'application/json',
+  });
+  protected apiUrl = environment.apiUrl;
+
+  constructor(protected http: HttpClient, protected storage: StorageService) {}
+
+  public post<T>(
+    endpoint: string,
+    data: any = {},
+    responseClass?: ResponseClass<T>
+  ): Observable<T> {
+    return this.makeHttpClientRequest(endpoint, data, 'post', responseClass);
+  }
+
+  public get<T>(
+    endpoint: string,
+    data: any = {},
+    responseClass?: ResponseClass<T>
+  ): Observable<T> {
+    return this.makeHttpClientRequest(
+      this.getEndpointWithData(endpoint, data),
+      {},
+      'get',
+      responseClass
+    );
+  }
+
+  public put<T>(
+    endpoint: string,
+    data: any = {},
+    responseClass?: ResponseClass<T>
+  ): Observable<T> {
+    return this.makeHttpClientRequest(endpoint, data, 'put', responseClass);
+  }
+
+  public delete<T>(
+    endpoint: string,
+    data: any = {},
+    responseClass?: ResponseClass<T>
+  ): Observable<T> {
+    return this.makeHttpClientRequest(
+      this.getEndpointWithData(endpoint, data),
+      {},
+      'delete',
+      responseClass
+    );
+  }
+
+  protected getEndpointWithData(endpoint: string, data: any = {}): string {
+    const params = new HttpParams().appendAll(data);
+    return `${endpoint}?${params.toString()}`;
+  }
+
+  protected appendCsrf(data: any): Object {
+    return {
+      ...data,
+      csrf: this.storage.session.get(CSRF_KEY),
+    };
+  }
+
+  protected getFullUrl(endpoint: string): string {
+    return Location.joinWithSlash(this.apiUrl, endpoint);
+  }
+
+  protected getHeaders() {
+    return {
+      headers: HttpV2Service.HttpHeaders,
+    };
+  }
+
+  protected getObservableWithBody(
+    url: string,
+    data: any = {},
+    method: HttpMethod
+  ): Observable<unknown> {
+    if (method === 'put') {
+      return this.http.put(url, data, this.getHeaders());
+    }
+    return this.http.post(url, data, this.getHeaders());
+  }
+
+  protected getObservableWithNoBody(
+    url: string,
+    method: HttpMethod
+  ): Observable<unknown> {
+    if (method === 'delete') {
+      return this.http.delete(url, this.getHeaders());
+    }
+    return this.http.get(url, this.getHeaders());
+  }
+
+  protected getObservable(
+    endpoint: string,
+    data: any = {},
+    method: HttpMethod = 'post'
+  ): Observable<unknown> {
+    if (method === 'post' || method === 'put') {
+      return this.getObservableWithBody(
+        this.getFullUrl(endpoint),
+        this.appendCsrf(data),
+        method
+      );
+    }
+    return this.getObservableWithNoBody(this.getFullUrl(endpoint), method);
+  }
+
+  protected makeHttpClientRequest<T>(
+    endpoint: string,
+    data: any = {},
+    method: HttpMethod = 'post',
+    responseClass?: new (data: any) => T
+  ): Observable<T> {
+    const observable = this.getObservable(endpoint, data, method);
+    return observable.pipe(
+      map((response: Object) => {
+        if (response.hasOwnProperty('csrf')) {
+          this.storage.session.set(CSRF_KEY, response['csrf']);
+        }
+        if (responseClass) {
+          return new responseClass(response);
+        }
+        return response as T;
+      })
+    );
+  }
+}

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -7,9 +7,28 @@ import { map } from 'rxjs/operators';
 import { Location } from '@angular/common';
 
 const CSRF_KEY = 'CSRF';
+const AUTH_KEY = 'AUTH_TOKEN';
 
 type HttpMethod = 'post' | 'get' | 'put' | 'delete';
 type ResponseClass<T> = new (data: any) => T;
+
+interface RequestOptions {
+  csrf?: boolean;
+  authToken?: boolean;
+}
+
+const defaultOptions: RequestOptions = {
+  csrf: false,
+  authToken: true,
+};
+
+export function getFirst<T>(observable: Observable<T[]>): Observable<T> {
+  return observable.pipe(
+    map((obj) => {
+      return obj[0];
+    })
+  );
+}
 
 @Injectable({
   providedIn: 'root',
@@ -20,54 +39,84 @@ export class HttpV2Service {
     'Content-Type': 'application/json',
   });
   protected apiUrl = environment.apiUrl;
-  protected authToken: string;
+  protected authToken: string | null;
 
-  constructor(protected http: HttpClient, protected storage: StorageService) {}
+  constructor(protected http: HttpClient, protected storage: StorageService) {
+    this.authToken = this.storage.local.get(AUTH_KEY) ?? '';
+  }
 
   public post<T>(
     endpoint: string,
     data: any = {},
-    responseClass?: ResponseClass<T>
-  ): Observable<T> {
-    return this.makeHttpClientRequest(endpoint, data, 'post', responseClass);
+    responseClass?: ResponseClass<T>,
+    options: RequestOptions = defaultOptions
+  ): Observable<T[]> {
+    return this.makeHttpClientRequest(
+      endpoint,
+      data,
+      'post',
+      responseClass,
+      this.getOptions(options)
+    );
   }
 
   public get<T>(
     endpoint: string,
     data: any = {},
-    responseClass?: ResponseClass<T>
-  ): Observable<T> {
+    responseClass?: ResponseClass<T>,
+    options: RequestOptions = defaultOptions
+  ): Observable<T[]> {
     return this.makeHttpClientRequest(
       this.getEndpointWithData(endpoint, data),
       {},
       'get',
-      responseClass
+      responseClass,
+      this.getOptions(options)
     );
   }
 
   public put<T>(
     endpoint: string,
     data: any = {},
-    responseClass?: ResponseClass<T>
-  ): Observable<T> {
-    return this.makeHttpClientRequest(endpoint, data, 'put', responseClass);
+    responseClass?: ResponseClass<T>,
+    options: RequestOptions = defaultOptions
+  ): Observable<T[]> {
+    return this.makeHttpClientRequest(
+      endpoint,
+      data,
+      'put',
+      responseClass,
+      this.getOptions(options)
+    );
   }
 
   public delete<T>(
     endpoint: string,
     data: any = {},
-    responseClass?: ResponseClass<T>
-  ): Observable<T> {
+    responseClass?: ResponseClass<T>,
+    options: RequestOptions = defaultOptions
+  ): Observable<T[]> {
     return this.makeHttpClientRequest(
       this.getEndpointWithData(endpoint, data),
       {},
       'delete',
-      responseClass
+      responseClass,
+      this.getOptions(options)
     );
   }
 
   public setAuthToken(token: string): void {
     this.authToken = token;
+    this.storage.local.set(AUTH_KEY, token);
+  }
+
+  public clearAuthToken(): void {
+    this.setAuthToken(null);
+    this.storage.local.delete(AUTH_KEY);
+  }
+
+  protected getOptions(opts: Partial<RequestOptions>): RequestOptions {
+    return Object.assign({}, defaultOptions, opts);
   }
 
   protected getEndpointWithData(endpoint: string, data: any = {}): string {
@@ -89,9 +138,9 @@ export class HttpV2Service {
     return Location.joinWithSlash(this.apiUrl, endpoint);
   }
 
-  protected getHeaders() {
+  protected getHeaders(options: RequestOptions) {
     let headers: HttpHeaders = HttpV2Service.HttpHeaders;
-    if (this.authToken) {
+    if (this.authToken && options.authToken) {
       headers = headers.append('Authorization', `Bearer ${this.authToken}`);
     }
     return {
@@ -102,55 +151,73 @@ export class HttpV2Service {
   protected getObservableWithBody(
     url: string,
     data: any = {},
-    method: HttpMethod
+    method: HttpMethod,
+    options: RequestOptions
   ): Observable<unknown> {
     if (method === 'put') {
-      return this.http.put(url, data, this.getHeaders());
+      return this.http.put(url, data, this.getHeaders(options));
     }
-    return this.http.post(url, data, this.getHeaders());
+    return this.http.post(url, data, this.getHeaders(options));
   }
 
   protected getObservableWithNoBody(
     url: string,
-    method: HttpMethod
+    method: HttpMethod,
+    options: RequestOptions
   ): Observable<unknown> {
     if (method === 'delete') {
-      return this.http.delete(url, this.getHeaders());
+      return this.http.delete(url, this.getHeaders(options));
     }
-    return this.http.get(url, this.getHeaders());
+    return this.http.get(url, this.getHeaders(options));
   }
 
   protected getObservable(
     endpoint: string,
     data: any = {},
-    method: HttpMethod = 'post'
+    method: HttpMethod = 'post',
+    options: RequestOptions = defaultOptions
   ): Observable<unknown> {
+    console.log(options);
     if (method === 'post' || method === 'put') {
       return this.getObservableWithBody(
         this.getFullUrl(endpoint),
-        this.appendCsrf(data),
-        method
+        options.csrf ? this.appendCsrf(data) : data,
+        method,
+        options
       );
     }
-    return this.getObservableWithNoBody(this.getFullUrl(endpoint), method);
+    return this.getObservableWithNoBody(
+      this.getFullUrl(endpoint),
+      method,
+      options
+    );
   }
 
   protected makeHttpClientRequest<T>(
     endpoint: string,
     data: any = {},
     method: HttpMethod = 'post',
-    responseClass?: new (data: any) => T
-  ): Observable<T> {
-    const observable = this.getObservable(endpoint, data, method);
+    responseClass?: new (data: any) => T,
+    options: RequestOptions = defaultOptions
+  ): Observable<T[]> {
+    const observable = this.getObservable(endpoint, data, method, options);
     return observable.pipe(
-      map((response: Object) => {
+      map((response: Object | Array<Object>) => {
+        if (Array.isArray(response)) {
+          return response.map((obj) => {
+            if (responseClass) {
+              return new responseClass(obj);
+            }
+            return obj as T;
+          });
+        }
         if (response.hasOwnProperty('csrf')) {
           this.storage.session.set(CSRF_KEY, response['csrf']);
         }
         if (responseClass) {
-          return new responseClass(response);
+          return [new responseClass(response)];
         }
-        return response as T;
+        return [response as T];
       })
     );
   }

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -15,11 +15,12 @@ type ResponseClass<T> = new (data: any) => T;
   providedIn: 'root',
 })
 export class HttpV2Service {
-  protected static readonly HttpHeaders: HttpHeaders = new HttpHeaders({
+  protected static readonly HttpHeaders = new HttpHeaders({
     'Request-Version': '2',
     'Content-Type': 'application/json',
   });
   protected apiUrl = environment.apiUrl;
+  protected authToken: string;
 
   constructor(protected http: HttpClient, protected storage: StorageService) {}
 
@@ -65,8 +66,15 @@ export class HttpV2Service {
     );
   }
 
+  public setAuthToken(token: string): void {
+    this.authToken = token;
+  }
+
   protected getEndpointWithData(endpoint: string, data: any = {}): string {
     const params = new HttpParams().appendAll(data);
+    if (params.toString().length === 0) {
+      return endpoint;
+    }
     return `${endpoint}?${params.toString()}`;
   }
 
@@ -82,8 +90,12 @@ export class HttpV2Service {
   }
 
   protected getHeaders() {
+    let headers: HttpHeaders = HttpV2Service.HttpHeaders;
+    if (this.authToken) {
+      headers = headers.append('Authorization', `Bearer ${this.authToken}`);
+    }
     return {
-      headers: HttpV2Service.HttpHeaders,
+      headers,
     };
   }
 

--- a/src/app/shared/services/http/http.service.ts
+++ b/src/app/shared/services/http/http.service.ts
@@ -59,40 +59,6 @@ export class HttpService {
       )
       .toPromise();
   }
-
-  public sendV2Request<T>(
-    endpoint: string,
-    data: any = {},
-    responseClass?: any
-  ): Observable<T> {
-    const requestBody = {
-      ...data,
-      csrf: this.storage.session.get(CSRF_KEY),
-    };
-    const url = this.apiUrl + endpoint;
-    return this.http
-      .post(url, requestBody, {
-        headers: {
-          'Request-Version': '2',
-          'Content-Type': 'application/json',
-        },
-      })
-      .pipe(
-        map((response: any) => {
-          if (response?.csrf) {
-            this.storage.session.set(CSRF_KEY, JSON.stringify(response.csrf));
-          }
-          if (responseClass) {
-            return new responseClass(response);
-          }
-          return response as T;
-        })
-      );
-  }
-
-  public sendV2RequestPromise<T>(endpoint: string, data: any = {}): Promise<T> {
-    return this.sendV2Request<T>(endpoint, data).toPromise();
-  }
 }
 
 export { Observable };


### PR DESCRIPTION
This PR implements the methods in the `ApiService`'s `DirectiveRepo` for sending requests to stela's directives endpoints. Previously, we added new methods to the `HttpService` to call V2 endpoints with the POST method only. This PR creates a new `HttpV2Service` that separates the V1 and V2 code from each other and allows for callers to specify the needed HTTP method.

A question with this PR is: What do we want making V2 requests in the web-app to look like? I had a lot of potential ideas for what I wanted the method calls to look like, but I arrived to my current solution by just building up the class bit by bit. If you have suggestions on what the methods should look like instead, feel free to make suggestions! (I'm not particularly satisfied with the `options` parameter to control adding CSRF / Auth Tokens to requests).

Right now there's no UI to test these methods. I actually ended up just sticking the directives API calls in a random dialog's `ngOnInit` method to test things out, if that helps!