### PR TITLE
Update copy to reflect that previous archive owners now become managers

### DIFF
--- a/src/app/core/components/members-dialog/members-dialog.component.ts
+++ b/src/app/core/components/members-dialog/members-dialog.component.ts
@@ -203,7 +203,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
   }
 
   confirmOwnershipTransfer() {
-    return this.promptService.confirm('Transfer ownership', 'Permanent Archives can only have one owner at a time. Once this is complete, your role will be changed to Curator');
+    return this.promptService.confirm('Transfer ownership', 'Permanent Archives can only have one owner at a time. Once this is complete, your role will be changed to Manager');
   }
 
   promptForInvite(member: AccountVO) {


### PR DESCRIPTION
We're updating the logic around archive ownership transfers to make the old owner become a manager of that archive after the transfer, rather than a curator. This commit updates the modal copy to reflect that change.