### PR TITLE
PER-9260: Always show jpg version of image

### DIFF
--- a/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -79,10 +79,11 @@ export class ThumbnailComponent
       this.item instanceof RecordVO &&
       this.item.FileVOs
     ) {
+      const fullSizeImage = this.chooseFullSizeImage(this.item);
       this.viewer = OpenSeaDragon({
         element: resizableImageElement as HTMLElement,
         prefixUrl: 'assets/openseadragon/images/',
-        tileSources: { type: 'image', url: this.item?.FileVOs[0].fileURL },
+        tileSources: { type: 'image', url: fullSizeImage },
         visibilityRatio: 1.0,
         constrainDuringPan: true,
         maxZoomLevel: 10,
@@ -203,6 +204,17 @@ export class ThumbnailComponent
       };
 
       imageLoader.src = imageUrl;
+    }
+  }
+
+  chooseFullSizeImage(record: RecordVO) {
+    if (record.FileVOs.length > 1) {
+      const convertedUrl = record.FileVOs.find(
+        (file) => file.format == 'file.format.converted'
+      ).fileURL;
+      return convertedUrl;
+    } else {
+      return record.FileVOs[0].fileURL;
     }
   }
 }

--- a/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -80,6 +80,9 @@ export class ThumbnailComponent
       this.item.FileVOs
     ) {
       const fullSizeImage = this.chooseFullSizeImage(this.item);
+      if (fullSizeImage == null) {
+        return;
+      }
       this.viewer = OpenSeaDragon({
         element: resizableImageElement as HTMLElement,
         prefixUrl: 'assets/openseadragon/images/',
@@ -214,7 +217,7 @@ export class ThumbnailComponent
       ).fileURL;
       return convertedUrl;
     } else {
-      return record.FileVOs[0].fileURL;
+      return record.FileVOs[0]?.fileURL;
     }
   }
 }

--- a/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import {
   Component,
   OnInit,
@@ -42,7 +43,7 @@ export class ThumbnailComponent
   private imageElement: Element;
   private resizableImageElement: Element;
 
-  private initialZoom:number;
+  private initialZoom: number;
 
   private targetThumbWidth: number;
   private currentThumbWidth = 200;
@@ -73,7 +74,11 @@ export class ThumbnailComponent
 
   ngAfterViewInit() {
     const resizableImageElement = this.element.querySelector('#openseadragon');
-    if (resizableImageElement && this.item instanceof RecordVO && this.item.FileVOs) {
+    if (
+      resizableImageElement &&
+      this.item instanceof RecordVO &&
+      this.item.FileVOs
+    ) {
       this.viewer = OpenSeaDragon({
         element: resizableImageElement as HTMLElement,
         prefixUrl: 'assets/openseadragon/images/',
@@ -85,17 +90,18 @@ export class ThumbnailComponent
 
       this.viewer.addHandler('zoom', (event: OpenSeaDragon.ZoomEvent) => {
         const zoom = event.zoom;
-        if(!this.initialZoom){
+        if (!this.initialZoom) {
           this.initialZoom = zoom;
         }
-              
-      if(zoom !== this.initialZoom){
-        this.disableSwipe.emit(true);
-      } else {
-        this.disableSwipe.emit(false);
-      }
+
+        if (zoom !== this.initialZoom) {
+          this.disableSwipe.emit(true);
+        } else {
+          this.disableSwipe.emit(false);
+        }
       });
-  }}
+    }
+  }
 
   ngOnChanges() {
     if (!this.imageElement) {


### PR DESCRIPTION
If we have a converted image file, it will be a jpg. If we don't, then the original was a jpg. Choose the full size image to show in the zoom window accordingly.

This will fail if for some reason a record has multiple original files and no converted files. That should never happen but I should be a little more defensive about it.

Looking for feedback on all of it, but in particular whether this is even the right file for this function.