### PR TITLE
Enable and fix import/no-self-import linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,6 @@ module.exports = {
         ],
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        'import/no-self-import': 'off',
         'import/no-useless-path-segments': 'off',
         'import/order': 'off',
         '@angular-eslint/component-selector': 'off',

--- a/src/app/apps/apps.routes.ts
+++ b/src/app/apps/apps.routes.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
@@ -7,11 +8,11 @@ import { AppsGuard } from '@core/guards/apps.guard';
 import { AppsComponent } from '@apps/components/apps/apps.component';
 import { AppsFolderResolveService } from '@apps/resolves/apps-folder-resolve.service';
 
-import { LazyLoadFileBrowserSibling } from '@fileBrowser/file-browser.module';
+import { LazyLoadFileBrowserSibling } from '@fileBrowser/lazy-load-file-browser-sibling';
 
 const appsRootResolve = {
   appsFolder: AppsFolderResolveService,
-  connectors: ConnectorsResolveService
+  connectors: ConnectorsResolveService,
 };
 
 export const routes: Routes = [
@@ -19,23 +20,17 @@ export const routes: Routes = [
     path: '',
     component: AppsComponent,
     resolve: appsRootResolve,
-    runGuardsAndResolvers: 'always'
+    runGuardsAndResolvers: 'always',
   },
   {
     path: ':archiveNbr/:folderLinkId',
     loadChildren: LazyLoadFileBrowserSibling,
-    canActivate: [ AppsGuard ],
-    canActivateChild: [ AppsGuard ],
+    canActivate: [AppsGuard],
+    canActivateChild: [AppsGuard],
   },
 ];
 @NgModule({
-  imports: [
-    RouterModule.forChild(routes)
-  ],
-  providers: [
-    AppsFolderResolveService,
-    ConnectorsResolveService
-  ]
+  imports: [RouterModule.forChild(routes)],
+  providers: [AppsFolderResolveService, ConnectorsResolveService],
 })
-export class AppsRoutingModule { }
-
+export class AppsRoutingModule {}

--- a/src/app/file-browser/file-browser.module.ts
+++ b/src/app/file-browser/file-browser.module.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
@@ -12,10 +13,6 @@ import { VideoComponent } from '@shared/components/video/video.component';
 import { DialogModule } from '../dialog/dialog.module';
 import { FileBrowserComponentsModule } from './file-browser-components.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { InViewportModule } from 'ng-in-viewport';
-
-
-export const LazyLoadFileBrowserSibling = () => import('../file-browser/file-browser.module').then(m => m.FileBrowserModule);
 
 @NgModule({
   imports: [
@@ -25,14 +22,13 @@ export const LazyLoadFileBrowserSibling = () => import('../file-browser/file-bro
     FileBrowserRoutingModule,
     SharedModule,
     DialogModule,
-    NgbTooltipModule
+    NgbTooltipModule,
   ],
   exports: [
     FileListComponent,
     FileListItemComponent,
     FileViewerComponent,
-    VideoComponent
-  ]
+    VideoComponent,
+  ],
 })
-export class FileBrowserModule {
-}
+export class FileBrowserModule {}

--- a/src/app/file-browser/lazy-load-file-browser-sibling.ts
+++ b/src/app/file-browser/lazy-load-file-browser-sibling.ts
@@ -1,0 +1,3 @@
+/* @format */
+export const LazyLoadFileBrowserSibling = () =>
+  import('./file-browser.module').then((m) => m.FileBrowserModule);

--- a/src/app/public/public.routes.ts
+++ b/src/app/public/public.routes.ts
@@ -9,7 +9,7 @@ import { ItemNotFoundComponent } from './components/item-not-found/item-not-foun
 import { PublicArchiveComponent } from './components/public-archive/public-archive.component';
 import { PublicArchiveResolveService } from './resolves/public-archive-resolve.service';
 import { PublicRootResolveService } from './resolves/public-root-resolve.service';
-import { LazyLoadFileBrowserSibling } from '@fileBrowser/file-browser.module';
+import { LazyLoadFileBrowserSibling } from '@fileBrowser/lazy-load-file-browser-sibling';
 import { PublicProfileItemsResolveService } from './resolves/public-profile-items-resolve.service';
 import { PublicProfileComponent } from './components/public-profile/public-profile.component';
 import { RoutesWithData } from '../app.routes';

--- a/src/app/share-preview/share-preview.routes.ts
+++ b/src/app/share-preview/share-preview.routes.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { NgModule, ComponentFactoryResolver, Optional } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -14,12 +15,11 @@ import { CreateAccountDialogComponent } from './components/create-account-dialog
 import { FileListComponent } from '@fileBrowser/components/file-list/file-list.component';
 import { InviteShareResolveService } from './resolves/invite-share-resolve.service';
 import { RelationshipShareResolveService } from './resolves/relationship-share-resolve.service';
-import { RoutedDialogWrapperComponent } from '@shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component';
 import { DialogChildComponentData } from '@root/app/dialog/dialog.module';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { Dialog, DialogModule } from '../dialog/dialog.module';
-import { LazyLoadFileBrowserSibling } from '@fileBrowser/file-browser.module';
+import { LazyLoadFileBrowserSibling } from '@fileBrowser/lazy-load-file-browser-sibling';
 import { AnnouncementModule } from '../announcement/announcement.module';
 import { SharePreviewFooterComponent } from './components/share-preview-footer/share-preview-footer.component';
 


### PR DESCRIPTION
This linting rule forbids files from importing themselves. This happens in one file in our codebase, and the specific self import can't be fully removed. Instead it's extracted from the file and any files importing that module have been updated.