### PR TITLE
PER-8802

### DIFF
--- a/constants/master_en.json
+++ b/constants/master_en.json
@@ -389,7 +389,7 @@
     "supplier": "Supplier",
     "supporter": "Supporter",
     "volunteer": "Volunteer",
-    "family_member": "Family Member",
+    "family_member": "Group Member",
     "employee": "Employee",
     "employer": "Employer",
     "owner": "Owner",
@@ -575,7 +575,7 @@
     "archive": {
       "organization": "Organization",
       "person": "Person",
-      "family": "Family",
+      "family": "Group",
       "nonprofit": "Nonprofit"
     },
     "auth": {

--- a/src/app/shared/components/new-archive-form/new-archive-form.component.ts
+++ b/src/app/shared/components/new-archive-form/new-archive-form.component.ts
@@ -15,7 +15,7 @@ const ARCHIVE_TYPES: { text: string, value: ArchiveType }[] = [
     value: 'type.archive.person'
   },
   {
-    text: 'Family',
+    text: 'Group',
     value: 'type.archive.family'
   },
   {


### PR DESCRIPTION
Changed all the family strings to group. This does not change the types "type.archive.family" because this would be problematic with the current back-end and i think it would be easier once the back-end is changed to do that change too

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205175187345745