### PR TITLE
Log out user on invalid auth token

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -20,6 +20,7 @@ import {
   AccessRoleType,
   checkMinimumAccess,
 } from '@models/access-role';
+import { HttpV2Service } from '../http-v2/http-v2.service';
 
 import * as Sentry from '@sentry/browser';
 
@@ -53,7 +54,8 @@ export class AccountService {
     private storage: StorageService,
     private cookies: CookieService,
     private dialog: Dialog,
-    private router: Router
+    private router: Router,
+    private httpv2: HttpV2Service
   ) {
     const cachedAccount = this.storage.local.get(ACCOUNT_KEY);
     const cachedArchive = this.storage.local.get(ARCHIVE_KEY);
@@ -73,6 +75,12 @@ export class AccountService {
       this.setRootFolder(new FolderVO(cachedRoot));
       this.refreshRoot();
     }
+
+    this.httpv2.tokenExpired.subscribe(() => {
+      this.logOut().then(() => {
+        window.location.reload();
+      });
+    });
   }
 
   public setAccount(newAccount: AccountVO) {

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { HttpClient } from '@angular/common/http';
 import {
   HttpClientTestingModule,
@@ -194,5 +195,30 @@ describe('HttpV2Service', () => {
 
     const req = httpTestingController.expectOne(apiUrl('/api/v2/health'));
     expect(req.request.body.csrf).toBeUndefined();
+  });
+
+  it('should emit an event on a 401 Unauthorized response code', (done) => {
+    let expirationObserved = false;
+    const subscription = service.tokenExpired.subscribe(() => {
+      expirationObserved = true;
+    });
+
+    service
+      .get('/api/v2/health', {}, HealthResponse)
+      .toPromise()
+      .catch(() => {
+        expect(expirationObserved).toBeTrue();
+        subscription.unsubscribe();
+        done();
+      });
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+    request.flush(
+      { error: 'error message' },
+      {
+        status: 401,
+        statusText: 'unauthorized',
+      }
+    );
   });
 });


### PR DESCRIPTION
Currently on our dev instance of FusionAuth, auth tokens only last for an hour with no way of being refreshed. This leads to tokens for calling Stela endpoints expiring pretty quickly and before the PHP session expires, leading to errors in Stela API calls. Fix this by logging out the user when the Auth Token expires.

This is accomplished by having an event fire off when the HttpV2Service receives an HTTP 401 status code. The AccountService is subscribed to this event and will log out the user and refresh the page to boot them back to the log in screen. (Originally I intended on just manually navigating the user back to `/app/auth/login`, but I think there's a conflict with our modal system or something that makes this not work. Perhaps we can use an auth guard???)

**Steps 2 Test:**
1. Log in to the application with an existing account with MFA disabled. If you're already logged in, log out and log back in to ensure that you initially have a valid auth token loaded in.
2. Go into the Legacy Planning UI by clicking the "Archive Settings" dialog and then adding `#legacy-planning` to the end of the URL.
3. Verify that the Legacy Planning UI works, no errors show up in the UI, and that the user isn't forcibly logged out with successful requests.
4. Go into your browser dev tools and modify the `AUTH_TOKEN` key in LocalStorage.
    * Alternatively, run this in your dev console:
   * `window.localStorage.setItem('AUTH_TOKEN', 'invalid_token');`
5. Refresh the page so the Auth Token is reloaded from LocalStorage
6. If you navigated away from the Legacy Planning UI, navigate back to it.
7.  Verify that the user is logged out shortly after the modal loads.
