### PR TITLE
Fix Unit Tests

### DIFF
--- a/src/app/core/services/tags/tags.service.spec.ts
+++ b/src/app/core/services/tags/tags.service.spec.ts
@@ -1,40 +1,49 @@
 /* @format */
 import { TestBed } from '@angular/core/testing';
-import { Shallow } from 'shallow-render';
 import { Subscription } from 'rxjs';
 
 import { TagsService } from './tags.service';
 import { AccountService } from '@shared/services/account/account.service';
-import { AppModule } from '../../../app.module';
 import { ArchiveVO, RecordVO } from '@models';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ApiService } from '@shared/services/api/api.service';
 
 describe('TagsService', () => {
-  let shallow: Shallow<TagsService>;
+  let service: TagsService;
 
   beforeEach(() => {
-    shallow = new Shallow(TagsService, AppModule).mock(AccountService, {
-      getArchive: () => new ArchiveVO({ archiveId: 1 }),
-      archiveChange: {
-        subscribe: (callback) => new Subscription(),
-      },
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        ApiService,
+        {
+          provide: AccountService,
+          useValue: {
+            getArchive: () => new ArchiveVO({ archiveId: 1 }),
+            archiveChange: {
+              subscribe: (callback) => new Subscription(),
+            },
+          },
+        },
+      ],
     });
+    TestBed.inject(ApiService);
+    service = TestBed.inject(TagsService);
   });
 
   it('should be created', () => {
-    const { instance } = shallow.createService();
-    expect(instance).toBeTruthy();
+    expect(service).toBeTruthy();
   });
 
   it('should only cache tags from the current archive', () => {
-    const { instance } = shallow.createService();
     const item = new RecordVO({
       TagVOs: [
         { tagId: 1, name: 'testOne', archiveId: 1 },
         { tagId: 2, name: 'testTwo', archiveId: 2 },
       ],
     });
-    instance.checkTagsOnItem(item);
+    service.checkTagsOnItem(item);
 
-    expect(instance.getTags().length).toEqual(1);
+    expect(service.getTags().length).toEqual(1);
   });
 });

--- a/src/app/shared/services/api/auth.repo.spec.ts
+++ b/src/app/shared/services/api/auth.repo.spec.ts
@@ -143,7 +143,11 @@ describe('AuthRepo', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.has('Request-Version')).toBeFalse();
-    req.flush({});
+    req.flush({
+      isSuccessful: true,
+      isSystemUp: true,
+      csrf: 'csrf',
+    });
   });
 
   it('should be able to send an update password V2 request with trust token', () => {

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -177,7 +177,6 @@ export class HttpV2Service {
     method: HttpMethod = 'post',
     options: RequestOptions = defaultOptions
   ): Observable<unknown> {
-    console.log(options);
     if (method === 'post' || method === 'put') {
       return this.getObservableWithBody(
         this.getFullUrl(endpoint),


### PR DESCRIPTION
Somehow, tests from the TagsService started to fail. The reason is that they were using shallow-render which was improperly mocking the ApiService and not injecting in the HttpClientTestingModule.

This fixes that error. There have been a lot of shallow-render related issues with unit testing lately and it begs the question: should we continue to use it? I still think it's valuable for making Angular unit tests easier to read and write, but it's concerning how often they can randomly break.

My suggestion is that shallow-render can continue to be used for component testing, but the "standard" Angular testing style should be used for services and other code that is pure TypeScript with no HTML templates.

**Additionally!** #222 introduced a random chance for a promise rejection to break some unit tests. This is also fixed in this PR.