### PR TITLE
Fix search by tag

### DIFF
--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -46,7 +46,7 @@ export class SearchRepo extends BaseRepo {
     const data = {
       SearchVO: {
       query,
-      tags: tags,
+      TagVOs: tags,
       numberOfResults: limit,
       }
     };


### PR DESCRIPTION
Recently, it looks like there was an attempt to switch calls to the /search/folderAndRecord endpoint over to use V2 requests, which was then reversed. However, the name of the tags passed in the request body was changed to "tags" from "TagVOs" and not changed back, which breaks searching by tag. This commit returns the name of that field to "TagVOs".