### PR TITLE
PER-9262 - Arrow nav

### DIFF
--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -31,6 +31,7 @@
       <div *ngIf="currentRecord == record" class="full" [ngSwitch]="">
         <pr-thumbnail
           (disableSwipe)="toggleSwipe($event)"
+          (isFullScreen)="toggleFullscreen($event)"
           [item]="currentRecord"
           *ngIf="showThumbnail"
           [hideResizableImage]="false"

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -60,6 +60,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   private bodyScroll: number;
   private hammer: HammerManager;
   private disableSwipes: boolean;
+  private fullscreen: boolean;
   private velocityThreshold = 0.2;
   private screenWidth: number;
   private offscreenThreshold: number;
@@ -161,13 +162,15 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   // Keyboard
   @HostListener('document:keydown', ['$event'])
   onKeyDown(event) {
-    switch (event.key) {
-      case Key.ArrowLeft:
-        this.incrementCurrentRecord(true);
-        break;
-      case Key.ArrowRight:
-        this.incrementCurrentRecord();
-        break;
+    if (!this.fullscreen) {
+      switch (event.key) {
+        case Key.ArrowLeft:
+          this.incrementCurrentRecord(true);
+          break;
+        case Key.ArrowRight:
+          this.incrementCurrentRecord();
+          break;
+      }
     }
   }
 
@@ -183,6 +186,10 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
   toggleSwipe(value: boolean) {
     this.disableSwipes = value;
+  }
+
+  toggleFullscreen(value: boolean) {
+    this.fullscreen = value;
   }
 
   getPdfUrl() {

--- a/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -22,7 +22,7 @@ import debug from 'debug';
 import { FolderVO, RecordVO, ItemVO } from '@root/app/models';
 import { DataStatus } from '@models/data-status.enum';
 import * as OpenSeaDragon from 'openseadragon';
-import { ViewerEvent } from 'openseadragon';
+import { ViewerEvent, ZoomEvent, FullScreenEvent } from 'openseadragon';
 
 const THUMB_SIZES = [200, 500, 1000, 2000];
 
@@ -59,6 +59,7 @@ export class ThumbnailComponent
 
   @Input() hideResizableImage: boolean = true;
   @Output() disableSwipe = new EventEmitter<boolean>(false);
+  @Output() isFullScreen = new EventEmitter<boolean>(false);
 
   viewer: OpenSeaDragon.Viewer;
 
@@ -92,7 +93,7 @@ export class ThumbnailComponent
         maxZoomLevel: 10,
       });
 
-      this.viewer.addHandler('zoom', (event: OpenSeaDragon.ZoomEvent) => {
+      this.viewer.addHandler('zoom', (event: ZoomEvent) => {
         const zoom = event.zoom;
         if (!this.initialZoom) {
           this.initialZoom = zoom;
@@ -103,6 +104,11 @@ export class ThumbnailComponent
         } else {
           this.disableSwipe.emit(false);
         }
+      });
+
+      this.viewer.addHandler('full-screen', (event: FullScreenEvent) => {
+        const { fullScreen } = event;
+        this.isFullScreen.emit(fullScreen);
       });
     }
   }


### PR DESCRIPTION
I have disabled the full screen arrow navigation mainly because of the behaviour of the open sea dragon library.

The library manipulates the dom and after navigating once and then clicking escape the app would be gone, only the div was still present.

Another issue with fullscreen was pdfs.

I have tried navigating back to them when an item was not an image, but the library did not have the router component so that was not possible.