### PR TITLE
Enable import/newline-after-import linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,6 @@ module.exports = {
         'max-classes-per-file': 'off',
         'no-console': ['error', { allow: ['error'] }],
         // Below are rules we want to eventually enable:
-        'import/newline-after-import': 'off',
         'import/no-cycle': 'off',
         'import/no-default-export': 'off',
         'import/no-duplicates': 'off',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { RouteHistoryService } from 'ngx-route-history';
 import { InViewportModule } from 'ng-in-viewport';
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faFileArchive, fas } from '@fortawesome/free-solid-svg-icons';
+
 declare var ga: any;
 
 if (environment.environment !== 'local') {

--- a/src/app/directive/directive.module.ts
+++ b/src/app/directive/directive.module.ts
@@ -16,6 +16,7 @@ import { DirectiveDialogComponent } from './components/directive-dialog/directiv
 import { LegacyContactDisplayComponent } from './components/legacy-contact-display/legacy-contact-display.component';
 import { LegacyContactEditComponent } from './components/legacy-contact-edit/legacy-contact-edit.component';
 import { LegacyContactDialogComponent } from './components/legacy-contact-dialog/legacy-contact-dialog.component';
+
 @NgModule({
   exports: [
     DirectiveDisplayComponent,

--- a/src/app/search/components/global-search-bar/global-search-bar.component.ts
+++ b/src/app/search/components/global-search-bar/global-search-bar.component.ts
@@ -12,6 +12,7 @@ import { DOCUMENT } from '@angular/common';
 import { AccountService } from '@shared/services/account/account.service';
 import { Router } from '@angular/router';
 import { remove } from 'lodash';
+
 const LOCAL_RESULTS_LIMIT = 5;
 
 type ResultsListType = 'local' | 'global' | 'tag';

--- a/src/app/shared/components/folder-view-toggle/folder-view-toggle.component.ts
+++ b/src/app/shared/components/folder-view-toggle/folder-view-toggle.component.ts
@@ -9,6 +9,7 @@ import { getLastChildRouteDataOperator } from '@shared/utilities/router';
 import { Subscription, Observable } from 'rxjs';
 import { unsubscribeAll, HasSubscriptions } from '@shared/utilities/hasSubscriptions';
 import { map } from 'rxjs/operators';
+
 interface FolderViewToggleOption {
   iconClass: 'reorder' | 'view_module';
   folderView: FolderView;

--- a/src/app/shared/directives/scroll-section.directive.ts
+++ b/src/app/shared/directives/scroll-section.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, Input } from '@angular/core';
+
 @Directive({
   selector: '[prScrollSection]'
 })

--- a/src/app/shared/pipes/pr-location.pipe.ts
+++ b/src/app/shared/pipes/pr-location.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { LocnVOData } from '@models';
+
 export interface LocnPipeOutput {
   line1?: string;
   line2?: string;

--- a/src/app/shared/pipes/share-action-label.pipe.ts
+++ b/src/app/shared/pipes/share-action-label.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { FolderVO, RecordVO } from '@models';
+
 @Pipe({
   name: 'shareActionLabel'
 })

--- a/src/app/shared/services/pr-constants/pr-constants.service.ts
+++ b/src/app/shared/services/pr-constants/pr-constants.service.ts
@@ -8,6 +8,7 @@ import { getCodeList, overwrite } from 'country-list';
 declare var require: any;
 const SYNC_CONSTANTS = require('../../../../../constants/master_en.json');
 const PROFILE_TEMPLATE = require('../../../../../constants/profile_template.json');
+
 export interface Country {
   name: string;
   abbrev: string;


### PR DESCRIPTION
**Time to start slowly enabling eslint rules!** :tada:  I'm going to aim to enable 1 or 2 rules a week until we get them all done, though some rules might end up being more complicated to enable (one day when we decide to enable `no-explicit-any` it's going to be a whole project to fix that).

This rule requires an empty line after the `import` statements at the beginning of Typescript files, so that there is a more clear distinction between imports and actual code. This PR enables the rule and runs `npm run lint --fix` to autofix these issues.