### PR TITLE
Implement legacy contact API

### DIFF
--- a/src/app/directive/components/directive-display/directive-display.component.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { AccountVO, Directive } from '@models/index';
+import { Directive } from '@models/index';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 
@@ -34,9 +34,7 @@ export class DirectiveDisplayComponent implements OnInit {
 
   protected async getLegacyContact(): Promise<void> {
     try {
-      const legacyContact = await this.api.directive.getLegacyContact(
-        this.account.getAccount()
-      );
+      const legacyContact = await this.api.directive.getLegacyContact();
       if (!legacyContact?.name || !legacyContact?.email) {
         this.noPlan = true;
       }

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.ts
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.ts
@@ -18,9 +18,7 @@ export class LegacyContactDisplayComponent implements OnInit {
 
   public async ngOnInit() {
     try {
-      this.legacyContact = await this.api.directive.getLegacyContact(
-        this.account.getAccount()
-      );
+      this.legacyContact = await this.api.directive.getLegacyContact();
     } catch {
       this.error = true;
     }

--- a/src/app/shared/services/api/directive.repo.spec.ts
+++ b/src/app/shared/services/api/directive.repo.spec.ts
@@ -121,4 +121,91 @@ describe('DirectiveRepo', () => {
       repo.update({ note: 'New Note' } as DirectiveUpdateRequest)
     ).toBeRejected();
   });
+
+  it('can get a legacy contact', (done) => {
+    repo.getLegacyContact().then((legacyContact) => {
+      expect(legacyContact.legacyContactId).toBe('test-id');
+      expect(legacyContact.accountId).toBe('test-accountid');
+      expect(legacyContact.name).toBe('Test Legacy Contact');
+      expect(legacyContact.email).toBe('test@example.com');
+      done();
+    });
+
+    const req = httpMock.expectOne(apiUrl('/v2/legacy-contact'));
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.has('Authorization')).toBeTrue();
+    req.flush([
+      {
+        legacyContactId: 'test-id',
+        accountId: 'test-accountid',
+        name: 'Test Legacy Contact',
+        email: 'test@example.com',
+      },
+    ]);
+  });
+
+  it('can create a legacy contact', (done) => {
+    repo
+      .createLegacyContact({
+        name: 'New User',
+        email: 'new@example.com',
+      })
+      .then((legacyContact) => {
+        expect(legacyContact.legacyContactId).toBe('test-id');
+        expect(legacyContact.accountId).toBe('test-accountid');
+        expect(legacyContact.name).toBe('New User');
+        expect(legacyContact.email).toBe('new@example.com');
+        done();
+      });
+
+    const req = httpMock.expectOne(apiUrl('/v2/legacy-contact'));
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.has('Authorization')).toBeTrue();
+    expect(req.request.body.name).toBe('New User');
+    expect(req.request.body.email).toBe('new@example.com');
+    req.flush({
+      legacyContactId: 'test-id',
+      accountId: 'test-accountid',
+      name: 'New User',
+      email: 'new@example.com',
+    });
+  });
+
+  it('can update a legacy contact', (done) => {
+    repo
+      .updateLegacyContact({
+        legacyContactId: 'test-id',
+        name: 'Updated User',
+        email: 'updated@example.com',
+      })
+      .then((legacyContact) => {
+        expect(legacyContact.legacyContactId).toBe('test-id');
+        expect(legacyContact.accountId).toBe('test-accountid');
+        expect(legacyContact.name).toBe('Updated User');
+        expect(legacyContact.email).toBe('updated@example.com');
+        done();
+      });
+
+    const req = httpMock.expectOne(apiUrl('/v2/legacy-contact/test-id'));
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.headers.has('Authorization')).toBeTrue();
+    expect(req.request.body.name).toBe('Updated User');
+    expect(req.request.body.email).toBe('updated@example.com');
+    expect(req.request.body.legacyContactId).toBeUndefined();
+    req.flush({
+      legacyContactId: 'test-id',
+      accountId: 'test-accountid',
+      name: 'Updated User',
+      email: 'updated@example.com',
+    });
+  });
+
+  it('will throw an error if no legacyContactId is specified in update', async () => {
+    await expectAsync(
+      repo.updateLegacyContact({
+        name: 'throw error',
+        email: 'error@example.com',
+      })
+    ).toBeRejected();
+  });
 });

--- a/src/app/shared/services/api/directive.repo.ts
+++ b/src/app/shared/services/api/directive.repo.ts
@@ -1,6 +1,5 @@
 /* @format */
 import {
-  AccountVO,
   ArchiveVO,
   DirectiveCreateRequest,
   LegacyContact,
@@ -21,25 +20,6 @@ export class DirectiveRepo extends BaseRepo {
     ).toPromise();
   }
 
-  public async getLegacyContact(account: AccountVO): Promise<LegacyContact> {
-    console.warn('Legacy Contact API is currently unimplemented.');
-    return {} as LegacyContact;
-  }
-
-  public async createLegacyContact(
-    legacyContact: LegacyContact
-  ): Promise<LegacyContact> {
-    console.warn('Legacy Contact API is currently unimplemented.');
-    return {} as LegacyContact;
-  }
-
-  public async updateLegacyContact(
-    legacyContact: LegacyContact
-  ): Promise<LegacyContact> {
-    console.warn('Legacy Contact API is currently unimplemented.');
-    return {} as LegacyContact;
-  }
-
   public async create(directive: DirectiveCreateRequest): Promise<Directive> {
     return getFirst(
       this.httpV2.post('/v2/directive', directive, Directive)
@@ -57,5 +37,53 @@ export class DirectiveRepo extends BaseRepo {
     return getFirst(
       this.httpV2.put(`/v2/directive/${directive.directiveId}`, data, Directive)
     ).toPromise();
+  }
+
+  public async getLegacyContact(): Promise<LegacyContact> {
+    return getFirst(
+      this.httpV2.get('/v2/legacy-contact', {}, LegacyContactClass)
+    ).toPromise();
+  }
+
+  public async createLegacyContact(
+    legacyContact: LegacyContact
+  ): Promise<LegacyContact> {
+    return getFirst(
+      this.httpV2.post('/v2/legacy-contact', legacyContact, LegacyContactClass)
+    ).toPromise();
+  }
+
+  public async updateLegacyContact(
+    legacyContact: LegacyContact
+  ): Promise<LegacyContact> {
+    if (!legacyContact.legacyContactId) {
+      throw new Error(
+        'legacyContactId is required to update an existing Legacy Contact'
+      );
+    }
+    const data = {
+      name: legacyContact.name,
+      email: legacyContact.email,
+    };
+    return getFirst(
+      this.httpV2.put(
+        `/v2/legacy-contact/${legacyContact.legacyContactId}`,
+        data,
+        LegacyContactClass
+      )
+    ).toPromise();
+  }
+}
+
+class LegacyContactClass implements LegacyContact {
+  public name: string;
+  public email: string;
+  public legacyContactId: string;
+  public accountId: string;
+
+  constructor(props: Object) {
+    for (const prop in props) {
+      this[prop] = props[prop];
+    }
   }
 }


### PR DESCRIPTION
Previously, the Legacy Contact API was stubbed out since it didn't need to be called for Storybook testing. This PR implements methods in the DirectiveRepo of the ApiService that lets us hit the Legacy Contact endpoints of stela.

Before the API was implemented in Stela, it was assumed that we might have to pass in the AccountID when calling these endpoints. Ultimately the real endpoints are able to get the currently authenticated account so this is unnecessary. As a result, we don't need to pass in an AccountVO on any Legacy Contact API methods and so previous calls to the stubbed out API methods that assumed this have been updated to remove AccountVO parameters.

A local helper class, `LegacyContactClass` is used by the DirectiveRepo to construct response objects, although since they implement the interface they are able to be passed around in place of the `LegacyContact` type.

Resolves PER-9162: Implement Legacy Contact API

**How to Test**
Since the Legacy Contact modal is not fully implemented in the UI yet, the only way to test this is to write code to call these endpoints. I ended up sticking this code in the `ngOnInit()` method of the AccountSettingsComponent to test it out, opening up the dialog in the UI and refreshing to verify that the calls were all successful:
```ts
this.api.directive.getLegacyContact().then((contact) => {
      const legacyContact = contact;
      console.log(legacyContact);
      if (contact) {
        legacyContact.name = 'Test Updated User';
        this.api.directive.updateLegacyContact(legacyContact).then((c) => {
          console.log('Updated Legacy Contact: ', c);
        });
      } else {
        this.api.directive
          .createLegacyContact({
            name: 'Test User',
            email: 'natalie+legacycontact@permanent.org',
          })
          .then((c) => {
            console.log('Created Legacy Contact: ', c);
          });
      }
    });
```
I then checked in my browser's dev tools to verify the `console.log` statements. I also manually verified the network requests: On the first page load I get a successful GET call to `/api/v2/legacy-contact`, then a successful POST call to the same endpoint. On the second page load, I get another successful GET call and then a successful PUT call to `api/v2/legacy-contact/{insert-id-here}`.

(Also you can look at the unit tests and compare them to the [API spec](https://github.com/PermanentOrg/stela/blob/main/API.md) if that helps)