### PR TITLE
Add optional STELA_DOMAIN secret

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -29,6 +29,7 @@ jobs:
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
           FEATURED_ARCHIVES: ${{ secrets.FEATURED_ARCHIVES_DEV }}
           RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
+          STELA_DOMAIN: ${{ secrets.STELA_DOMAIN_DEV }}
         run: npm run build:dev
 
       - name: Archive `dist`

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -25,6 +25,7 @@ jobs:
           STRIPE_API_KEY: ${{ secrets.STRIPE_LIVE_KEY }}
           RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY }}
           FUSIONAUTH_HOST: ${{ secrets.FUSIONAUTH_PROD_HOST }}
+          STELA_DOMAIN: ${{ secrets.STELA_DOMAIN_PROD }}
         run: npm run build
       - name: Archive `dist`
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -25,6 +25,7 @@ jobs:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_STAGING }}
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
           RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
+          STELA_DOMAIN: ${{ secrets.STELA_DOMAIN_STAGING }}
         run: npm run build:staging
       - name: Archive `dist`
         uses: actions/upload-artifact@v2

--- a/src/app/shared/services/api/auth.repo.spec.ts
+++ b/src/app/shared/services/api/auth.repo.spec.ts
@@ -111,7 +111,9 @@ describe('AuthRepo', () => {
       )
       .subscribe((response) => {
         expect(response).toEqual(expected);
-        repo.httpV2.get('/v2/health').toPromise();
+        repo.httpV2
+          .get('/v2/health', {}, Object, { useStelaDomain: false })
+          .toPromise();
         const req2 = httpMock.expectOne(`${environment.apiUrl}/v2/health`);
         expect(req2.request.headers.get('Authorization')).toBe(
           'Bearer test_token'

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -156,10 +156,19 @@ export class HttpV2Service {
     endpoint: string,
     options: RequestOptions
   ): string {
-    if (options.useStelaDomain && endpoint.match(/^\/*v2\//)) {
+    if (
+      options.useStelaDomain &&
+      endpoint.match(/^\/*v2\//) &&
+      this.isStelaDomainDefined()
+    ) {
       return this.secrets.get('STELA_DOMAIN') ?? this.apiUrl;
     }
     return this.apiUrl;
+  }
+
+  protected isStelaDomainDefined() {
+    const stelaDomain = this.secrets.get('STELA_DOMAIN') ?? '';
+    return stelaDomain.length > 0;
   }
 
   protected getHeaders(options: RequestOptions) {

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -6,6 +6,7 @@ import { environment } from '@root/environments/environment';
 import { Observable, Subject, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Location } from '@angular/common';
+import { SecretsService } from '../secrets/secrets.service';
 
 const CSRF_KEY = 'CSRF';
 const AUTH_KEY = 'AUTH_TOKEN';
@@ -16,11 +17,13 @@ type ResponseClass<T> = new (data: any) => T;
 interface RequestOptions {
   csrf?: boolean;
   authToken?: boolean;
+  useStelaDomain?: boolean;
 }
 
 const defaultOptions: RequestOptions = {
   csrf: false,
   authToken: true,
+  useStelaDomain: true,
 };
 
 export function getFirst<T>(observable: Observable<T[]>): Observable<T> {
@@ -45,7 +48,11 @@ export class HttpV2Service {
   protected apiUrl = environment.apiUrl;
   protected authToken: string | null;
 
-  constructor(protected http: HttpClient, protected storage: StorageService) {
+  constructor(
+    protected http: HttpClient,
+    protected storage: StorageService,
+    protected secrets: SecretsService
+  ) {
     this.authToken = this.storage.local.get(AUTH_KEY) ?? '';
   }
 
@@ -138,8 +145,21 @@ export class HttpV2Service {
     };
   }
 
-  protected getFullUrl(endpoint: string): string {
-    return Location.joinWithSlash(this.apiUrl, endpoint);
+  protected getFullUrl(endpoint: string, options: RequestOptions): string {
+    return Location.joinWithSlash(
+      this.getRequestDomain(endpoint, options),
+      endpoint
+    );
+  }
+
+  protected getRequestDomain(
+    endpoint: string,
+    options: RequestOptions
+  ): string {
+    if (options.useStelaDomain && endpoint.match(/^\/*v2\//)) {
+      return this.secrets.get('STELA_DOMAIN') ?? this.apiUrl;
+    }
+    return this.apiUrl;
   }
 
   protected getHeaders(options: RequestOptions) {
@@ -183,14 +203,14 @@ export class HttpV2Service {
   ): Observable<unknown> {
     if (method === 'post' || method === 'put') {
       return this.getObservableWithBody(
-        this.getFullUrl(endpoint),
+        this.getFullUrl(endpoint, options),
         options.csrf ? this.appendCsrf(data) : data,
         method,
         options
       );
     }
     return this.getObservableWithNoBody(
-      this.getFullUrl(endpoint),
+      this.getFullUrl(endpoint, options),
       method,
       options
     );

--- a/src/optional-secrets.js
+++ b/src/optional-secrets.js
@@ -13,7 +13,7 @@ const optionalSecrets = [
   },
   {
     name: 'STELA_DOMAIN',
-    default: null,
+    default: '',
   },
 ];
 

--- a/src/optional-secrets.js
+++ b/src/optional-secrets.js
@@ -11,6 +11,10 @@ const optionalSecrets = [
     name: 'FUSIONAUTH_HOST',
     default: 'https://permanent-dev.fusionauth.io',
   },
+  {
+    name: 'STELA_DOMAIN',
+    default: null,
+  },
 ];
 
 module.exports = optionalSecrets;


### PR DESCRIPTION
On local environments, the domain to access Stela endpoints is the same as the standard API. In dev/staging/prod, Stela will live on a different domain and this domain needs to be configured for these different environments. Allow the Stela domain to be configured with a secret, and then make the HttpV2Service use this domain for Stela requests.

One thing that has affected the design of the HttpV2Service is that there are two different types of V2 endpoints we hit: Those on the legacy backend and those on Stela. To avoid messing up any calls to the legacy backend, the HttpV2Service tries to detect that we're hitting Stela with the presence of the `/v2/` in the endpoint path, *and* I've also allowed callers to manually switch off using the Stela domain value just in case.

While this works, it did make me pause and think about how we really want to structure this. I also came up with an alternate idea where Stela paths could be specified with some kind of marker (e.g. calling the endpoint `stela:/directive/archive/{archiveId}`) which sounds somewhat appealing to me as it would make all the stela endpoint calls potentially more readable as a Stela endpoint vs a legacy backend endpoint. But I could also see how it could obfuscate where Stela endpoints actually live. Feel free to discuss in this PR!

PER-9287: Configure web-app with Stela API Domain