### PR TITLE
Create Directive Modal

### DIFF
--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
@@ -28,6 +28,14 @@
       >
         Archive Settings
       </div>
+      <div
+        class="dialog-tab"
+        (click)="setTab('legacy-planning')"
+        [class.active]="activeTab === 'legacy-planning'"
+        *ngIf="legacyPlanningEnabled"
+      >
+        Legacy Planning
+      </div>
     </div>
     <div class="panel" #panel>
       <ng-container [ngSwitch]="activeTab">
@@ -75,6 +83,9 @@
           <ng-container *ngIf="hasAccess; else noAccess">
             <pr-manage-custom-metadata></pr-manage-custom-metadata>
           </ng-container>
+        </ng-container>
+        <ng-container *ngSwitchCase="'legacy-planning'">
+          <pr-directive-dialog></pr-directive-dialog>
         </ng-container>
       </ng-container>
     </div>

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -59,6 +59,7 @@ import { AnnouncementModule } from '../announcement/announcement.module';
 import { PublicSettingsComponent } from './components/public-settings/public-settings.component';
 import { ManageMetadataModule } from '../archive-settings/manage-metadata/manage-metadata.module';
 import { ArchiveTypeChangeDialogComponent } from './components/archive-type-change-dialog/archive-type-change-dialog.component';
+import { DirectiveModule } from '../directive/directive.module';
 
 @NgModule({
   imports: [
@@ -74,6 +75,7 @@ import { ArchiveTypeChangeDialogComponent } from './components/archive-type-chan
     NotificationsModule,
     PledgeModule,
     ManageMetadataModule,
+    DirectiveModule,
   ],
   declarations: [
     MainComponent,

--- a/src/app/directive/components/directive-dialog/directive-dialog.component.html
+++ b/src/app/directive/components/directive-dialog/directive-dialog.component.html
@@ -1,0 +1,19 @@
+<!-- @format -->
+<ng-container [ngSwitch]="mode">
+  <pr-directive-display
+    *ngSwitchDefault
+    [checkLegacyContact]="false"
+    [initialDirective]="directive"
+    (loadedDirective)="setSavedDirective($event)"
+    (beginEdit)="switchToEdit($event)"
+  ></pr-directive-display>
+  <ng-container *ngSwitchCase="'edit'">
+    <a class="edit-close" (click)="mode = 'display'">
+      <fa-icon [icon]="['fas', 'chevron-left']"></fa-icon>
+    </a>
+    <pr-directive-edit
+      [directive]="directive"
+      (savedDirective)="saveEditedDirective($event)"
+    ></pr-directive-edit>
+  </ng-container>
+</ng-container>

--- a/src/app/directive/components/directive-dialog/directive-dialog.component.scss
+++ b/src/app/directive/components/directive-dialog/directive-dialog.component.scss
@@ -1,0 +1,5 @@
+/* @format */
+.edit-close {
+  font-size: 1.25em;
+  color: #646464 !important;
+}

--- a/src/app/directive/components/directive-dialog/directive-dialog.component.spec.ts
+++ b/src/app/directive/components/directive-dialog/directive-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+/* @format */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DirectiveDialogComponent } from './directive-dialog.component';
+
+describe('DirectiveDialogComponent', () => {
+  let component: DirectiveDialogComponent;
+  let fixture: ComponentFixture<DirectiveDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DirectiveDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DirectiveDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/directive/components/directive-dialog/directive-dialog.component.ts
+++ b/src/app/directive/components/directive-dialog/directive-dialog.component.ts
@@ -1,0 +1,29 @@
+/* @format */
+import { Component } from '@angular/core';
+import { Directive } from '@models/directive';
+
+type DialogState = 'display' | 'edit';
+
+@Component({
+  selector: 'pr-directive-dialog',
+  templateUrl: './directive-dialog.component.html',
+  styleUrls: ['./directive-dialog.component.scss'],
+})
+export class DirectiveDialogComponent {
+  public mode: DialogState = 'display';
+  public directive: Directive;
+
+  public setSavedDirective(d: Directive): void {
+    this.directive = d;
+  }
+
+  public switchToEdit(d: Directive): void {
+    this.setSavedDirective(d);
+    this.mode = 'edit';
+  }
+
+  public saveEditedDirective(d: Directive): void {
+    this.setSavedDirective(d);
+    this.mode = 'display';
+  }
+}

--- a/src/app/directive/components/directive-dialog/directive-dialog.component.ts
+++ b/src/app/directive/components/directive-dialog/directive-dialog.component.ts
@@ -13,17 +13,17 @@ export class DirectiveDialogComponent {
   public mode: DialogState = 'display';
   public directive: Directive;
 
-  public setSavedDirective(d: Directive): void {
-    this.directive = d;
+  public setSavedDirective(directive: Directive): void {
+    this.directive = directive;
   }
 
-  public switchToEdit(d: Directive): void {
-    this.setSavedDirective(d);
+  public switchToEdit(directive: Directive): void {
+    this.setSavedDirective(directive);
     this.mode = 'edit';
   }
 
-  public saveEditedDirective(d: Directive): void {
-    this.setSavedDirective(d);
+  public saveEditedDirective(directive: Directive): void {
+    this.setSavedDirective(directive);
     this.mode = 'display';
   }
 }

--- a/src/app/directive/components/directive-display/directive-display.component.html
+++ b/src/app/directive/components/directive-display/directive-display.component.html
@@ -20,7 +20,9 @@
     We have additional support and resources about planning your legacy
     <a href="#">here.</a>
   </p>
-  <div class="archive-steward-header">Archive Steward: {{ archiveName }}</div>
+  <div class="archive-steward-header">
+    Archive Steward: The {{ archiveName }} Archive
+  </div>
   <div class="no-plan-warning" *ngIf="noPlan">
     <div class="warning-icon">
       <fa-icon [icon]="['fas', 'exclamation-triangle']"></fa-icon>

--- a/src/app/directive/components/directive-display/directive-display.component.html
+++ b/src/app/directive/components/directive-display/directive-display.component.html
@@ -50,10 +50,10 @@
       <div
         [class]="{
           'archive-steward-email': true,
-          'not-assigned': !directive?.stewardEmail
+          'not-assigned': !directive?.steward?.email
         }"
       >
-        {{ directive?.stewardEmail ?? 'not assigned' }}
+        {{ directive?.steward?.email ?? 'not assigned' }}
       </div>
     </div>
     <div class="row">
@@ -73,7 +73,7 @@
     [disabled]="error || noPlan"
     (click)="beginEdit.emit(directive)"
   >
-    {{ directive?.stewardEmail ? 'Edit' : 'Assign' }} Archive Steward
+    {{ directive?.steward?.email ? 'Edit' : 'Assign' }} Archive Steward
   </button>
   <div>&nbsp;</div>
 </div>

--- a/src/app/directive/components/directive-display/directive-display.component.html
+++ b/src/app/directive/components/directive-display/directive-display.component.html
@@ -66,7 +66,11 @@
       </div>
     </div>
   </div>
-  <button class="btn btn-primary" [disabled]="error || noPlan">
+  <button
+    class="btn btn-primary"
+    [disabled]="error || noPlan"
+    (click)="beginEdit.emit(directive)"
+  >
     {{ directive?.stewardEmail ? 'Edit' : 'Assign' }} Archive Steward
   </button>
   <div>&nbsp;</div>

--- a/src/app/directive/components/directive-display/directive-display.component.spec.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.spec.ts
@@ -28,7 +28,7 @@ describe('DirectiveDisplayComponent', () => {
       });
     MockAccountService.mockArchive = new ArchiveVO({
       archiveId: 1,
-      fullName: 'The Test Archive',
+      fullName: 'Test',
     });
     MockDirectiveRepo.reset();
     MockDirectiveRepo.mockStewardEmail = 'test@example.com';

--- a/src/app/directive/components/directive-display/directive-display.component.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { AccountVO, DirectiveData } from '@models/index';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { AccountVO, Directive } from '@models/index';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 
@@ -10,8 +10,11 @@ import { ApiService } from '@shared/services/api/api.service';
 })
 export class DirectiveDisplayComponent implements OnInit {
   @Input() public checkLegacyContact: boolean = true;
+  @Input() public initialDirective: Directive;
+  @Output() public loadedDirective = new EventEmitter<Directive>();
+  @Output() public beginEdit = new EventEmitter<Directive>();
   public archiveName: string;
-  public directive: DirectiveData;
+  public directive: Directive;
   public error: boolean;
   public noPlan: boolean;
 
@@ -21,6 +24,7 @@ export class DirectiveDisplayComponent implements OnInit {
   }
 
   async ngOnInit(): Promise<void> {
+    this.directive = this.initialDirective;
     this.archiveName = this.account.getArchive().fullName;
     if (this.checkLegacyContact) {
       await this.getLegacyContact();
@@ -52,5 +56,6 @@ export class DirectiveDisplayComponent implements OnInit {
     if (this.directive?.note) {
       this.directive.note = this.directive.note.trim();
     }
+    this.loadedDirective.emit(this.directive);
   }
 }

--- a/src/app/directive/components/directive-display/directive-display.stories.ts
+++ b/src/app/directive/components/directive-display/directive-display.stories.ts
@@ -39,7 +39,7 @@ export default {
   },
   argTypes: {
     archiveName: {
-      defaultValue: 'The Volunteer Firefighter Archive',
+      defaultValue: 'Volunteer Firefighter',
       control: { type: 'text' },
     },
     hasArchiveSteward: {
@@ -76,7 +76,7 @@ export default {
 
 const storyTemplate: Story = (args) => {
   MockAccountService.mockArchive = new ArchiveVO({
-    fullName: args.archiveName,
+    fullName: args.archiveName ?? 'Volunteer Firefighter',
   });
   MockDirectiveRepo.reset();
   MockDirectiveRepo.failRequest = args.failDirectivesFetch;
@@ -116,7 +116,7 @@ export const WithDirective: Story = storyTemplate.bind({});
 
 export const WithoutDirective: Story = storyTemplate.bind({});
 WithoutDirective.args = {
-  archiveName: 'The Volunteer Firefighter Archive',
+  archiveName: 'Volunteer Firefighter',
   hasArchiveSteward: false,
   archiveStewardEmail: 'test@example.com',
   note: 'Test note for Archive Steward',

--- a/src/app/directive/components/directive-display/test-utils.ts
+++ b/src/app/directive/components/directive-display/test-utils.ts
@@ -57,7 +57,10 @@ export class MockDirectiveRepo {
         createdDt: new Date(),
         updatedDt: new Date(),
       },
-      stewardEmail: MockDirectiveRepo.mockStewardEmail,
+      steward: {
+        email: MockDirectiveRepo.mockStewardEmail,
+        name: '',
+      },
       note: MockDirectiveRepo.mockNote,
       executionDt: null,
     };

--- a/src/app/directive/components/directive-edit/directive-edit.component.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { DirectiveData } from '@models/directive';
+import { Directive, DirectiveData } from '@models/directive';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -11,8 +11,8 @@ import { MessageService } from '@shared/services/message/message.service';
   styleUrls: ['./directive-edit.component.scss'],
 })
 export class DirectiveEditComponent implements OnInit {
-  @Output() public savedDirective = new EventEmitter<DirectiveData>();
-  @Input() public directive: DirectiveData;
+  @Output() public savedDirective = new EventEmitter<Directive>();
+  @Input() public directive: Directive;
   public email: string;
   public note: string;
   public waiting = false;
@@ -38,7 +38,8 @@ export class DirectiveEditComponent implements OnInit {
     this.accountExists = true;
     try {
       if (this.directive) {
-        const directive = Object.assign({}, this.directive);
+        const directive: Partial<DirectiveData> = {};
+        directive.directiveId = this.directive.directiveId;
         directive.stewardEmail = this.email;
         directive.note = this.note;
         const response = await this.api.directive.update(directive);
@@ -47,7 +48,7 @@ export class DirectiveEditComponent implements OnInit {
         this.savedDirective.emit(this.directive);
       } else {
         const savedDirective = await this.api.directive.create({
-          archiveId: this.account.getArchive().archiveId,
+          archiveId: this.account.getArchive().archiveId.toString(),
           type: 'transfer',
           trigger: {
             type: 'admin',

--- a/src/app/directive/components/directive-edit/directive-edit.component.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.ts
@@ -41,7 +41,7 @@ export class DirectiveEditComponent implements OnInit {
         const directive: DirectiveUpdateRequest = {
           directiveId: this.directive.directiveId,
         };
-        directive.stewardEmail = this.directive.steward.email;
+        directive.stewardEmail = this.email;
         directive.note = this.note;
         const response = await this.api.directive.update(directive);
         this.catchNotFoundError(response);

--- a/src/app/directive/components/directive-edit/directive-edit.component.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { Directive, DirectiveData } from '@models/directive';
+import { Directive, DirectiveUpdateRequest } from '@models/directive';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -27,7 +27,7 @@ export class DirectiveEditComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.directive) {
-      this.email = this.directive.stewardEmail;
+      this.email = this.directive.steward.email;
       this.note = this.directive.note;
     }
     this.archiveName = this.account.getArchive().fullName;
@@ -38,9 +38,10 @@ export class DirectiveEditComponent implements OnInit {
     this.accountExists = true;
     try {
       if (this.directive) {
-        const directive: Partial<DirectiveData> = {};
-        directive.directiveId = this.directive.directiveId;
-        directive.stewardEmail = this.email;
+        const directive: DirectiveUpdateRequest = {
+          directiveId: this.directive.directiveId,
+        };
+        directive.stewardEmail = this.directive.steward.email;
         directive.note = this.note;
         const response = await this.api.directive.update(directive);
         this.catchNotFoundError(response);

--- a/src/app/directive/components/directive-edit/test-utils.ts
+++ b/src/app/directive/components/directive-edit/test-utils.ts
@@ -71,7 +71,10 @@ export class MockDirectiveRepo {
         createdDt: new Date(),
         updatedDt: new Date(),
       },
-      stewardEmail: directive.stewardEmail,
+      steward: {
+        email: directive.stewardEmail,
+        name: '',
+      },
       note: directive.note,
       executionDt: null,
     };

--- a/src/app/directive/directive.module.ts
+++ b/src/app/directive/directive.module.ts
@@ -5,16 +5,28 @@ import {
   FontAwesomeModule,
   FaIconLibrary,
 } from '@fortawesome/angular-fontawesome';
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import {
+  faChevronLeft,
+  faExclamationTriangle,
+} from '@fortawesome/free-solid-svg-icons';
 import { DirectiveEditComponent } from './components/directive-edit/directive-edit.component';
 import { FormsModule } from '@angular/forms';
+import { DirectiveDialogComponent } from './components/directive-dialog/directive-dialog.component';
 @NgModule({
-  exports: [DirectiveDisplayComponent, DirectiveEditComponent],
-  declarations: [DirectiveDisplayComponent, DirectiveEditComponent],
+  exports: [
+    DirectiveDisplayComponent,
+    DirectiveEditComponent,
+    DirectiveDialogComponent,
+  ],
+  declarations: [
+    DirectiveDisplayComponent,
+    DirectiveEditComponent,
+    DirectiveDialogComponent,
+  ],
   imports: [CommonModule, FontAwesomeModule, FormsModule],
 })
 export class DirectiveModule {
   constructor(private library: FaIconLibrary) {
-    this.library.addIcons(faExclamationTriangle);
+    this.library.addIcons(faExclamationTriangle, faChevronLeft);
   }
 }

--- a/src/app/models/directive.ts
+++ b/src/app/models/directive.ts
@@ -6,6 +6,11 @@ export interface DirectiveTrigger {
   updatedDt: Date;
 }
 
+export interface ArchiveSteward {
+  name?: string;
+  email: string;
+}
+
 export interface DirectiveData {
   directiveId: string;
   archiveId: number;
@@ -13,7 +18,7 @@ export interface DirectiveData {
   createdDt: Date;
   updatedDt: Date;
   trigger: DirectiveTrigger;
-  stewardEmail?: string;
+  steward?: ArchiveSteward;
   note?: string;
   executionDt?: Date;
 }
@@ -25,7 +30,7 @@ export class Directive implements DirectiveData {
   public createdDt: Date;
   public updatedDt: Date;
   public trigger: DirectiveTrigger;
-  public stewardEmail: string;
+  public steward: ArchiveSteward;
   public note: string;
   public executionDt: Date | null;
 
@@ -51,4 +56,10 @@ export interface DirectiveCreateRequest {
   };
   stewardEmail?: string;
   note?: string;
+}
+
+export interface DirectiveUpdateRequest {
+  directiveId: string;
+  note?: string;
+  stewardEmail?: string;
 }

--- a/src/app/shared/services/api/directive.repo.spec.ts
+++ b/src/app/shared/services/api/directive.repo.spec.ts
@@ -13,7 +13,7 @@ import {
   ArchiveVO,
   Directive,
   DirectiveCreateRequest,
-  DirectiveData,
+  DirectiveUpdateRequest,
 } from '@models/index';
 
 const apiUrl = (endpoint: string) => `${environment.apiUrl}${endpoint}`;
@@ -97,7 +97,7 @@ describe('DirectiveRepo', () => {
   });
 
   it('can update an existing directive', (done) => {
-    const directiveUpdate: Partial<DirectiveData> = {
+    const directiveUpdate: DirectiveUpdateRequest = {
       directiveId: 'test-id',
       note: 'New Note',
     };
@@ -117,6 +117,8 @@ describe('DirectiveRepo', () => {
   });
 
   it('will throw an error if no directiveId is specified in update', async () => {
-    await expectAsync(repo.update({ note: 'New Note' })).toBeRejected();
+    await expectAsync(
+      repo.update({ note: 'New Note' } as DirectiveUpdateRequest)
+    ).toBeRejected();
   });
 });

--- a/src/app/shared/services/api/directive.repo.ts
+++ b/src/app/shared/services/api/directive.repo.ts
@@ -1,10 +1,10 @@
 import {
   AccountVO,
   ArchiveVO,
-  DirectiveData,
   DirectiveCreateRequest,
   LegacyContact,
   Directive,
+  DirectiveUpdateRequest,
 } from '@models/index';
 import { BaseRepo } from './base';
 import { getFirst } from '../http-v2/http-v2.service';
@@ -31,7 +31,7 @@ export class DirectiveRepo extends BaseRepo {
     ).toPromise();
   }
 
-  public async update(directive: Partial<DirectiveData>): Promise<Directive> {
+  public async update(directive: DirectiveUpdateRequest): Promise<Directive> {
     if (!directive.directiveId) {
       throw new Error(
         'directiveID is required to update an existing Directive.'


### PR DESCRIPTION
This PR creates a hidden tab on the Archive Settings dialog that finally exposes the Legacy Planning UI in the web-app. To access it, the user just has to open the Archive Settings dialog and add `#legacy-planning` to the end of the URL.

This PR will be adjusted to conform to the API changes in https://github.com/PermanentOrg/stela/pull/30 when finished. <del>Right now it still is based on a version of the API that does not return an object for the steward.</del>

**Open Questions**
* This is the first screen that uses the Stela endpoints that require an Auth Token. If the Auth Token isn't loaded, do we forcibly log out the user?

**Steps To Test**:
1. Open the "Archive Settings" dialog
2. Add `#legacy-planning` to the end of the URL
3. Test out the Legacy Planning UI