### PR TITLE
Enable import/no-extraneous-dependencies linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,9 +55,12 @@ module.exports = {
         'max-classes-per-file': 'off',
         'no-console': ['error', { allow: ['error'] }],
         'import/no-default-export': 'error',
+        'import/no-extraneous-dependencies': [
+          'error',
+          { devDependencies: true },
+        ],
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        'import/no-extraneous-dependencies': 'off',
         'import/no-self-import': 'off',
         'import/no-useless-path-segments': 'off',
         'import/order': 'off',
@@ -150,6 +153,7 @@ module.exports = {
       files: ['*.stories.ts', 'src/stories/*.ts'],
       rules: {
         'import/no-default-export': 'off',
+        'import/no-extraneous-dependencies': 'off',
       },
     },
   ],


### PR DESCRIPTION
This linting rule forbids importing modules that are not declared as specific dependencies of the project. With our current configuration, the default behavior was also to forbid the imports of devDependencies, but due to our project configuration (with things like Storybook and various configuration scripts we have to use with Angular) it doesn't make sense to forbid importing devDependencies, at least in files that are only run in the development environment. 

Enable the rule with the `devDependencies` property set to true. This should prevent future imports of extraneous dependencies but silence our currently existing errors which only happen in development-related code.

This is based on #273 just to avoid merge conflicts when it's merged. Do not merge this until its parent branch merged.