### PR TITLE
Fix environment typing errors

### DIFF
--- a/src/environments/environment-interface.ts
+++ b/src/environments/environment-interface.ts
@@ -1,0 +1,17 @@
+interface FirebaseConfig {
+  authDomain: string;
+  databaseURL: string;
+  functionsURL: string;
+  projectId: string;
+}
+
+export interface Environment {
+  production: boolean;
+  apiUrl: string;
+  hmr: boolean;
+  firebase: FirebaseConfig;
+  debug: boolean;
+  release: string;
+  environment: string;
+  analyticsDebug: boolean;
+}

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -1,7 +1,8 @@
 /* @format */
 import PackageJson from '../../package.json';
+import { Environment } from './environment-interface';
 
-export const environment = {
+export const environment: Environment = {
   production: true,
   apiUrl: 'https://dev.permanent.org/api',
   hmr: false,

--- a/src/environments/environment.local.proxy.ts
+++ b/src/environments/environment.local.proxy.ts
@@ -1,7 +1,8 @@
 /* @format */
 import PackageJson from '../../package.json';
+import { Environment } from './environment-interface';
 
-export const environment = {
+export const environment: Environment = {
   production: false,
   apiUrl: 'https://ng.permanent.org:4200/api',
   hmr: false,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,7 +1,8 @@
 /* @format */
 import PackageJson from '../../package.json';
+import { Environment } from './environment-interface';
 
-export const environment = {
+export const environment: Environment = {
   production: true,
   apiUrl: 'https://www.permanent.org/api',
   hmr: false,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -1,7 +1,8 @@
 /* @format */
 import PackageJson from '../../package.json';
+import { Environment } from './environment-interface';
 
-export const environment = {
+export const environment: Environment = {
   production: true,
   apiUrl: 'https://staging.permanent.org/api',
   hmr: false,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,7 +1,8 @@
 /* @format */
 import PackageJson from '../../package.json';
+import { Environment } from './environment-interface';
 
-export const environment = {
+export const environment: Environment = {
   production: false,
   apiUrl: 'https://local.permanent.org/api',
   hmr: false,


### PR DESCRIPTION
I decided to force the `environment` variables to be readonly for safety purposes since they should never be modified by code. Unfortunately this caused some typing errors that caused compilation to fail. Create an interface to hopefully fix these compliation errors.