### PR TITLE
Save auth token when verifying MFA

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -331,7 +331,7 @@ export class AccountService {
             }
             this.skipSessionCheck = true;
 
-            const authToken = response.getSimpleVO()?.value;
+            const authToken = response.getAuthToken()?.value;
             if (authToken) {
               this.api.auth.httpV2.setAuthToken(authToken);
             }
@@ -385,6 +385,11 @@ export class AccountService {
         map((response: AuthResponse) => {
           if (response.isSuccessful) {
             this.setAccount(response.getAccountVO());
+
+            const authToken = response.getAuthToken()?.value;
+            if (authToken) {
+              this.api.auth.httpV2.setAuthToken(authToken);
+            }
 
             this.accountChange.emit(this.account);
             return response;

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -175,4 +175,19 @@ export class AuthResponse extends BaseResponse {
 
     return new SimpleVO(data[0][0].SimpleVO);
   }
+
+  public getAuthToken() {
+    const data = this.getResultsData();
+    if (!data || !data.length) {
+      return null;
+    }
+
+    for (const voType in data[0][0]) {
+      if (data[0][0][voType]?.key === 'authToken') {
+        return new SimpleVO(data[0][0][voType]);
+      }
+    }
+
+    return null;
+  }
 }


### PR DESCRIPTION
Previously, the Auth Token was only recorded on the `login` endpoint, which fails when MFA is required to log in. Only once a user successfully verifies through the `verify` endpoint do they get an Auth Token. Because the verification step also gives a `trustToken`, we have to manually find the specific instance of SimpleVO or AuthSimpleVO with the key "authToken" which is probably a better way of looking for the token than relying on just finding the first SimpleVO in the data set.

Fortunately it looks like the token is grabbed when creating an account for the first time.

Resolves PER-9284: Store JWT in all authentication flows