### PR TITLE
PER-9235: archive modal sometimes not opening

### DIFF
--- a/src/app/core/components/profile-edit/profile-edit.component.ts
+++ b/src/app/core/components/profile-edit/profile-edit.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Component, OnInit, Inject, AfterViewInit } from '@angular/core';
 import { FolderVO, ArchiveVO, RecordVO } from '@models';
 import {

--- a/src/app/core/components/profile-edit/profile-edit.component.ts
+++ b/src/app/core/components/profile-edit/profile-edit.component.ts
@@ -64,15 +64,16 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
     private message: MessageService,
     private cookies: CookieService
   ) {
+   
+  }
+
+   ngOnInit(): void {
     this.archive = this.account.getArchive();
     this.publicRoot = new FolderVO(this.account.getPublicRoot());
 
     this.profileItems = this.profile.getProfileItemDictionary();
     this.canEdit = this.account.checkMinimumArchiveAccess(AccessRole.Curator);
     this.checkProfilePublic();
-  }
-
-  ngOnInit(): void {
   }
 
   ngAfterViewInit() {

--- a/src/app/core/components/profile-edit/profile-edit.component.ts
+++ b/src/app/core/components/profile-edit/profile-edit.component.ts
@@ -1,18 +1,36 @@
 import { Component, OnInit, Inject, AfterViewInit } from '@angular/core';
 import { FolderVO, ArchiveVO, RecordVO } from '@models';
-import { ProfileItemVOData, FieldNameUI, ProfileItemVODictionary, FieldNameUIShort } from '@models/profile-item-vo';
+import {
+  ProfileItemVOData,
+  FieldNameUI,
+  ProfileItemVODictionary,
+  FieldNameUIShort,
+} from '@models/profile-item-vo';
 import { AccountService } from '@shared/services/account/account.service';
 import { AccessRole } from '@models/access-role';
 import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
 import { ApiService } from '@shared/services/api/api.service';
-import { ArchiveResponse, FolderResponse } from '@shared/services/api/index.repo';
+import {
+  ArchiveResponse,
+  FolderResponse,
+} from '@shared/services/api/index.repo';
 import { MessageService } from '@shared/services/message/message.service';
 import { DIALOG_DATA, DialogRef, Dialog } from '@root/app/dialog/dialog.module';
 import { EditService } from '@core/services/edit/edit.service';
-import { ProfileService, ProfileItemsDataCol, ALWAYS_PUBLIC } from '@shared/services/profile/profile.service';
-import { collapseAnimation, ngIfScaleAnimationDynamic } from '@shared/animations';
+import {
+  ProfileService,
+  ProfileItemsDataCol,
+  ALWAYS_PUBLIC,
+} from '@shared/services/profile/profile.service';
+import {
+  collapseAnimation,
+  ngIfScaleAnimationDynamic,
+} from '@shared/animations';
 import debug from 'debug';
-import { PromptService, READ_ONLY_FIELD } from '@shared/services/prompt/prompt.service';
+import {
+  PromptService,
+  READ_ONLY_FIELD,
+} from '@shared/services/prompt/prompt.service';
 import { Deferred } from '@root/vendor/deferred';
 import { some } from 'lodash';
 import { CookieService } from 'ngx-cookie-service';
@@ -23,7 +41,7 @@ import { copyFromInputElement } from '@shared/utilities/forms';
   selector: 'pr-profile-edit',
   templateUrl: './profile-edit.component.html',
   styleUrls: ['./profile-edit.component.scss'],
-  animations: [ collapseAnimation, ngIfScaleAnimationDynamic ]
+  animations: [collapseAnimation, ngIfScaleAnimationDynamic],
 })
 export class ProfileEditComponent implements OnInit, AfterViewInit {
   archive: ArchiveVO;
@@ -47,7 +65,7 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
     decimal: '.',
     duration: 1,
     suffix: '%',
-    startValue: 0
+    startValue: 0,
   };
 
   private debug = debug('component:profileEdit');
@@ -63,11 +81,9 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
     private prompt: PromptService,
     private message: MessageService,
     private cookies: CookieService
-  ) {
-   
-  }
+  ) {}
 
-   ngOnInit(): void {
+  ngOnInit(): void {
     this.archive = this.account.getArchive();
     this.publicRoot = new FolderVO(this.account.getPublicRoot());
 
@@ -93,8 +109,11 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
     }
 
     try {
-      this.dialog.open('ProfileEditFirstTimeDialogComponent', null, { width: '760px', height: 'auto'});
-    } catch (err) { }
+      this.dialog.open('ProfileEditFirstTimeDialogComponent', null, {
+        width: '760px',
+        height: 'auto',
+      });
+    } catch (err) {}
   }
 
   onDoneClick() {
@@ -106,7 +125,7 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
   }
 
   getProgressTransform() {
-    return `transform: translateX(${(this.totalProgress * 100) - 100}%)`;
+    return `transform: translateX(${this.totalProgress * 100 - 100}%)`;
   }
 
   checkProfilePublic() {
@@ -120,12 +139,22 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
   async chooseBannerPicture() {
     const originalValue = this.publicRoot.thumbArchiveNbr;
     try {
-      const record = await this.folderPicker.chooseRecord(this.account.getPrivateRoot());
+      const record = await this.folderPicker.chooseRecord(
+        this.account.getPrivateRoot()
+      );
       const updateFolder = new FolderVO(this.publicRoot);
       updateFolder.thumbArchiveNbr = record.archiveNbr;
-      await this.api.folder.updateRoot([updateFolder], ['thumbArchiveNbr', 'view', 'viewProperty']);
+      await this.api.folder.updateRoot(
+        [updateFolder],
+        ['thumbArchiveNbr', 'view', 'viewProperty']
+      );
       // borrow thumb URLs from record for now, until they can be regenerated
-      const thumbProps: Array<keyof (ArchiveVO|RecordVO)> = ['thumbURL200', 'thumbURL500', 'thumbURL1000', 'thumbURL2000'];
+      const thumbProps: Array<keyof (ArchiveVO | RecordVO)> = [
+        'thumbURL200',
+        'thumbURL500',
+        'thumbURL1000',
+        'thumbURL2000',
+      ];
       for (const prop of thumbProps) {
         this.publicRoot[prop] = record[prop] as never;
       }
@@ -137,7 +166,12 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
     }
   }
 
-  async onSaveProfileItem(item: ProfileItemVOData, valueKey: ProfileItemsDataCol, newValue: any, refreshArchive = false) {
+  async onSaveProfileItem(
+    item: ProfileItemVOData,
+    valueKey: ProfileItemsDataCol,
+    newValue: any,
+    refreshArchive = false
+  ) {
     const originalValue = item[valueKey];
     item[valueKey] = newValue as never;
     item.isPendingAction = true;
@@ -205,7 +239,11 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
 
   async chooseLocationForItem(item: ProfileItemVOData) {
     try {
-      await this.dialog.open('LocationPickerComponent', { profileItem: item }, { height: 'auto', width: '600px' } );
+      await this.dialog.open(
+        'LocationPickerComponent',
+        { profileItem: item },
+        { height: 'auto', width: '600px' }
+      );
     } finally {
       this.updateProgress();
     }
@@ -213,13 +251,16 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
 
   async onShareClick() {
     const url = `https://${location.host}/p/archive/${this.archive.archiveNbr}/profile`;
-    const fields = [
-      READ_ONLY_FIELD('profileLink', 'Profile link', url)
-    ];
+    const fields = [READ_ONLY_FIELD('profileLink', 'Profile link', url)];
 
     const deferred = new Deferred();
 
-    await this.prompt.prompt(fields, 'Share profile link', deferred.promise, 'Copy link');
+    await this.prompt.prompt(
+      fields,
+      'Share profile link',
+      deferred.promise,
+      'Copy link'
+    );
     const input = this.prompt.getInput('profileLink');
     copyFromInputElement(input);
     deferred.resolve();

--- a/src/app/public/components/public-archive/public-archive.component.html
+++ b/src/app/public/components/public-archive/public-archive.component.html
@@ -45,7 +45,7 @@
                 class="profile-data profile-data-date"
                 *ngIf="hasSingleValueFor('birth_info', 'day1')"
               >
-                on {{ profileItems.birth_info[0]?.day1 | date }}
+                on {{ publicProfileItems.birth_info[0]?.day1 | date }}
               </span>
             </ng-container>
             <ng-container *ngSwitchDefault>
@@ -53,7 +53,7 @@
                 class="profile-data profile-data-date"
                 *ngIf="hasSingleValueFor('established_info', 'day1')"
               >
-                {{ profileItems.established_info[0]?.day1 | date }}
+                {{ publicProfileItems.established_info[0]?.day1 | date }}
               </span>
             </ng-container>
           </ng-container>
@@ -69,7 +69,7 @@
                 class="profile-data profile-data-date"
                 *ngIf="hasSingleValueFor('birth_info', 'locnId1')"
               >
-                {{ (profileItems.birth_info[0].LocnVOs[0] | prLocation).full }}
+                {{ (publicProfileItems.birth_info[0].LocnVOs[0] | prLocation).full }}
               </span>
             </ng-container>
             <ng-container *ngSwitchDefault>
@@ -78,7 +78,7 @@
                 *ngIf="hasSingleValueFor('established_info', 'locnId1')"
               >
                 {{
-                  (profileItems.established_info[0].LocnVOs[0] | prLocation)
+                  (publicProfileItems.established_info[0].LocnVOs[0] | prLocation)
                     .full
                 }}
               </span>
@@ -90,12 +90,12 @@
             class="profile-blurb"
             *ngIf="hasSingleValueFor('blurb', 'string1')"
           >
-            {{ this.profileItems.blurb[0].string1 }}
+            {{ this.publicProfileItems.blurb[0].string1 }}
           </div>
           <div
             class="profile-description"
             *ngIf="hasSingleValueFor('description', 'textData1')"
-            [innerHTML]="this.profileItems.description[0].textData1"
+            [innerHTML]="this.publicProfileItems.description[0].textData1"
           ></div>
         </ng-container>
       </div>

--- a/src/app/public/components/public-archive/public-archive.component.ts
+++ b/src/app/public/components/public-archive/public-archive.component.ts
@@ -23,7 +23,7 @@ import { RouteData } from '@root/app/app.routes';
 export class PublicArchiveComponent implements OnInit, OnDestroy {
   publicRoot: FolderVO;
   archive: ArchiveVO;
-  profileItems: ProfileItemVODictionary = {};
+  publicProfileItems: ProfileItemVODictionary = {};
   description: string;
   socialMedia: Record<string, string> = {};
   searchResults: any[] = [];
@@ -69,7 +69,7 @@ export class PublicArchiveComponent implements OnInit, OnDestroy {
         .subscribe((archive) => (this.archive = archive)),
       this.publicProfile
         .profileItemsDictionary$()
-        .subscribe((items) => (this.profileItems = items)),
+        .subscribe((items) => (this.publicProfileItems = items)),
       this.publicProfile
         .profileItemsDictionary$()
         .subscribe(
@@ -94,7 +94,7 @@ export class PublicArchiveComponent implements OnInit, OnDestroy {
 
   hasSingleValueFor(field: FieldNameUIShort, column: ProfileItemsDataCol) {
     return (
-      this.profileItems[field]?.length && this.profileItems[field][0][column]
+      this.publicProfileItems[field]?.length && this.publicProfileItems[field][0][column]
     );
   }
 

--- a/src/app/public/components/public-profile/public-profile.component.ts
+++ b/src/app/public/components/public-profile/public-profile.component.ts
@@ -14,7 +14,7 @@ import { concat, orderBy } from 'lodash';
 })
 export class PublicProfileComponent implements OnInit, OnDestroy, HasSubscriptions {
   archive: ArchiveVO;
-  profileItems: ProfileItemVODictionary = {};
+  publicProfileItems: ProfileItemVODictionary = {};
   milestones$: Observable<ProfileItemVOData[]>;
 
   subscriptions: Subscription[] = [];
@@ -26,7 +26,7 @@ export class PublicProfileComponent implements OnInit, OnDestroy, HasSubscriptio
   ngOnInit(): void {
     this.subscriptions.push(
       this.publicProfile.archive$().subscribe(archive => this.archive = archive),
-      this.publicProfile.profileItemsDictionary$().subscribe(items => this.profileItems = items)
+      this.publicProfile.profileItemsDictionary$().subscribe(items => this.publicProfileItems = items)
     );
 
     this.milestones$ = this.publicProfile.profileItemsDictionary$().pipe(

--- a/src/app/public/public.routes.ts
+++ b/src/app/public/public.routes.ts
@@ -20,7 +20,7 @@ const publicArchiveResolve = {
   archive: PublicArchiveResolveService,
   profileItems: ProfileItemsResolveService,
   publicProfileItems: PublicProfileItemsResolveService,
-  publicRoot: PublicRootResolveService
+  publicRoot: PublicRootResolveService,
 };
 
 const publishResolve = {
@@ -80,7 +80,7 @@ export const routes: RoutesWithData = [
     PublicArchiveResolveService,
     PublicRootResolveService,
     ProfileItemsResolveService,
-    PublicProfileItemsResolveService
+    PublicProfileItemsResolveService,
   ],
 })
 export class PublicRoutingModule {}

--- a/src/app/public/public.routes.ts
+++ b/src/app/public/public.routes.ts
@@ -14,11 +14,13 @@ import { PublicProfileItemsResolveService } from './resolves/public-profile-item
 import { PublicProfileComponent } from './components/public-profile/public-profile.component';
 import { RoutesWithData } from '../app.routes';
 import { PublicSearchResultsComponent } from './components/public-search-results/public-search-results.component';
+import { ProfileItemsResolveService } from '@core/resolves/profile-items-resolve.service';
 
 const publicArchiveResolve = {
   archive: PublicArchiveResolveService,
-  profileItems: PublicProfileItemsResolveService,
-  publicRoot: PublicRootResolveService,
+  profileItems: ProfileItemsResolveService,
+  publicProfileItems: PublicProfileItemsResolveService,
+  publicRoot: PublicRootResolveService
 };
 
 const publishResolve = {
@@ -77,7 +79,8 @@ export const routes: RoutesWithData = [
     PublishArchiveResolveService,
     PublicArchiveResolveService,
     PublicRootResolveService,
-    PublicProfileItemsResolveService,
+    ProfileItemsResolveService,
+    PublicProfileItemsResolveService
   ],
 })
 export class PublicRoutingModule {}

--- a/src/app/shared/services/profile/profile.service.ts
+++ b/src/app/shared/services/profile/profile.service.ts
@@ -78,7 +78,6 @@ export function addProfileItemToDictionary(dict: ProfileItemVODictionary, item: 
     dict[fieldNameUIShort].push(item);
   }
 
-  console.log('dict', dict);
 }
 
 export function orderItemsInDictionary(dict: ProfileItemVODictionary, field: FieldNameUIShort, column: ProfileItemsDataCol = 'day1') {
@@ -122,12 +121,9 @@ export class ProfileService {
   }
 
   async fetchProfileItems() {
-    console.log('here')
     const currentArchive = this.account.getArchive();
     const profileResponse = await this.api.archive.getAllProfileItems(currentArchive);
-    console.log(profileResponse)
     const profileItems = profileResponse.getProfileItemVOs();
-    console.log(profileItems)
     this.profileItemDictionary = {};
 
     for (const item of profileItems) {
@@ -154,7 +150,6 @@ export class ProfileService {
   }
 
    getProfileItemDictionary() {
-    console.log(this.profileItemDictionary)
     return this.profileItemDictionary;
   }
 

--- a/src/app/shared/services/profile/profile.service.ts
+++ b/src/app/shared/services/profile/profile.service.ts
@@ -77,7 +77,6 @@ export function addProfileItemToDictionary(dict: ProfileItemVODictionary, item: 
   } else {
     dict[fieldNameUIShort].push(item);
   }
-
 }
 
 export function orderItemsInDictionary(dict: ProfileItemVODictionary, field: FieldNameUIShort, column: ProfileItemsDataCol = 'day1') {
@@ -149,7 +148,7 @@ export class ProfileService {
     this.orderItems('milestone');
   }
 
-   getProfileItemDictionary() {
+  getProfileItemDictionary() {
     return this.profileItemDictionary;
   }
 

--- a/src/app/shared/services/profile/profile.service.ts
+++ b/src/app/shared/services/profile/profile.service.ts
@@ -77,6 +77,8 @@ export function addProfileItemToDictionary(dict: ProfileItemVODictionary, item: 
   } else {
     dict[fieldNameUIShort].push(item);
   }
+
+  console.log('dict', dict);
 }
 
 export function orderItemsInDictionary(dict: ProfileItemVODictionary, field: FieldNameUIShort, column: ProfileItemsDataCol = 'day1') {
@@ -120,9 +122,12 @@ export class ProfileService {
   }
 
   async fetchProfileItems() {
+    console.log('here')
     const currentArchive = this.account.getArchive();
     const profileResponse = await this.api.archive.getAllProfileItems(currentArchive);
+    console.log(profileResponse)
     const profileItems = profileResponse.getProfileItemVOs();
+    console.log(profileItems)
     this.profileItemDictionary = {};
 
     for (const item of profileItems) {
@@ -148,7 +153,8 @@ export class ProfileService {
     this.orderItems('milestone');
   }
 
-  getProfileItemDictionary() {
+   getProfileItemDictionary() {
+    console.log(this.profileItemDictionary)
     return this.profileItemDictionary;
   }
 


### PR DESCRIPTION
When accesing the public archive, then navigating to the private page, and then clicking the archive settings modal, there was an error being thrown.

The public module was missing the resolver for the profile items. Instead the profile items were being initialized using the resolver for the public items.

I have added the missing resolver and renamed the profileItems variable to publicProfileItems.