### PR TITLE
PER-9266-removed the header from the public archive page and changed the name

### DIFF
--- a/src/app/public/components/public-archive/public-archive.component.html
+++ b/src/app/public/components/public-archive/public-archive.component.html
@@ -24,7 +24,7 @@
     >
       <div>
         <div class="profile-name">
-          {{ this.archive.fullName }}
+         The {{ this.archive.fullName }} Archive
         </div>
         <div class="profile-description">
           <span
@@ -187,7 +187,6 @@
 
 <div *ngIf="waiting" class="profile-contents">
   <div class="profile-container">
-    <div class="profile-name">The {{ this.archive.fullName }} Archive</div>
     <pr-breadcrumbs
       *ngIf="!(isViewingProfile$ | async)"
       [darkText]="true"


### PR DESCRIPTION
PER-9266-removed the header from the public archive page and changed the way the name is displayed using "the 'archive name' archive" instead of just the name