### PR TITLE
Enable and fix import/no-useless-path-segments linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,6 @@ module.exports = {
         ],
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        'import/no-useless-path-segments': 'off',
         'import/order': 'off',
         '@angular-eslint/component-selector': 'off',
         '@angular-eslint/directive-selector': 'off',

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.html
@@ -1,3 +1,4 @@
+<!-- @format -->
 <div class="dialog-content">
   <div class="header">
     <span>Archive Settings</span>
@@ -63,7 +64,10 @@
         </ng-container>
         <ng-container *ngSwitchCase="'public-settings'">
           <div class="panel-title">Archive Storage</div>
-            <pr-archive-payer [payer]="payer" [archive]="archive"></pr-archive-payer>
+          <pr-archive-payer
+            [payer]="payer"
+            [archive]="archive"
+          ></pr-archive-payer>
           <div class="panel-title">Public Gallery Page Settings</div>
           <ng-container *ngIf="hasTagsAccess; else noAccess">
             <pr-public-settings [archive]="archive"></pr-public-settings>

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.scss
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.scss
@@ -1,3 +1,4 @@
+/* @format */
 @import '../storage-dialog/storage-dialog.component.scss';
 @import 'variables';
 

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -1,6 +1,7 @@
+/* @format*/
 import { Component, OnInit } from '@angular/core';
 import { IsTabbedDialog, DialogRef } from '@root/app/dialog/dialog.module';
-import { AccountVO } from "../../../models/account-vo";
+import { AccountVO } from '../../../models/account-vo';
 import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { TagsService } from '@core/services/tags/tags.service';

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { IsTabbedDialog, DialogRef } from '@root/app/dialog/dialog.module';
-import { AccountVO } from './../../../models/account-vo';
+import { AccountVO } from "../../../models/account-vo";
 import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { TagsService } from '@core/services/tags/tags.service';

--- a/src/app/core/components/confirm-payer-dialog/confirm-payer-dialog.component.spec.ts
+++ b/src/app/core/components/confirm-payer-dialog/confirm-payer-dialog.component.spec.ts
@@ -1,10 +1,14 @@
-/* #format */
+/* @format */
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
-import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  TestModuleMetadata,
+} from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { ConfirmPayerDialogComponent } from './confirm-payer-dialog.component';
 import { cloneDeep } from 'lodash';
-import { SharedModule } from "../../../shared/shared.module";
+import { SharedModule } from '../../../shared/shared.module';
 
 describe('ConfirmPayerDialogComponent', () => {
   let component: ConfirmPayerDialogComponent;
@@ -17,7 +21,7 @@ describe('ConfirmPayerDialogComponent', () => {
     cancelAccountPayerSet: () => void;
   };
 
-  beforeEach(async() => {
+  beforeEach(async () => {
     const config: TestModuleMetadata = cloneDeep(Testing.BASE_TEST_CONFIG);
 
     dialogData = {
@@ -42,7 +46,7 @@ describe('ConfirmPayerDialogComponent', () => {
       useValue: dialogRef,
     });
     await TestBed.configureTestingModule(config).compileComponents();
-  })
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfirmPayerDialogComponent);

--- a/src/app/core/components/confirm-payer-dialog/confirm-payer-dialog.component.spec.ts
+++ b/src/app/core/components/confirm-payer-dialog/confirm-payer-dialog.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/tes
 import * as Testing from '@root/test/testbedConfig';
 import { ConfirmPayerDialogComponent } from './confirm-payer-dialog.component';
 import { cloneDeep } from 'lodash';
-import { SharedModule } from './../../../shared/shared.module';
+import { SharedModule } from "../../../shared/shared.module";
 
 describe('ConfirmPayerDialogComponent', () => {
   let component: ConfirmPayerDialogComponent;

--- a/src/app/file-browser/components/download-button/download-button.component.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { MessageService } from "../../../shared/services/message/message.service";
+import { MessageService } from '../../../shared/services/message/message.service';
 import {
   Component,
   Input,

--- a/src/app/file-browser/components/download-button/download-button.component.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { MessageService } from './../../../shared/services/message/message.service';
+import { MessageService } from "../../../shared/services/message/message.service";
 import {
   Component,
   Input,

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -26,7 +26,7 @@ import { EditService } from '@core/services/edit/edit.service';
 import { DataStatus } from '@models/data-status.enum';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
-import { TagsService } from './../../../core/services/tags/tags.service';
+import { TagsService } from "../../../core/services/tags/tags.service";
 import type { KeysOfType } from '@shared/utilities/keysoftype';
 import { Subscription } from 'rxjs';
 

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -26,7 +26,7 @@ import { EditService } from '@core/services/edit/edit.service';
 import { DataStatus } from '@models/data-status.enum';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
-import { TagsService } from "../../../core/services/tags/tags.service";
+import { TagsService } from '../../../core/services/tags/tags.service';
 import type { KeysOfType } from '@shared/utilities/keysoftype';
 import { Subscription } from 'rxjs';
 

--- a/src/app/shared/services/api/archive.repo.ts
+++ b/src/app/shared/services/api/archive.repo.ts
@@ -1,4 +1,4 @@
-import { TagVOData } from './../../../models/tag-vo';
+import { TagVOData } from "../../../models/tag-vo";
 import { AccountVO, AccountPasswordVO, ArchiveVO, AuthVO } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { flatten, isArray } from 'lodash';

--- a/src/app/shared/services/api/archive.repo.ts
+++ b/src/app/shared/services/api/archive.repo.ts
@@ -1,5 +1,11 @@
-import { TagVOData } from "../../../models/tag-vo";
-import { AccountVO, AccountPasswordVO, ArchiveVO, AuthVO } from '@root/app/models';
+/* @format */
+import { TagVOData } from '../../../models/tag-vo';
+import {
+  AccountVO,
+  AccountPasswordVO,
+  ArchiveVO,
+  AuthVO,
+} from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { flatten, isArray } from 'lodash';
 import { ProfileItemVOData } from '@models/profile-item-vo';
@@ -227,7 +233,7 @@ export class ArchiveRepo extends BaseRepo {
     if (!archive?.archiveId && !archive?.archiveNbr) {
       return;
     }
-    
+
     return this.http.sendRequestPromise<ArchiveResponse>(
       endpoint,
       data,
@@ -264,7 +270,9 @@ export class ArchiveRepo extends BaseRepo {
   }
 
   public getPublicArchiveTags(archiveId: string) {
-    return this.httpV2.get<TagVOData>(`v2/archive/${archiveId}/tags/public`).toPromise();
+    return this.httpV2
+      .get<TagVOData>(`v2/archive/${archiveId}/tags/public`)
+      .toPromise();
   }
 }
 


### PR DESCRIPTION
 Enable and fix the import/no-useless-path-segments linting rule. This rule tries to standardize how paths look like in local imports, by forbidding usage of "./" when not necessary.