### PR TITLE
Add new linting workflow with eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
         'import/no-import-module-exports': 'off',
         'no-underscore-dangle': 'off',
         'max-classes-per-file': 'off',
+        'no-console': ['error', { allow: ['error'] }],
         // Below are rules we want to eventually enable:
         'import/newline-after-import': 'off',
         'import/no-cycle': 'off',

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,33 +1,24 @@
-name: Unit tests
-
+name: Linting
 on:
   pull_request:
-
   workflow_dispatch:
-
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v1
         with:
-          node-version: '16'
-
+          node-version: "16"
       - uses: actions/cache@v2
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
-
       - name: Install dependencies
         run: npm install
-
-      - name: Run unit tests
-        env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_DEV }}
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_DEV }}
-          STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
-        run: npm run test:build
+      - name: Run Prettier
+        run: npx prettier --check --require-pragma .
+      - name: Run eslint
+        run: npm run lint

--- a/src/app/public/components/public-archive/public-archive.component.ts
+++ b/src/app/public/components/public-archive/public-archive.component.ts
@@ -118,7 +118,7 @@ export class PublicArchiveComponent implements OnInit, OnDestroy {
         relativeTo: this.route,
       });
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   }
 


### PR DESCRIPTION
This PR adds a new workflow run on pull requests for linting. This workflow runs both prettier and eslint, removing prettier from the unit testing workflow so that it's more clear why automated checks are failing. In addition, I added the `no-console` rule to eslint. Initially it was to test linting failures with, but since it's a good rule that we ~~mostly~~ weren't breaking, I decided to leave it in so we can immediately benefit from turning on eslint.

Resolves PER-8554: Add eslint to CI

## Notes on Merging
Once this PR is merged I will add the `lint` workflow to be required to pass in order to merge a PR into `main`.