### PR TITLE
Add Legacy Contact Modal Stories

### DIFF
--- a/src/app/directive/components/directive-edit/directive-edit.component.scss
+++ b/src/app/directive/components/directive-edit/directive-edit.component.scss
@@ -12,9 +12,12 @@
     flex-direction: column;
     small {
       font-style: italic;
-      color: #444;
     }
   }
+}
+
+small {
+  color: #444;
 }
 
 .account-not-found {

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.html
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.html
@@ -2,7 +2,7 @@
 <div>
   <div class="panel-title">Manage Your Digital Legacy</div>
   <p>
-    Your Legacy Plan determins what should happen to your materials on
+    Your Legacy Plan determines what should happen to your materials on
     Permanent.org in the event of your death or incapacitation. Your Legacy Plan
     has two parts:
   </p>

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.html
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.html
@@ -1,0 +1,57 @@
+<!-- @format -->
+<div>
+  <div class="panel-title">Manage Your Digital Legacy</div>
+  <p>
+    Your Legacy Plan determins what should happen to your materials on
+    Permanent.org in the event of your death or incapacitation. Your Legacy Plan
+    has two parts:
+  </p>
+  <ol>
+    <li>
+      Designate an account <strong>Legacy Contact</strong> below. This person
+      will inform Permanent of your death or incapacitation and activate your
+      Legacy Plan as you have outlined it.
+    </li>
+    <li>
+      Designate an <strong>Archive Steward</strong> for each archive that you
+      have created in the Archive's Settings menu. Archive Stewards will assume
+      ownership and management of your archives.
+    </li>
+  </ol>
+  <p>
+    We have additional support and resources about planning your legacy here.
+  </p>
+  <div class="legacy-contact-header">Your Legacy Contact</div>
+  <p class="legacy-contact-description">
+    In the event of your death or incapacitation, your Legacy Contact can
+    activate your Legacy Plan by reaching out to Permanent.org.
+  </p>
+  <div class="archive-steward-table" *ngIf="!error">
+    <div class="row">
+      <div>Legacy Contact name</div>
+      <div
+        class="legacy-contact-name"
+        [class.not-assigned]="!legacyContact?.name"
+      >
+        {{ legacyContact?.name ?? 'not assigned' }}
+      </div>
+    </div>
+    <div class="row">
+      <div>Legacy Contact email</div>
+      <div
+        class="legacy-contact-email"
+        [class.not-assigned]="!legacyContact?.email"
+      >
+        {{ legacyContact?.email ?? 'not assigned' }}
+      </div>
+    </div>
+  </div>
+  <div class="error" *ngIf="error">
+    An error occured while trying to find the current account's Legacy Contact
+    information. Please reload the page and try again. If the problem persists,
+    try logging out and logging in again.
+  </div>
+  <button class="btn btn-primary" [disabled]="error">
+    {{ legacyContact?.email ? 'Edit' : 'Assign' }} Legacy Contact
+  </button>
+</div>

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.scss
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.scss
@@ -1,0 +1,13 @@
+@import '../directive-display/directive-display.component.scss';
+
+.legacy-contact-header {
+  @extend .archive-steward-header;
+}
+
+.legacy-contact-description {
+  @extend .archive-steward-description;
+}
+
+.legacy-contact-table {
+  @extend .archive-steward-table;
+}

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
@@ -1,0 +1,68 @@
+/* @format */
+import { ApiService } from '@shared/services/api/api.service';
+import { Shallow } from 'shallow-render';
+import { DirectiveModule } from '../../directive.module';
+import { LegacyContactDisplayComponent } from './legacy-contact-display.component';
+import { MockAccountService } from '../directive-display/test-utils';
+import { AccountService } from '@shared/services/account/account.service';
+import { MessageService } from '@shared/services/message/message.service';
+import { MockMessageService } from '../directive-edit/test-utils';
+import { MockApiService, MockDirectiveRepo } from './test-utils';
+
+describe('LegacyContactDisplayComponent', () => {
+  let shallow: Shallow<LegacyContactDisplayComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(LegacyContactDisplayComponent, DirectiveModule)
+      .provideMock({
+        provide: ApiService,
+        useClass: MockApiService,
+      })
+      .provideMock({
+        provide: AccountService,
+        useClass: MockAccountService,
+      })
+      .provideMock({
+        provide: MessageService,
+        useClass: MockMessageService,
+      });
+    MockDirectiveRepo.reset();
+    MockMessageService.reset();
+  });
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+    expect(instance).toBeTruthy();
+  });
+  it('should list legacy contact information', async () => {
+    MockDirectiveRepo.legacyContactName = 'Test User';
+    MockDirectiveRepo.legacyContactEmail = 'test@example.com';
+    const { find } = await shallow.render();
+    expect(find('.legacy-contact-name').length).toBe(1);
+    expect(find('.legacy-contact-name')[0].nativeElement.innerText).toContain(
+      'Test User'
+    );
+    expect(find('.legacy-contact-email').length).toBe(1);
+    expect(find('.legacy-contact-email')[0].nativeElement.innerText).toContain(
+      'test@example.com'
+    );
+    expect(find('.not-assigned').length).toBe(0);
+  });
+  it('should show "not assigned" if no legacy contact', async () => {
+    const { find } = await shallow.render();
+    expect(find('.legacy-contact-name')[0].nativeElement.innerText).toContain(
+      'not assigned'
+    );
+    expect(find('.legacy-contact-email')[0].nativeElement.innerText).toContain(
+      'not assigned'
+    );
+    expect(find('.not-assigned').length).toBe(2);
+  });
+  it('should show an error message if there was an error fetching legacy contact', async () => {
+    MockDirectiveRepo.throwError = true;
+    const { find } = await shallow.render();
+    expect(find('.legacy-contact-name').length).toBe(0);
+    expect(find('.legacy-contact-email').length).toBe(0);
+    expect(find('.error').length).toBe(1);
+  });
+});

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.ts
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.ts
@@ -1,0 +1,28 @@
+/* @format */
+import { Component, OnInit } from '@angular/core';
+import { LegacyContact } from '@models/directive';
+import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
+
+@Component({
+  selector: 'pr-legacy-contact-display',
+  templateUrl: './legacy-contact-display.component.html',
+  styleUrls: ['./legacy-contact-display.component.scss'],
+})
+export class LegacyContactDisplayComponent implements OnInit {
+  public legacyContact: LegacyContact;
+  public error: boolean = false;
+
+  constructor(protected account: AccountService, protected api: ApiService) {}
+
+  public async ngOnInit() {
+    try {
+      this.legacyContact = await this.api.directive.getLegacyContact(
+        this.account.getAccount()
+      );
+    } catch {
+      this.error = true;
+    }
+  }
+}

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.stories.ts
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.stories.ts
@@ -1,0 +1,84 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { DirectiveModule } from '../../directive.module';
+import { MockAccountService } from '../directive-display/test-utils';
+import { MockDirectiveRepo, MockApiService } from './test-utils';
+import { LegacyContactDisplayComponent } from './legacy-contact-display.component';
+
+type Story = StoryObj<LegacyContactDisplayComponent>;
+
+const meta: Meta<LegacyContactDisplayComponent> = {
+  title: 'Legacy Contact Display',
+  component: LegacyContactDisplayComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [],
+      imports: [DirectiveModule, HttpClientTestingModule],
+      providers: [
+        {
+          provide: AccountService,
+          useClass: MockAccountService,
+        },
+        {
+          provide: ApiService,
+          useClass: MockApiService,
+        },
+      ],
+    }),
+  ],
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'archiveSettingsDesktop',
+    },
+  },
+};
+export default meta;
+
+interface StoryArgs {
+  name?: string;
+  email?: string;
+  hasLegacyContact?: boolean;
+  throwError?: boolean;
+}
+
+const StoryTemplate: (a: StoryArgs) => Story = (args: StoryArgs) => {
+  return {
+    render: () => {
+      MockDirectiveRepo.reset();
+      if (args.hasLegacyContact) {
+        MockDirectiveRepo.legacyContactName = args.name;
+        MockDirectiveRepo.legacyContactEmail = args.email;
+      }
+      MockDirectiveRepo.throwError = !!args.throwError;
+      return {};
+    },
+    moduleMetadata: {
+      providers: [
+        {
+          provide: '__force_rerender_on_propschange__',
+          useValue: JSON.stringify(args),
+        },
+      ],
+    },
+  };
+};
+
+export const Default: Story = StoryTemplate({
+  hasLegacyContact: false,
+  throwError: false,
+});
+
+export const WithLegacyContact: Story = StoryTemplate({
+  name: 'Test User',
+  email: 'email@example.com',
+  hasLegacyContact: true,
+  throwError: false,
+});
+
+export const ApiError: Story = StoryTemplate({
+  throwError: true,
+});

--- a/src/app/directive/components/legacy-contact-display/test-utils.ts
+++ b/src/app/directive/components/legacy-contact-display/test-utils.ts
@@ -5,11 +5,17 @@ export class MockDirectiveRepo {
   public static legacyContactName: string;
   public static legacyContactEmail: string;
   public static throwError: boolean = false;
+  public static savedLegacyContact: LegacyContact;
+  public static createdLegacyContact: boolean;
+  public static updatedLegacyContact: boolean;
 
   public static reset(): void {
     MockDirectiveRepo.legacyContactEmail = undefined;
     MockDirectiveRepo.legacyContactName = undefined;
     MockDirectiveRepo.throwError = false;
+    MockDirectiveRepo.savedLegacyContact = undefined;
+    MockDirectiveRepo.createdLegacyContact = false;
+    MockDirectiveRepo.updatedLegacyContact = false;
   }
 
   public async getLegacyContact(_account: AccountVO): Promise<LegacyContact> {
@@ -26,6 +32,37 @@ export class MockDirectiveRepo {
       name: MockDirectiveRepo.legacyContactName,
       email: MockDirectiveRepo.legacyContactEmail,
     };
+  }
+
+  public async createLegacyContact(
+    legacyContact: LegacyContact
+  ): Promise<LegacyContact> {
+    if (MockDirectiveRepo.throwError) {
+      throw new Error('Forced Unit Testing Error');
+    }
+    MockDirectiveRepo.savedLegacyContact = {
+      legacyContactId: 'test-id',
+      name: legacyContact.name,
+      email: legacyContact.email,
+    };
+    MockDirectiveRepo.createdLegacyContact = true;
+    return Object.assign({}, MockDirectiveRepo.savedLegacyContact);
+  }
+
+  public async updateLegacyContact(
+    legacyContact: LegacyContact
+  ): Promise<LegacyContact> {
+    if (MockDirectiveRepo.throwError) {
+      throw new Error('Forced Unit Testing Error');
+    }
+    MockDirectiveRepo.savedLegacyContact = Object.assign(
+      {
+        legacyContactId: 'test-id',
+      },
+      legacyContact
+    );
+    MockDirectiveRepo.updatedLegacyContact = true;
+    return Object.assign({}, MockDirectiveRepo.savedLegacyContact);
   }
 }
 

--- a/src/app/directive/components/legacy-contact-display/test-utils.ts
+++ b/src/app/directive/components/legacy-contact-display/test-utils.ts
@@ -1,0 +1,34 @@
+import { AccountVO } from '@models/account-vo';
+import { LegacyContact } from '@models/directive';
+
+export class MockDirectiveRepo {
+  public static legacyContactName: string;
+  public static legacyContactEmail: string;
+  public static throwError: boolean = false;
+
+  public static reset(): void {
+    MockDirectiveRepo.legacyContactEmail = undefined;
+    MockDirectiveRepo.legacyContactName = undefined;
+    MockDirectiveRepo.throwError = false;
+  }
+
+  public async getLegacyContact(_account: AccountVO): Promise<LegacyContact> {
+    if (MockDirectiveRepo.throwError) {
+      throw new Error('Forced Unit Testing Error');
+    }
+    if (
+      !MockDirectiveRepo.legacyContactName &&
+      !MockDirectiveRepo.legacyContactEmail
+    ) {
+      return;
+    }
+    return {
+      name: MockDirectiveRepo.legacyContactName,
+      email: MockDirectiveRepo.legacyContactEmail,
+    };
+  }
+}
+
+export class MockApiService {
+  public directive = new MockDirectiveRepo();
+}

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.html
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.html
@@ -1,0 +1,52 @@
+<!-- @format -->
+<div>
+  <div class="panel-title">Designate a Legacy Contact</div>
+  <p>
+    Who will reach out to Permanent to let us know of your death or permanent
+    incapacitation? This person, your Legacy Contact, will activate your
+    Permanent Legacy Plan. Your Legacy Contact will receive an email with
+    instructions from Permanent, but they are not required to create an account.
+    However, we strongly recommend that you also discuss your Legacy Plan with
+    this person.
+  </p>
+  <div class="legacy-contact-form-section">
+    <label for="legacy-contact-name"
+      ><strong>Legacy Contact Name</strong></label
+    >
+    <input
+      [(ngModel)]="name"
+      class="legacy-contact-name input form-control"
+      id="legacy-contact-name"
+      type="text"
+      [attr.disabled]="waiting || null"
+      required
+      placeholder="Legacy Contact Name"
+    />
+  </div>
+  <div class="legacy-contact-form-section">
+    <label for="legacy-contact-name"
+      ><strong>Legacy Contact Email</strong></label
+    >
+    <input
+      [(ngModel)]="email"
+      class="legacy-contact-email input form-control"
+      type="email"
+      [attr.disabled]="waiting || null"
+      required
+      placeholder="Legacy Contact Email"
+    />
+  </div>
+  <small
+    >Permanent will send an automatic email to your Legacy Contact to inform
+    them that they have been designated to activate your Account Legacy Plan,
+    alongside instructions on how to do so. However, we strongly recommend that
+    you also discuss your Legacy Plan with this person.</small
+  >
+  <button
+    class="save-btn btn btn-primary"
+    [disabled]="waiting || !name || !email || null"
+    (click)="saveLegacyContact()"
+  >
+    Save Legacy Contact
+  </button>
+</div>

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.scss
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.scss
@@ -1,0 +1,11 @@
+/* @format */
+@import '../directive-edit/directive-edit.component.scss';
+
+.legacy-contact-form-section {
+  @extend .steward-email-section;
+  & > label {
+    flex-shrink: 0;
+    margin: auto;
+    margin-right: 1em;
+  }
+}

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.spec.ts
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.spec.ts
@@ -1,0 +1,214 @@
+/* @format */
+import { Type, DebugElement } from '@angular/core';
+import { Shallow } from 'shallow-render';
+import { QueryMatch } from 'shallow-render/dist/lib/models/query-match';
+import { LegacyContactEditComponent } from './legacy-contact-edit.component';
+import { DirectiveModule } from '../../directive.module';
+import { LegacyContact } from '@models/directive';
+import { ApiService } from '@shared/services/api/api.service';
+import { MockDirectiveRepo } from '../legacy-contact-display/test-utils';
+import { MessageService } from '@shared/services/message/message.service';
+import { MockMessageService } from '../directive-edit/test-utils';
+
+type Find = (
+  cssOrDirective: string | Type<any>,
+  options?: {
+    query?: string;
+  }
+) => QueryMatch<DebugElement>;
+
+class MockApiService {
+  public directive = new MockDirectiveRepo();
+}
+
+describe('LegacyContactEditComponent', () => {
+  let shallow: Shallow<LegacyContactEditComponent>;
+
+  const fillOutForm = (find: Find, email: string, name: string) => {
+    const emailInput = find('.legacy-contact-email')[0]
+      .nativeElement as HTMLInputElement;
+    const nameInput = find('.legacy-contact-name')[0]
+      .nativeElement as HTMLTextAreaElement;
+
+    emailInput.value = email;
+    emailInput.dispatchEvent(new Event('input'));
+    nameInput.value = name;
+    nameInput.dispatchEvent(new Event('input'));
+  };
+
+  beforeEach(() => {
+    shallow = new Shallow(
+      LegacyContactEditComponent,
+      DirectiveModule
+    ).provideMock(
+      {
+        provide: ApiService,
+        useClass: MockApiService,
+      },
+      {
+        provide: MessageService,
+        useClass: MockMessageService,
+      }
+    );
+    MockDirectiveRepo.reset();
+  });
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+    expect(instance).toBeTruthy();
+  });
+
+  it('should be able to fill out legacy contact form', async () => {
+    const { instance, find } = await shallow.render();
+    expect(find('.legacy-contact-name').length).toBe(1);
+    expect(find('.legacy-contact-email').length).toBe(1);
+
+    fillOutForm(find, 'test@example.com', 'Unit Testing');
+
+    expect(instance.name).toBe('Unit Testing');
+    expect(instance.email).toBe('test@example.com');
+  });
+
+  it('should be able to save a legacy contact', async () => {
+    const { instance, find, fixture } = await shallow.render();
+
+    fillOutForm(find, 'save@example.com', 'Save Test');
+
+    expect(find('.save-btn').length).toBe(1);
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+
+    expect(find('*[disabled]').length).toBe(3);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(find('*[disabled]').length).toBe(0);
+
+    expect(MockDirectiveRepo.savedLegacyContact.email).toBe('save@example.com');
+    expect(MockDirectiveRepo.savedLegacyContact.name).toBe('Save Test');
+    expect(MockDirectiveRepo.createdLegacyContact).toBeTrue();
+  });
+
+  it('should be able to have existing legacy contact data passed in', async () => {
+    const legacyContact: LegacyContact = {
+      name: 'Existing Contact',
+      email: 'existing@example.com',
+    };
+    const { instance } = await shallow.render({
+      bind: {
+        legacyContact,
+      },
+    });
+
+    expect(instance.email).toBe('existing@example.com');
+    expect(instance.name).toBe('Existing Contact');
+  });
+
+  it('should make an update call if the legacy contact already exists', async () => {
+    const legacyContact: LegacyContact = {
+      name: 'Existing Contact',
+      email: 'existing@example.com',
+    };
+    const { instance, find, fixture } = await shallow.render({
+      bind: {
+        legacyContact,
+      },
+    });
+
+    fillOutForm(find, 'existing@example.com', 'Existing Updated Contact');
+
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(MockDirectiveRepo.savedLegacyContact.name).toBe(
+      'Existing Updated Contact'
+    );
+    expect(MockDirectiveRepo.createdLegacyContact).toBeFalse();
+    expect(MockDirectiveRepo.updatedLegacyContact).toBeTrue();
+  });
+
+  it('should handle API errors on creation', async () => {
+    MockDirectiveRepo.throwError = true;
+    const { instance, find, fixture } = await shallow.render();
+
+    fillOutForm(find, 'error@example.com', 'Throw Error');
+
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(MockMessageService.errorShown).toBeTrue();
+    expect(MockDirectiveRepo.savedLegacyContact).toBeUndefined();
+  });
+
+  it('should handle API errors on editing', async () => {
+    MockDirectiveRepo.throwError = true;
+    const legacyContact: LegacyContact = {
+      name: 'Test',
+      email: 'test@example.com',
+    };
+    const { instance, find, fixture } = await shallow.render({
+      bind: {
+        legacyContact,
+      },
+    });
+
+    fillOutForm(find, 'error@example.com', 'Throw Error');
+
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(MockMessageService.errorShown).toBeTrue();
+    expect(MockDirectiveRepo.savedLegacyContact).toBeUndefined();
+  });
+
+  it('should emit an output after saving (creation)', async () => {
+    const { instance, find, fixture, outputs } = await shallow.render();
+
+    fillOutForm(find, 'output@example.com', 'Test Output');
+
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(outputs.savedLegacyContact.emit).toHaveBeenCalled();
+  });
+
+  it('should emit an output after saving (update)', async () => {
+    const { instance, find, fixture, outputs } = await shallow.render({
+      bind: {
+        legacyContact: {
+          name: 'Test Output',
+          email: 'output@example.com',
+        },
+      },
+    });
+
+    fillOutForm(find, 'output@example.com', 'Test Update Output');
+
+    find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(outputs.savedLegacyContact.emit).toHaveBeenCalled();
+  });
+
+  it('should not allow the form to submit until all fields are filled out', async () => {
+    const { find, fixture } = await shallow.render();
+
+    expect(find('.save-btn[disabled]').length).toBe(1);
+
+    fillOutForm(find, '', 'Test No Submit');
+    fixture.detectChanges();
+    expect(find('.save-btn[disabled]').length).toBe(1);
+
+    fillOutForm(find, 'no-submit@example.com', '');
+    fixture.detectChanges();
+    expect(find('.save-btn[disabled]').length).toBe(1);
+
+    fillOutForm(find, 'submit@example.com', 'Submit Now Works');
+    fixture.detectChanges();
+    expect(find('.save-btn[disabled]').length).toBe(0);
+  });
+});

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.ts
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.ts
@@ -1,0 +1,54 @@
+/* @format */
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { LegacyContact } from '@models/directive';
+import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
+
+@Component({
+  selector: 'pr-legacy-contact-edit',
+  templateUrl: './legacy-contact-edit.component.html',
+  styleUrls: ['./legacy-contact-edit.component.scss'],
+})
+export class LegacyContactEditComponent implements OnInit {
+  @Input() public legacyContact: LegacyContact;
+  @Output() public savedLegacyContact = new EventEmitter<LegacyContact>();
+  public name: string;
+  public email: string;
+  public waiting = false;
+
+  constructor(private api: ApiService, private message: MessageService) {}
+
+  ngOnInit(): void {
+    this.name = this.legacyContact?.name;
+    this.email = this.legacyContact?.email;
+  }
+
+  public async saveLegacyContact() {
+    this.waiting = true;
+    try {
+      let returnedLegacyContact: LegacyContact;
+      if (this.isUpdating()) {
+        returnedLegacyContact = await this.api.directive.updateLegacyContact({
+          name: this.name,
+          email: this.email,
+        });
+      } else {
+        returnedLegacyContact = await this.api.directive.createLegacyContact({
+          name: this.name,
+          email: this.email,
+        });
+      }
+      this.savedLegacyContact.emit(returnedLegacyContact);
+    } catch {
+      this.message.showError(
+        "An error occured when saving your account's Legacy Contact. Please try again."
+      );
+    } finally {
+      this.waiting = false;
+    }
+  }
+
+  protected isUpdating(): boolean {
+    return !!(this.legacyContact?.name && this.legacyContact?.email);
+  }
+}

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.stories.ts
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.stories.ts
@@ -1,0 +1,112 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { DirectiveModule } from '../../directive.module';
+import { MockAccountService } from '../directive-display/test-utils';
+import { MockDirectiveRepo } from '../legacy-contact-display/test-utils';
+import { LegacyContactEditComponent } from './legacy-contact-edit.component';
+import { MessageService } from '@shared/services/message/message.service';
+import { LegacyContact } from '@models/directive';
+import { action } from '@storybook/addon-actions';
+
+type Story = StoryObj<LegacyContactEditComponent>;
+
+const savedAction = action('savedLegacyContact');
+const errorAction = action('Error Message in UI');
+
+class MockApiService {
+  public directive = new MockDirectiveRepo();
+}
+
+class MockMessageService {
+  public showError(err: string): void {
+    errorAction(err);
+  }
+}
+
+const meta: Meta<LegacyContactEditComponent> = {
+  title: 'Legacy Contact Edit',
+  component: LegacyContactEditComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [],
+      imports: [DirectiveModule, HttpClientTestingModule],
+      providers: [
+        {
+          provide: AccountService,
+          useClass: MockAccountService,
+        },
+        {
+          provide: ApiService,
+          useClass: MockApiService,
+        },
+        {
+          provide: MessageService,
+          useClass: MockMessageService,
+        },
+      ],
+    }),
+  ],
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'archiveSettingsDesktop',
+    },
+  },
+};
+export default meta;
+
+interface StoryArgs {
+  editing?: boolean;
+  legacyContact?: LegacyContact;
+  throwError?: boolean;
+}
+
+const StoryTemplate: (a: StoryArgs) => Story = (args: StoryArgs) => {
+  return {
+    render: () => {
+      MockDirectiveRepo.reset();
+      MockDirectiveRepo.throwError = !!args.throwError;
+      if (args.editing) {
+        return {
+          props: {
+            legacyContact: args.legacyContact,
+            savedLegacyContact: savedAction,
+          },
+        };
+      }
+      return {
+        props: {
+          savedLegacyContact: savedAction,
+        },
+      };
+    },
+    moduleMetadata: {
+      providers: [
+        {
+          provide: '__force_rerender_on_propschange__',
+          useValue: JSON.stringify(args),
+        },
+      ],
+    },
+  };
+};
+
+export const Creating: Story = StoryTemplate({
+  throwError: false,
+});
+
+export const Editing: Story = StoryTemplate({
+  editing: true,
+  legacyContact: {
+    name: 'Test Example',
+    email: 'test@example.com',
+  },
+  throwError: false,
+});
+
+export const ApiError: Story = StoryTemplate({
+  throwError: true,
+});

--- a/src/app/directive/directive.module.ts
+++ b/src/app/directive/directive.module.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DirectiveDisplayComponent } from './components/directive-display/directive-display.component';
@@ -13,18 +14,21 @@ import { DirectiveEditComponent } from './components/directive-edit/directive-ed
 import { FormsModule } from '@angular/forms';
 import { DirectiveDialogComponent } from './components/directive-dialog/directive-dialog.component';
 import { LegacyContactDisplayComponent } from './components/legacy-contact-display/legacy-contact-display.component';
+import { LegacyContactEditComponent } from './components/legacy-contact-edit/legacy-contact-edit.component';
 @NgModule({
   exports: [
     DirectiveDisplayComponent,
     DirectiveEditComponent,
     DirectiveDialogComponent,
     LegacyContactDisplayComponent,
+    LegacyContactEditComponent,
   ],
   declarations: [
     DirectiveDisplayComponent,
     DirectiveEditComponent,
     DirectiveDialogComponent,
     LegacyContactDisplayComponent,
+    LegacyContactEditComponent,
   ],
   imports: [CommonModule, FontAwesomeModule, FormsModule],
 })

--- a/src/app/directive/directive.module.ts
+++ b/src/app/directive/directive.module.ts
@@ -12,16 +12,19 @@ import {
 import { DirectiveEditComponent } from './components/directive-edit/directive-edit.component';
 import { FormsModule } from '@angular/forms';
 import { DirectiveDialogComponent } from './components/directive-dialog/directive-dialog.component';
+import { LegacyContactDisplayComponent } from './components/legacy-contact-display/legacy-contact-display.component';
 @NgModule({
   exports: [
     DirectiveDisplayComponent,
     DirectiveEditComponent,
     DirectiveDialogComponent,
+    LegacyContactDisplayComponent,
   ],
   declarations: [
     DirectiveDisplayComponent,
     DirectiveEditComponent,
     DirectiveDialogComponent,
+    LegacyContactDisplayComponent,
   ],
   imports: [CommonModule, FontAwesomeModule, FormsModule],
 })

--- a/src/app/models/directive.ts
+++ b/src/app/models/directive.ts
@@ -44,6 +44,8 @@ export class Directive implements DirectiveData {
 }
 
 export interface LegacyContact {
+  legacyContactId?: string;
+  accountId?: string;
   name: string;
   email: string;
 }

--- a/src/app/public/components/public-search-results/public-search-results.component.spec.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.spec.ts
@@ -6,6 +6,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PublicSearchResultsComponent } from './public-search-results.component';
 import { SearchService } from '@search/services/search.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('PublicSearchResultsComponent', () => {
   let component: PublicSearchResultsComponent;
@@ -30,10 +31,9 @@ describe('PublicSearchResultsComponent', () => {
         Router,
         SearchService,
         Location,
-        HttpClient,
-        HttpHandler,
         DataService,
       ],
+      imports: [HttpClientTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PublicSearchResultsComponent);

--- a/src/app/shared/services/api/directive.repo.ts
+++ b/src/app/shared/services/api/directive.repo.ts
@@ -1,3 +1,4 @@
+/* @format */
 import {
   AccountVO,
   ArchiveVO,
@@ -21,6 +22,20 @@ export class DirectiveRepo extends BaseRepo {
   }
 
   public async getLegacyContact(account: AccountVO): Promise<LegacyContact> {
+    console.warn('Legacy Contact API is currently unimplemented.');
+    return {} as LegacyContact;
+  }
+
+  public async createLegacyContact(
+    legacyContact: LegacyContact
+  ): Promise<LegacyContact> {
+    console.warn('Legacy Contact API is currently unimplemented.');
+    return {} as LegacyContact;
+  }
+
+  public async updateLegacyContact(
+    legacyContact: LegacyContact
+  ): Promise<LegacyContact> {
     console.warn('Legacy Contact API is currently unimplemented.');
     return {} as LegacyContact;
   }


### PR DESCRIPTION
This PR adds the components that will make up the Legacy Contact modal, as well as corresponding Storybook stories to test them with. The final flow that connects the two components together, fully implemented API code, and finally linking the modal in the web app's UI will be finished in future tickets.

Because Storybook was updated in between this ticket and the previous one, the way the stories are written in this ticket differ from previous stories written for the web-app.

Resolves PER-9146 and PER-9147.

**Steps to Test:**
1. Run `npm run storybook`
2. View the Legacy Contact Display / Legacy Contact Edit stories
3. Play around with the various stories.