### PR TITLE
PER-9253-archive-settings-modal-should-be-blue

### DIFF
--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.scss
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.scss
@@ -1,1 +1,10 @@
 @import '../storage-dialog/storage-dialog.component.scss';
+@import 'variables';
+
+.header {
+  @include tabbedDialogHeader($PR-blue-light);
+}
+
+.tabs {
+  @include tabbedDialogNav($PR-blue-light);
+}


### PR DESCRIPTION
Added the missing classes to the archive settings modal so the header and the tabs are light blue instead of purple