### PR TITLE
Enable and fix import/no-duplicates linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,6 @@ module.exports = {
         'import/no-default-export': 'error',
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        'import/no-duplicates': 'off',
         'import/no-extraneous-dependencies': 'off',
         'import/no-self-import': 'off',
         'import/no-useless-path-segments': 'off',
@@ -151,8 +150,8 @@ module.exports = {
       files: ['*.stories.ts', 'src/stories/*.ts'],
       rules: {
         'import/no-default-export': 'off',
-      }
-    }
+      },
+    },
   ],
   extends: ['plugin:storybook/recommended'],
 };

--- a/src/app/core/guards/myfiles.guard.ts
+++ b/src/app/core/guards/myfiles.guard.ts
@@ -1,7 +1,6 @@
 /* @format */
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
-import {
+import { Router ,
   ActivatedRouteSnapshot,
   CanActivate,
   RouterStateSnapshot,

--- a/src/app/core/guards/myfiles.guard.ts
+++ b/src/app/core/guards/myfiles.guard.ts
@@ -1,6 +1,7 @@
 /* @format */
 import { Injectable } from '@angular/core';
-import { Router ,
+import {
+  Router,
   ActivatedRouteSnapshot,
   CanActivate,
   RouterStateSnapshot,

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -27,7 +27,6 @@ import { DataStatus } from '@models/data-status.enum';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
 import { TagsService } from './../../../core/services/tags/tags.service';
-import { OnChanges, SimpleChanges } from '@angular/core';
 import type { KeysOfType } from '@shared/utilities/keysoftype';
 import { Subscription } from 'rxjs';
 

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable , EventEmitter } from '@angular/core';
 import { map } from 'rxjs/operators';
 import { partition, remove, find, findIndex } from 'lodash';
 
@@ -16,7 +16,6 @@ import {
   FolderResponse,
   RecordResponse,
 } from '@shared/services/api/index.repo';
-import { EventEmitter } from '@angular/core';
 import { Subject, BehaviorSubject, Observable } from 'rxjs';
 import debug from 'debug';
 import { debugSubscribable } from '@shared/utilities/debug';

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -1,4 +1,5 @@
-import { Injectable , EventEmitter } from '@angular/core';
+/* @format */
+import { Injectable, EventEmitter } from '@angular/core';
 import { map } from 'rxjs/operators';
 import { partition, remove, find, findIndex } from 'lodash';
 


### PR DESCRIPTION
This PR enables the `import/no-duplicates` linting rule. This rule makes sure all imports from the same module are imported together in the same `import` statement. Files are autofixed with eslint and formatted with prettier.