### PR TITLE
Enable and fix import/order linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,9 +59,20 @@ module.exports = {
           'error',
           { devDependencies: true },
         ],
+        'import/order': [
+          'error',
+          {
+            groups: [
+              'builtin',
+              'external',
+              ['internal', 'parent'],
+              'sibling',
+              'index',
+            ],
+          },
+        ],
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        'import/order': 'off',
         '@angular-eslint/component-selector': 'off',
         '@angular-eslint/directive-selector': 'off',
         '@angular-eslint/no-conflicting-lifecycle': 'off',

--- a/src/app/announcement/announcement.module.ts
+++ b/src/app/announcement/announcement.module.ts
@@ -1,8 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { AnnouncementComponent } from './components/announcement/announcement.component';
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faWindowClose } from '@fortawesome/free-solid-svg-icons';
+import { AnnouncementComponent } from './components/announcement/announcement.component';
 import { AndroidAppNotifyComponent } from './components/android-app-notify/android-app-notify.component';
 
 

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
@@ -1,11 +1,11 @@
 /* @format */
 import { Shallow } from 'shallow-render';
 
+import { AnnouncementModule } from '@announcement/announcement.module';
 import {
   AndroidAppNotifyComponent,
   BeforeInstallPromptEvent,
 } from './android-app-notify.component';
-import { AnnouncementModule } from '@announcement/announcement.module';
 
 class DummyInstallPromptEvent
   extends Event

--- a/src/app/announcement/components/announcement/announcement.component.spec.ts
+++ b/src/app/announcement/components/announcement/announcement.component.spec.ts
@@ -1,9 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Shallow } from 'shallow-render';
 
-import { AnnouncementComponent } from './announcement.component';
 import { AnnouncementModule } from '@announcement/announcement.module';
 import { AnnouncementEvent } from '@announcement/models/announcement-event';
+import { AnnouncementComponent } from './announcement.component';
 
 const currentTestEvent: AnnouncementEvent = {
   start: Date.now(),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,7 +26,6 @@ import { AppRoutingModule } from '@root/app/app.routes';
 
 import { AppComponent } from '@root/app/app.component';
 import { MessageComponent } from '@shared/components/message/message.component';
-import { DialogModule } from './dialog/dialog.module';
 import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { ApiService } from '@shared/services/api/api.service';
 import { StorageService } from '@shared/services/storage/storage.service';
@@ -40,6 +39,7 @@ import {
 import { faFileArchive, fas } from '@fortawesome/free-solid-svg-icons';
 
 import { MixpanelService } from '@shared/services/mixpanel/mixpanel.service';
+import { DialogModule } from './dialog/dialog.module';
 
 declare var ga: any;
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,11 +4,11 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterModule, Routes, Route } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FolderView } from '@shared/services/folder-view/folder-view.enum';
+import { SecretsService } from '@shared/services/secrets/secrets.service';
 import { DialogComponentToken } from './dialog/dialog.module';
 import { DialogOptions } from './dialog/dialog.service';
-import { FolderView } from '@shared/services/folder-view/folder-view.enum';
 import { FolderVO, RecordVO } from './models';
-import { SecretsService } from '@shared/services/secrets/secrets.service';
 
 export interface RouteData {
   title?: string;

--- a/src/app/apps/components/apps/apps.component.ts
+++ b/src/app/apps/components/apps/apps.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 import { DataService } from '@shared/services/data/data.service';
 import { StorageService } from '@shared/services/storage/storage.service';
 import { ConnectorOverviewVO, FolderVO } from '@root/app/models';
-import { ConnectorComponent, FAMILYSEARCH_CONNECT_KEY } from '../connector/connector.component';
 import { find } from 'lodash';
 import { AccountService } from '@shared/services/account/account.service';
 import { HasSubscriptions } from '@shared/utilities/hasSubscriptions';
@@ -14,6 +13,7 @@ import { timeout } from '@shared/utilities/timeout';
 import { GuidedTourService } from '@shared/services/guided-tour/guided-tour.service';
 import { CreateArchivesComplete } from '@shared/services/guided-tour/tours/familysearch.tour';
 import { GuidedTourEvent } from '@shared/services/guided-tour/events';
+import { ConnectorComponent, FAMILYSEARCH_CONNECT_KEY } from '../connector/connector.component';
 
 @Component({
   selector: 'pr-apps',

--- a/src/app/apps/components/connector/connector.component.spec.ts
+++ b/src/app/apps/components/connector/connector.component.spec.ts
@@ -2,12 +2,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep  } from 'lodash';
 
-import { ConnectorComponent } from './connector.component';
 import { ArchiveResponse } from '@shared/services/api/index.repo';
 import { AccountService } from '@shared/services/account/account.service';
 import { SharedModule } from '@shared/shared.module';
 import { ArchiveVO, ConnectorOverviewVO, FolderVO } from '@root/app/models';
 import { Component, ViewChild } from '@angular/core';
+import { ConnectorComponent } from './connector.component';
 
 @Component({
   selector: `pr-test-host-component`,

--- a/src/app/archive-settings/manage-metadata/manage-custom-metadata/manage-custom-metadata.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/manage-custom-metadata/manage-custom-metadata.component.spec.ts
@@ -1,14 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ManageCustomMetadataComponent } from './manage-custom-metadata.component';
 import { Shallow } from 'shallow-render';
-import { ManageMetadataModule } from '../manage-metadata.module';
 import { ApiService } from '@shared/services/api/api.service';
 import { Observable } from 'rxjs';
 import { TagVO, TagVOData } from '@models/tag-vo';
 import { TagsService } from '@core/services/tags/tags.service';
-import { MetadataValuePipe } from '../pipes/metadata-value.pipe';
 import { find } from 'lodash';
+import { MetadataValuePipe } from '../pipes/metadata-value.pipe';
+import { ManageMetadataModule } from '../manage-metadata.module';
+import { ManageCustomMetadataComponent } from './manage-custom-metadata.component';
 
 describe('ManageCustomMetadataComponent #custom-metadata', () => {
   let shallow: Shallow<ManageCustomMetadataComponent>;

--- a/src/app/archive-settings/manage-metadata/manage-metadata.module.ts
+++ b/src/app/archive-settings/manage-metadata/manage-metadata.module.ts
@@ -1,15 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '@shared/shared.module';
-import { ManageCustomMetadataComponent } from './manage-custom-metadata/manage-custom-metadata.component';
-import { MetadataValuePipe } from './pipes/metadata-value.pipe';
-import { AddNewValueComponent } from './subcomponents/value-add/add-new-value.component';
 import { FormsModule } from '@angular/forms';
-import { EditValueComponent } from './subcomponents/value-edit/value-edit.component';
-import { FormCreateComponent } from './subcomponents/form-create/form-create.component';
-import { AddNewCategoryComponent } from './subcomponents/category-add/add-new-category.component';
-import { FormEditComponent } from './subcomponents/form-edit/form-edit.component';
-import { CategoryEditComponent } from './subcomponents/category-edit/category-edit.component';
 import { A11yModule } from '@angular/cdk/a11y';
 import {
   FontAwesomeModule,
@@ -20,6 +12,14 @@ import {
   faEdit,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
+import { ManageCustomMetadataComponent } from './manage-custom-metadata/manage-custom-metadata.component';
+import { MetadataValuePipe } from './pipes/metadata-value.pipe';
+import { AddNewValueComponent } from './subcomponents/value-add/add-new-value.component';
+import { EditValueComponent } from './subcomponents/value-edit/value-edit.component';
+import { FormCreateComponent } from './subcomponents/form-create/form-create.component';
+import { AddNewCategoryComponent } from './subcomponents/category-add/add-new-category.component';
+import { FormEditComponent } from './subcomponents/form-edit/form-edit.component';
+import { CategoryEditComponent } from './subcomponents/category-edit/category-edit.component';
 
 @NgModule({
   declarations: [

--- a/src/app/archive-settings/manage-metadata/subcomponents/category-add/add-new-category.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/category-add/add-new-category.component.spec.ts
@@ -1,14 +1,14 @@
 import { ComponentFixture, TestBed, tick } from '@angular/core/testing';
 
-import { AddNewCategoryComponent } from './add-new-category.component';
 import { Shallow } from 'shallow-render';
-import { ManageMetadataModule } from '../../manage-metadata.module';
 import { FormsModule } from '@angular/forms';
 import { MessageService } from '@shared/services/message/message.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { TagVOData } from '@models/tag-vo';
-import { FormCreateComponent } from '../form-create/form-create.component';
 import { PromptService } from '@shared/services/prompt/prompt.service';
+import { FormCreateComponent } from '../form-create/form-create.component';
+import { ManageMetadataModule } from '../../manage-metadata.module';
+import { AddNewCategoryComponent } from './add-new-category.component';
 
 describe('AddNewCategoryComponent', () => {
   let shallow: Shallow<AddNewCategoryComponent>;

--- a/src/app/archive-settings/manage-metadata/subcomponents/category-edit/category-edit.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/category-edit/category-edit.component.spec.ts
@@ -1,11 +1,11 @@
 import { Shallow } from 'shallow-render';
-import { CategoryEditComponent } from './category-edit.component';
-import { ManageMetadataModule } from '../../manage-metadata.module';
-import { FormEditComponent } from '../form-edit/form-edit.component';
 import { TagVO } from '@models/tag-vo';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
+import { FormEditComponent } from '../form-edit/form-edit.component';
+import { ManageMetadataModule } from '../../manage-metadata.module';
+import { CategoryEditComponent } from './category-edit.component';
 
 describe('CategoryEditComponent', () => {
   let shallow: Shallow<CategoryEditComponent>;

--- a/src/app/archive-settings/manage-metadata/subcomponents/form-create/form-create.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/form-create/form-create.component.spec.ts
@@ -1,8 +1,8 @@
-import { FormCreateComponent } from './form-create.component';
 import { Shallow } from 'shallow-render';
-import { ManageMetadataModule } from '../../manage-metadata.module';
 import { FormsModule } from '@angular/forms';
 import { A11yModule } from '@angular/cdk/a11y';
+import { ManageMetadataModule } from '../../manage-metadata.module';
+import { FormCreateComponent } from './form-create.component';
 
 describe('FormCreateComponent', () => {
   let shallow: Shallow<FormCreateComponent>;

--- a/src/app/archive-settings/manage-metadata/subcomponents/form-edit/form-edit.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/form-edit/form-edit.component.spec.ts
@@ -1,11 +1,11 @@
 import { Shallow } from 'shallow-render';
-import { FormEditComponent } from './form-edit.component';
-import { ManageMetadataModule } from '../../manage-metadata.module';
-import { MetadataValuePipe } from '../../pipes/metadata-value.pipe';
-
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { A11yModule } from '@angular/cdk/a11y';
+import { ManageMetadataModule } from '../../manage-metadata.module';
+import { MetadataValuePipe } from '../../pipes/metadata-value.pipe';
+import { FormEditComponent } from './form-edit.component';
+
 
 describe('FormEditComponent', () => {
   let shallow: Shallow<FormEditComponent>;

--- a/src/app/archive-settings/manage-metadata/subcomponents/value-add/add-new-value.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/value-add/add-new-value.component.spec.ts
@@ -1,11 +1,11 @@
-import { AddNewValueComponent } from './add-new-value.component';
 import { Shallow } from 'shallow-render';
-import { ManageMetadataModule } from '../../manage-metadata.module';
 import { FormsModule } from '@angular/forms';
 import { MessageService } from '@shared/services/message/message.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { TagVOData } from '@models/tag-vo';
+import { ManageMetadataModule } from '../../manage-metadata.module';
 import { FormCreateComponent } from '../form-create/form-create.component';
+import { AddNewValueComponent } from './add-new-value.component';
 
 describe('AddNewValueComponent', () => {
   let shallow: Shallow<AddNewValueComponent>;

--- a/src/app/archive-settings/manage-metadata/subcomponents/value-edit/value-edit.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/value-edit/value-edit.component.spec.ts
@@ -1,14 +1,14 @@
 import { Shallow } from 'shallow-render';
-import { EditValueComponent } from './value-edit.component';
-import { ManageMetadataModule } from '../../manage-metadata.module';
-import { MetadataValuePipe } from '../../pipes/metadata-value.pipe';
 
 import { TagVO, TagVOData } from '@models/tag-vo';
 import { ApiService } from '@shared/services/api/api.service';
 import { FormsModule } from '@angular/forms';
 import { MessageService } from '@shared/services/message/message.service';
-import { FormEditComponent } from '../form-edit/form-edit.component';
 import { PromptService } from '@shared/services/prompt/prompt.service';
+import { FormEditComponent } from '../form-edit/form-edit.component';
+import { MetadataValuePipe } from '../../pipes/metadata-value.pipe';
+import { ManageMetadataModule } from '../../manage-metadata.module';
+import { EditValueComponent } from './value-edit.component';
 
 describe('EditValueComponent', () => {
   let shallow: Shallow<EditValueComponent>;

--- a/src/app/auth/auth.routes.ts
+++ b/src/app/auth/auth.routes.ts
@@ -6,16 +6,16 @@ import { RecaptchaModule } from 'ng-recaptcha';
 
 import { SharedModule } from '@shared/shared.module';
 
-import { AuthComponent } from './components/auth/auth.component';
 import { SignupComponent } from '@auth/components/signup/signup.component';
 import { VerifyComponent } from '@auth/components/verify/verify.component';
 import { MfaComponent } from '@auth/components/mfa/mfa.component';
 import { LoginComponent } from '@auth/components/login/login.component';
 import { ForgotPasswordComponent } from '@auth/components/forgot-password/forgot-password.component';
+import { AnnouncementModule } from '../announcement/announcement.module';
+import { AuthComponent } from './components/auth/auth.component';
 import { ShareInviteResolveService } from './resolves/share-invite-resolve.service';
 
 import { AuthGuard } from './guards/auth.guard';
-import { AnnouncementModule } from '../announcement/announcement.module';
 
 const unauthenticatedRoutes: Routes = [
   { path: 'login', component: LoginComponent, data: { title: 'Log In' } },

--- a/src/app/core/components/all-archives/all-archives.component.spec.ts
+++ b/src/app/core/components/all-archives/all-archives.component.spec.ts
@@ -2,12 +2,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep  } from 'lodash';
 
-import { AllArchivesComponent } from './all-archives.component';
 import { ArchiveResponse } from '@shared/services/api/index.repo';
 import { AccountService } from '@shared/services/account/account.service';
 import { SharedModule } from '@shared/shared.module';
 import { ArchiveVO } from '@root/app/models';
 import { ActivatedRoute } from '@angular/router';
+import { AllArchivesComponent } from './all-archives.component';
 
 const archiveResponseData = require('@root/test/responses/archive.get.multiple.success.json');
 

--- a/src/app/core/components/archive-payer/archive-payer.component.spec.ts
+++ b/src/app/core/components/archive-payer/archive-payer.component.spec.ts
@@ -1,10 +1,10 @@
 /* @format */
-import { MessageService } from '../../../shared/services/message/message.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ArchivePayerComponent } from './archive-payer.component';
 import { ArchiveVO, AccountVO } from '@models/index';
+import { MessageService } from '../../../shared/services/message/message.service';
+import { ArchivePayerComponent } from './archive-payer.component';
 
 describe('ArchivePayerComponent', () => {
   let component: ArchivePayerComponent;

--- a/src/app/core/components/archive-payer/archive-payer.component.ts
+++ b/src/app/core/components/archive-payer/archive-payer.component.ts
@@ -1,12 +1,12 @@
 /* @format */
-import { MessageService } from '../../../shared/services/message/message.service';
-import { ApiService } from '../../../shared/services/api/api.service';
 import { Dialog } from '@root/app/dialog/dialog.module';
-import { AccountVO } from '../../../models/account-vo';
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { ArchiveVO } from '@models/index';
 import { AccountService } from '@shared/services/account/account.service';
 import { SwitcherComponent } from '@shared/components/switcher/switcher.component';
+import { AccountVO } from '../../../models/account-vo';
+import { ApiService } from '../../../shared/services/api/api.service';
+import { MessageService } from '../../../shared/services/message/message.service';
 
 @Component({
   selector: 'pr-archive-payer',

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -1,7 +1,6 @@
 /* @format*/
 import { Component, OnInit } from '@angular/core';
 import { IsTabbedDialog, DialogRef } from '@root/app/dialog/dialog.module';
-import { AccountVO } from '../../../models/account-vo';
 import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { TagsService } from '@core/services/tags/tags.service';
@@ -9,6 +8,7 @@ import { TagVO } from '@models/tag-vo';
 import { ArchiveVO } from '@models/index';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { AccountVO } from '../../../models/account-vo';
 
 type ArchiveSettingsDialogTab =
   | 'manage-keywords'

--- a/src/app/core/components/archive-switcher/archive-switcher.component.spec.ts
+++ b/src/app/core/components/archive-switcher/archive-switcher.component.spec.ts
@@ -2,13 +2,13 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep  } from 'lodash';
 
-import { ArchiveSwitcherComponent } from './archive-switcher.component';
 import { BgImageSrcDirective } from '@shared/directives/bg-image-src.directive';
 import { ArchiveResponse } from '@shared/services/api/index.repo';
 import { AccountService } from '@shared/services/account/account.service';
 import { SharedModule } from '@shared/shared.module';
 import { ArchiveVO } from '@root/app/models';
 import { ActivatedRoute } from '@angular/router';
+import { ArchiveSwitcherComponent } from './archive-switcher.component';
 
 const archiveResponseData = require('@root/test/responses/archive.get.multiple.success.json');
 

--- a/src/app/core/components/confirm-payer-dialog/confirm-payer-dialog.component.spec.ts
+++ b/src/app/core/components/confirm-payer-dialog/confirm-payer-dialog.component.spec.ts
@@ -6,9 +6,9 @@ import {
   TestModuleMetadata,
 } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
-import { ConfirmPayerDialogComponent } from './confirm-payer-dialog.component';
 import { cloneDeep } from 'lodash';
 import { SharedModule } from '../../../shared/shared.module';
+import { ConfirmPayerDialogComponent } from './confirm-payer-dialog.component';
 
 describe('ConfirmPayerDialogComponent', () => {
   let component: ConfirmPayerDialogComponent;

--- a/src/app/core/components/folder-picker/folder-picker.component.spec.ts
+++ b/src/app/core/components/folder-picker/folder-picker.component.spec.ts
@@ -3,7 +3,6 @@ import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep, some, remove } from 'lodash';
 import { environment } from '@root/environments/environment';
 
-import { FolderPickerComponent } from './folder-picker.component';
 import { DataService } from '@shared/services/data/data.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { FolderResponse } from '@shared/services/api/index.repo';
@@ -13,6 +12,7 @@ import { HttpTestingController, TestRequest } from '@angular/common/http/testing
 import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
 import { DataStatus } from '@models/data-status.enum';
 import { of } from 'rxjs';
+import { FolderPickerComponent } from './folder-picker.component';
 
 describe('FolderPickerComponent', () => {
   let component: FolderPickerComponent;

--- a/src/app/core/components/loading-archive/loading-archive.component.spec.ts
+++ b/src/app/core/components/loading-archive/loading-archive.component.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { LoadingArchiveComponent } from './loading-archive.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
+import { LoadingArchiveComponent } from './loading-archive.component';
 
 describe('LoadingArchiveComponent', () => {
   let component: LoadingArchiveComponent;

--- a/src/app/core/components/main/main.component.spec.ts
+++ b/src/app/core/components/main/main.component.spec.ts
@@ -19,16 +19,16 @@ import { RightMenuComponent } from '@core/components/right-menu/right-menu.compo
 import { UploadButtonComponent } from '@core/components/upload-button/upload-button.component';
 import { SharedModule } from '@shared/shared.module';
 import { DataService } from '@shared/services/data/data.service';
-import { FolderPickerComponent } from '../folder-picker/folder-picker.component';
 import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
 import { DialogComponent } from '@root/app/dialog/dialog.component';
 import { Dialog } from '@root/app/dialog/dialog.service';
 import { DialogModule } from '@root/app/dialog/dialog.module';
-import { MultiSelectStatusComponent } from '../multi-select-status/multi-select-status.component';
 import { GlobalSearchBarComponent } from '@search/components/global-search-bar/global-search-bar.component';
 import { SearchService } from '@search/services/search.service';
 import { TagsService } from '@core/services/tags/tags.service';
+import { MultiSelectStatusComponent } from '../multi-select-status/multi-select-status.component';
+import { FolderPickerComponent } from '../folder-picker/folder-picker.component';
 
 const defaultAuthData = require('@root/test/responses/auth.login.success.json') as any;
 

--- a/src/app/core/components/manage-tags/manage-tags.component.spec.ts
+++ b/src/app/core/components/manage-tags/manage-tags.component.spec.ts
@@ -1,10 +1,10 @@
 import { NgModule } from '@angular/core';
 import { Shallow } from 'shallow-render';
-import { ManageTagsComponent } from './manage-tags.component';
 
 import { TagVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
+import { ManageTagsComponent } from './manage-tags.component';
 
 @NgModule({
   declarations: [], // components your module owns.

--- a/src/app/core/components/profile-edit/profile-edit.component.ts
+++ b/src/app/core/components/profile-edit/profile-edit.component.ts
@@ -16,8 +16,8 @@ import { PromptService, READ_ONLY_FIELD } from '@shared/services/prompt/prompt.s
 import { Deferred } from '@root/vendor/deferred';
 import { some } from 'lodash';
 import { CookieService } from 'ngx-cookie-service';
-import { PROFILE_ONBOARDING_COOKIE } from '../profile-edit-first-time-dialog/profile-edit-first-time-dialog.component';
 import { copyFromInputElement } from '@shared/utilities/forms';
+import { PROFILE_ONBOARDING_COOKIE } from '../profile-edit-first-time-dialog/profile-edit-first-time-dialog.component';
 
 @Component({
   selector: 'pr-profile-edit',

--- a/src/app/core/components/public-settings/public-settings.component.spec.ts
+++ b/src/app/core/components/public-settings/public-settings.component.spec.ts
@@ -1,10 +1,10 @@
-import { PublicSettingsComponent } from './public-settings.component';
 
 import { NgModule } from '@angular/core';
 import { Shallow } from 'shallow-render';
 
 import { ArchiveVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
+import { PublicSettingsComponent } from './public-settings.component';
 
 @NgModule({
   declarations: [], // components your module owns.

--- a/src/app/core/components/upload-button/upload-button.component.spec.ts
+++ b/src/app/core/components/upload-button/upload-button.component.spec.ts
@@ -2,12 +2,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep  } from 'lodash';
 
-import { UploadButtonComponent } from './upload-button.component';
 import { DataService } from '@shared/services/data/data.service';
 import { FolderVO, ArchiveVO } from '@root/app/models';
 import { AccountService } from '@shared/services/account/account.service';
 
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { UploadButtonComponent } from './upload-button.component';
 
 describe('UploadButtonComponent', () => {
   let component: UploadButtonComponent;

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -18,48 +18,48 @@ import { LeftMenuComponent } from '@core/components/left-menu/left-menu.componen
 import { UploadProgressComponent } from '@core/components/upload-progress/upload-progress.component';
 import { UploadButtonComponent } from '@core/components/upload-button/upload-button.component';
 import { RightMenuComponent } from '@core/components/right-menu/right-menu.component';
-import { ArchiveSwitcherComponent } from './components/archive-switcher/archive-switcher.component';
 import { FolderPickerComponent } from '@core/components/folder-picker/folder-picker.component';
 import {
   DialogModule,
   DialogChildComponentData,
   Dialog,
 } from '@root/app/dialog/dialog.module';
-import { MultiSelectStatusComponent } from './components/multi-select-status/multi-select-status.component';
-import { EditService } from './services/edit/edit.service';
 import { RouterModule } from '@angular/router';
 import { DragService } from '@shared/services/drag/drag.service';
 import { SearchModule } from '@search/search.module';
+import { PortalModule } from '@angular/cdk/portal';
+import { ProfileService } from '@shared/services/profile/profile.service';
+import { CountUpModule } from 'ngx-countup';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { PledgeModule } from '../pledge/pledge.module';
+import { AnnouncementModule } from '../announcement/announcement.module';
+import { ManageMetadataModule } from '../archive-settings/manage-metadata/manage-metadata.module';
+import { DirectiveModule } from '../directive/directive.module';
+import { ArchiveSwitcherComponent } from './components/archive-switcher/archive-switcher.component';
+import { MultiSelectStatusComponent } from './components/multi-select-status/multi-select-status.component';
+import { EditService } from './services/edit/edit.service';
 import { AccountSettingsComponent } from './components/account-settings/account-settings.component';
 import { ProfileEditComponent } from './components/profile-edit/profile-edit.component';
 import { NotificationPreferencesComponent } from './components/notification-preferences/notification-preferences.component';
-import { PortalModule } from '@angular/cdk/portal';
 import { SidebarActionPortalService } from './services/sidebar-action-portal/sidebar-action-portal.service';
 import { AccountSettingsDialogComponent } from './components/account-settings-dialog/account-settings-dialog.component';
 import { AllArchivesComponent } from './components/all-archives/all-archives.component';
 import { ConnectionsDialogComponent } from './components/connections-dialog/connections-dialog.component';
 import { MembersDialogComponent } from './components/members-dialog/members-dialog.component';
-import { ProfileService } from '@shared/services/profile/profile.service';
 import { MyArchivesDialogComponent } from './components/my-archives-dialog/my-archives-dialog.component';
 import { InvitationsDialogComponent } from './components/invitations-dialog/invitations-dialog.component';
 import { LoadingArchiveComponent } from './components/loading-archive/loading-archive.component';
-import { CountUpModule } from 'ngx-countup';
 import { ProfileEditFirstTimeDialogComponent } from './components/profile-edit-first-time-dialog/profile-edit-first-time-dialog.component';
 import { StorageDialogComponent } from './components/storage-dialog/storage-dialog.component';
 import { FileHistoryComponent } from './components/file-history/file-history.component';
 import { TransactionHistoryComponent } from './components/transaction-history/transaction-history.component';
 import { BillingSettingsComponent } from './components/billing-settings/billing-settings.component';
-import { NotificationsModule } from '../notifications/notifications.module';
-import { PledgeModule } from '../pledge/pledge.module';
 import { ArchiveSettingsDialogComponent } from './components/archive-settings-dialog/archive-settings-dialog.component';
 import { ManageTagsComponent } from './components/manage-tags/manage-tags.component';
 import { WelcomeDialogComponent } from './components/welcome-dialog/welcome-dialog.component';
 import { WelcomeInvitationDialogComponent } from './components/welcome-invitation-dialog/welcome-invitation-dialog.component';
-import { AnnouncementModule } from '../announcement/announcement.module';
 import { PublicSettingsComponent } from './components/public-settings/public-settings.component';
-import { ManageMetadataModule } from '../archive-settings/manage-metadata/manage-metadata.module';
 import { ArchiveTypeChangeDialogComponent } from './components/archive-type-change-dialog/archive-type-change-dialog.component';
-import { DirectiveModule } from '../directive/directive.module';
 import { ArchivePayerComponent } from './components/archive-payer/archive-payer.component';
 import { ConfirmPayerDialogComponent } from './components/confirm-payer-dialog/confirm-payer-dialog.component';
 

--- a/src/app/core/core.routes.ts
+++ b/src/app/core/core.routes.ts
@@ -10,20 +10,20 @@ import { FolderResolveService } from '@core/resolves/folder-resolve.service';
 import { RootFolderResolveService } from '@core/resolves/root-folder-resolve.service';
 import { RecordResolveService } from '@core/resolves/record-resolve.service';
 import { ArchivesResolveService } from '@core/resolves/archives-resolve.service';
-import { RelationshipsResolveService } from './resolves/relationships-resolve.service';
-
 import { SharedModule } from '@shared/shared.module';
 import { ArchiveSwitcherComponent } from '@core/components/archive-switcher/archive-switcher.component';
-import { MembersResolveService } from './resolves/members-resolve.service';
+import { GlobalSearchResultsComponent } from '@search/components/global-search-results/global-search-results.component';
+import { RoutedDialogWrapperComponent } from '@shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component';
 import { RoutesWithData } from '../app.routes';
+import { RelationshipsResolveService } from './resolves/relationships-resolve.service';
+
+import { MembersResolveService } from './resolves/members-resolve.service';
 import { AccountResolveService } from './resolves/account-resolve.service';
 import { ProfileEditComponent } from './components/profile-edit/profile-edit.component';
 import { ProfileItemsResolveService } from './resolves/profile-items-resolve.service';
-import { GlobalSearchResultsComponent } from '@search/components/global-search-results/global-search-results.component';
 import { TagsResolveService } from './resolves/tags.resolve.service';
 import { AllArchivesComponent } from './components/all-archives/all-archives.component';
 import { LoadingArchiveComponent } from './components/loading-archive/loading-archive.component';
-import { RoutedDialogWrapperComponent } from '@shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component';
 import { MyfilesGuard } from './guards/myfiles.guard';
 
 const rootFolderResolve = {

--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -27,13 +27,13 @@ import {
 } from '@shared/services/prompt/prompt.service';
 import { Deferred } from '@root/vendor/deferred';
 import { FolderPickerOperations } from '@core/components/folder-picker/folder-picker.component';
-import { FolderPickerService } from '../folder-picker/folder-picker.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { Dialog } from '@root/app/dialog/dialog.service';
 import { DeviceService } from '@shared/services/device/device.service';
 import { SecretsService } from '@shared/services/secrets/secrets.service';
 
 import type { KeysOfType } from '@shared/utilities/keysoftype';
+import { FolderPickerService } from '../folder-picker/folder-picker.service';
 
 export const ItemActions: { [key: string]: PromptButton } = {
   Rename: {

--- a/src/app/core/services/relationship/relationship.service.spec.ts
+++ b/src/app/core/services/relationship/relationship.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed, inject } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 
-import { RelationshipService } from './relationship.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { cloneDeep } from 'lodash';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CookieService } from 'ngx-cookie-service';
 import { StorageService } from '@shared/services/storage/storage.service';
+import { RelationshipService } from './relationship.service';
 
 describe('RelationshipService', () => {
   beforeEach(() => {

--- a/src/app/core/services/tags/tags.service.spec.ts
+++ b/src/app/core/services/tags/tags.service.spec.ts
@@ -2,11 +2,11 @@
 import { TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 
-import { TagsService } from './tags.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { ArchiveVO, RecordVO } from '@models';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ApiService } from '@shared/services/api/api.service';
+import { TagsService } from './tags.service';
 
 describe('TagsService', () => {
   let service: TagsService;

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -11,8 +11,6 @@ import { MessageService } from '@shared/services/message/message.service';
 
 import { FolderVO } from '@root/app/models';
 
-import { UploadSession, UploadSessionStatus } from './upload.session';
-import { UploadItem, UploadStatus } from './uploadItem';
 import { UploadButtonComponent } from '@core/components/upload-button/upload-button.component';
 import { Subscription } from 'rxjs';
 import {
@@ -22,6 +20,8 @@ import {
 import debug from 'debug';
 import { AccountService } from '@shared/services/account/account.service';
 import { Deferred } from '@root/vendor/deferred';
+import { UploadItem, UploadStatus } from './uploadItem';
+import { UploadSession, UploadSessionStatus } from './upload.session';
 
 const FILENAME_BLACKLIST = ['.DS_Store'];
 

--- a/src/app/core/services/upload/upload.session.ts
+++ b/src/app/core/services/upload/upload.session.ts
@@ -2,9 +2,9 @@
 import { Injectable, EventEmitter } from '@angular/core';
 import { BaseResponse } from '@shared/services/api/base';
 import { FolderVO } from '@root/app/models';
+import debug from 'debug';
 import { Uploader } from './uploader';
 import { UploadItem, UploadStatus } from './uploadItem';
-import debug from 'debug';
 
 export enum UploadSessionStatus {
   Start,

--- a/src/app/dialog/dialog.component.ts
+++ b/src/app/dialog/dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewContainerRef, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
-import { DialogOptions, DialogRef } from './dialog.service';
 import { DeviceService } from '@shared/services/device/device.service';
+import { DialogOptions, DialogRef } from './dialog.service';
 
 @Component({
   selector: 'pr-dialog',

--- a/src/app/dialog/dialog.service.ts
+++ b/src/app/dialog/dialog.service.ts
@@ -1,12 +1,12 @@
 // eslint-disable-next-line max-len
 import { Injectable, ApplicationRef, ElementRef, ComponentRef, ComponentFactory, ComponentFactoryResolver, Injector, InjectionToken, Inject, ViewChild, TemplateRef } from '@angular/core';
 import { PortalInjector } from '@root/vendor/portal-injector';
-import { DialogComponent } from './dialog.component';
 import { Deferred } from '@root/vendor/deferred';
-import { DialogRootComponent } from './dialog-root.component';
 import { DOCUMENT } from '@angular/common';
 import debug from 'debug';
 import { ActivatedRoute } from '@angular/router';
+import { DialogRootComponent } from './dialog-root.component';
+import { DialogComponent } from './dialog.component';
 
 export type DialogComponentToken =
   'FamilySearchImportComponent' |

--- a/src/app/directive/components/directive-display/directive-display.component.spec.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.spec.ts
@@ -1,17 +1,17 @@
 import { Shallow } from 'shallow-render';
 
-import { DirectiveDisplayComponent } from './directive-display.component';
-import { DirectiveModule } from '../../directive.module';
-
 import { ArchiveVO } from '@models/index';
 import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { DirectiveModule } from '../../directive.module';
+import { DirectiveDisplayComponent } from './directive-display.component';
+
 
 import {
   MockAccountService,
   MockApiService,
   MockDirectiveRepo,
 } from './test-utils';
-import { ApiService } from '@shared/services/api/api.service';
 
 describe('DirectiveDisplayComponent', () => {
   let shallow: Shallow<DirectiveDisplayComponent>;

--- a/src/app/directive/components/directive-display/directive-display.stories.ts
+++ b/src/app/directive/components/directive-display/directive-display.stories.ts
@@ -1,17 +1,17 @@
 import { Meta, moduleMetadata, Story } from '@storybook/angular';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
+import { AccountService } from '@shared/services/account/account.service';
+import { ArchiveVO } from '@models/index';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ApiService } from '@shared/services/api/api.service';
+import { DirectiveModule } from '../../directive.module';
+import { DirectiveDisplayComponent } from './directive-display.component';
 import {
   MockAccountService,
   MockApiService,
   MockDirectiveRepo,
 } from './test-utils';
-import { DirectiveModule } from '../../directive.module';
-import { DirectiveDisplayComponent } from './directive-display.component';
-import { AccountService } from '@shared/services/account/account.service';
-import { ArchiveVO } from '@models/index';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ApiService } from '@shared/services/api/api.service';
 
 export default {
   title: 'Directive Display',

--- a/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
@@ -5,6 +5,7 @@ import { ApiService } from '@shared/services/api/api.service';
 import { Shallow } from 'shallow-render';
 import { QueryMatch } from 'shallow-render/dist/lib/models/query-match';
 
+import { MessageService } from '@shared/services/message/message.service';
 import { DirectiveModule } from '../../directive.module';
 import { MockAccountService } from '../directive-display/test-utils';
 import { DirectiveEditComponent } from './directive-edit.component';
@@ -14,7 +15,6 @@ import {
   MockMessageService,
   createDirective,
 } from './test-utils';
-import { MessageService } from '@shared/services/message/message.service';
 
 class MockApiService {
   public directive = new MockDirectiveRepo();

--- a/src/app/directive/components/directive-edit/directive-edit.stories.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.stories.ts
@@ -3,16 +3,16 @@ import { action } from '@storybook/addon-actions';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-import { DirectiveModule } from '../../directive.module';
-import { DirectiveEditComponent } from './directive-edit.component';
 
-import { MockDirectiveRepo, createDirective } from './test-utils';
-import { MockAccountService } from '../directive-display/test-utils';
 import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { MessageService } from '@shared/services/message/message.service';
 import { ArchiveVO } from '@models/index';
 import { Directive } from '@angular/core';
+import { MockAccountService } from '../directive-display/test-utils';
+import { DirectiveModule } from '../../directive.module';
+import { MockDirectiveRepo, createDirective } from './test-utils';
+import { DirectiveEditComponent } from './directive-edit.component';
 
 const savedAction = action('savedDirective');
 const errorAction = action('Error Message in UI');

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
@@ -1,14 +1,14 @@
 /* @format */
 import { ApiService } from '@shared/services/api/api.service';
 import { Shallow } from 'shallow-render';
-import { DirectiveModule } from '../../directive.module';
-import { LegacyContactDisplayComponent } from './legacy-contact-display.component';
-import { MockAccountService } from '../directive-display/test-utils';
 import { AccountService } from '@shared/services/account/account.service';
 import { MessageService } from '@shared/services/message/message.service';
-import { MockMessageService } from '../directive-edit/test-utils';
-import { MockApiService, MockDirectiveRepo } from './test-utils';
 import { LegacyContact } from '@models/directive';
+import { DirectiveModule } from '../../directive.module';
+import { MockAccountService } from '../directive-display/test-utils';
+import { MockMessageService } from '../directive-edit/test-utils';
+import { LegacyContactDisplayComponent } from './legacy-contact-display.component';
+import { MockApiService, MockDirectiveRepo } from './test-utils';
 
 describe('LegacyContactDisplayComponent', () => {
   let shallow: Shallow<LegacyContactDisplayComponent>;

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.spec.ts
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.spec.ts
@@ -2,13 +2,13 @@
 import { Type, DebugElement } from '@angular/core';
 import { Shallow } from 'shallow-render';
 import { QueryMatch } from 'shallow-render/dist/lib/models/query-match';
-import { LegacyContactEditComponent } from './legacy-contact-edit.component';
-import { DirectiveModule } from '../../directive.module';
 import { LegacyContact } from '@models/directive';
 import { ApiService } from '@shared/services/api/api.service';
-import { MockDirectiveRepo } from '../legacy-contact-display/test-utils';
 import { MessageService } from '@shared/services/message/message.service';
+import { DirectiveModule } from '../../directive.module';
+import { MockDirectiveRepo } from '../legacy-contact-display/test-utils';
 import { MockMessageService } from '../directive-edit/test-utils';
+import { LegacyContactEditComponent } from './legacy-contact-edit.component';
 
 type Find = (
   cssOrDirective: string | Type<any>,

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.stories.ts
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.stories.ts
@@ -3,13 +3,13 @@ import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { MessageService } from '@shared/services/message/message.service';
+import { LegacyContact } from '@models/directive';
+import { action } from '@storybook/addon-actions';
 import { DirectiveModule } from '../../directive.module';
 import { MockAccountService } from '../directive-display/test-utils';
 import { MockDirectiveRepo } from '../legacy-contact-display/test-utils';
 import { LegacyContactEditComponent } from './legacy-contact-edit.component';
-import { MessageService } from '@shared/services/message/message.service';
-import { LegacyContact } from '@models/directive';
-import { action } from '@storybook/addon-actions';
 
 type Story = StoryObj<LegacyContactEditComponent>;
 

--- a/src/app/directive/directive.module.ts
+++ b/src/app/directive/directive.module.ts
@@ -1,7 +1,6 @@
 /* @format */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DirectiveDisplayComponent } from './components/directive-display/directive-display.component';
 import {
   FontAwesomeModule,
   FaIconLibrary,
@@ -10,8 +9,9 @@ import {
   faChevronLeft,
   faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons';
-import { DirectiveEditComponent } from './components/directive-edit/directive-edit.component';
 import { FormsModule } from '@angular/forms';
+import { DirectiveEditComponent } from './components/directive-edit/directive-edit.component';
+import { DirectiveDisplayComponent } from './components/directive-display/directive-display.component';
 import { DirectiveDialogComponent } from './components/directive-dialog/directive-dialog.component';
 import { LegacyContactDisplayComponent } from './components/legacy-contact-display/legacy-contact-display.component';
 import { LegacyContactEditComponent } from './components/legacy-contact-edit/legacy-contact-edit.component';

--- a/src/app/embed/embed.routes.ts
+++ b/src/app/embed/embed.routes.ts
@@ -2,11 +2,11 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { SharedModule } from '@shared/shared.module';
-import { EmbedComponentsModule } from './embed-components.module';
 
 import { SignupEmbedComponent } from '@embed/components/signup-embed/signup-embed.component';
 import { DoneEmbedComponent } from '@embed/components/done-embed/done-embed.component';
 import { VerifyEmbedComponent } from '@embed/components/verify-embed/verify-embed.component';
+import { EmbedComponentsModule } from './embed-components.module';
 import { NewsletterSignupComponent } from './components/newsletter-signup/newsletter-signup.component';
 import { LoginEmbedComponent } from './components/login-embed/login-embed.component';
 import { MfaEmbedComponent } from './components/mfa-embed/mfa-embed.component';

--- a/src/app/file-browser/components/download-button/download-button.component.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.ts
@@ -1,5 +1,4 @@
 /* @format */
-import { MessageService } from '../../../shared/services/message/message.service';
 import {
   Component,
   Input,
@@ -10,6 +9,7 @@ import {
 } from '@angular/core';
 import { RecordVO } from '@models/index';
 import { DataService } from '@shared/services/data/data.service';
+import { MessageService } from '../../../shared/services/message/message.service';
 
 interface Format {
   name: string;

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -3,8 +3,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Shallow } from 'shallow-render';
 import { Subject, Observable } from 'rxjs';
 
-import { EditTagsComponent, TagType } from './edit-tags.component';
-import { FileBrowserComponentsModule } from '../../file-browser-components.module';
 import { ItemVO, TagVOData, RecordVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
 import { DataService } from '@shared/services/data/data.service';
@@ -14,6 +12,8 @@ import { SearchService } from '@search/services/search.service';
 import { TagResponse } from '@shared/services/api/tag.repo';
 import { Dialog } from '@root/app/dialog/dialog.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FileBrowserComponentsModule } from '../../file-browser-components.module';
+import { EditTagsComponent, TagType } from './edit-tags.component';
 
 const defaultTagList: TagVOData[] = [
   {

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -55,7 +55,6 @@ import { checkMinimumAccess, AccessRole } from '@models/access-role';
 import { DeviceService } from '@shared/services/device/device.service';
 import { StorageService } from '@shared/services/storage/storage.service';
 
-import { ItemClickEvent } from '../file-list/file-list.component';
 import {
   DragService,
   DragServiceEvent,
@@ -74,6 +73,7 @@ import { InViewportTrigger } from 'ng-in-viewport';
 import { RouteData } from '@root/app/app.routes';
 
 import { ThumbnailCache } from '@shared/utilities/thumbnail-cache/thumbnail-cache';
+import { ItemClickEvent } from '../file-list/file-list.component';
 
 export const ItemActions: { [key: string]: PromptButton } = {
   Rename: {

--- a/src/app/file-browser/components/file-viewer/file-view.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-view.component.spec.ts
@@ -4,15 +4,15 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { Shallow } from 'shallow-render';
 
 import { RecordVO, ItemVO, TagVOData, AccessRole } from '@root/app/models';
-import { FileViewerComponent } from './file-viewer.component';
-import { TagsComponent } from '../../../shared/components/tags/tags.component';
 import { AccountService } from '@shared/services/account/account.service';
 import { DataService } from '@shared/services/data/data.service';
 import { EditService } from '@core/services/edit/edit.service';
-import { FileBrowserComponentsModule } from '../../file-browser-components.module';
 import { Observable } from '@shared/services/http/http.service';
 import { TagsService } from '@core/services/tags/tags.service';
 import { HttpClient } from '@angular/common/http';
+import { FileBrowserComponentsModule } from '../../file-browser-components.module';
+import { TagsComponent } from '../../../shared/components/tags/tags.component';
+import { FileViewerComponent } from './file-viewer.component';
 
 const defaultTagList: TagVOData[] = [
   {

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -26,9 +26,9 @@ import { EditService } from '@core/services/edit/edit.service';
 import { DataStatus } from '@models/data-status.enum';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
-import { TagsService } from '../../../core/services/tags/tags.service';
 import type { KeysOfType } from '@shared/utilities/keysoftype';
 import { Subscription } from 'rxjs';
+import { TagsService } from '../../../core/services/tags/tags.service';
 
 @Component({
   selector: 'pr-file-viewer',

--- a/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.spec.ts
+++ b/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.spec.ts
@@ -8,7 +8,6 @@ import {
 import { SharedModule } from '@shared/shared.module';
 import { cloneDeep } from 'lodash';
 import * as Testing from '@root/test/testbedConfig';
-import { SharingDialogComponent } from './sharing-dialog.component';
 import {
   DialogModule,
   DialogRef,
@@ -26,6 +25,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AccountService } from '@shared/services/account/account.service';
+import { SharingDialogComponent } from './sharing-dialog.component';
 import {
   MockAccountService,
   MockApiService,

--- a/src/app/file-browser/components/sharing-dialog/sharing-dialog.stories.ts
+++ b/src/app/file-browser/components/sharing-dialog/sharing-dialog.stories.ts
@@ -1,8 +1,6 @@
 import { Meta, moduleMetadata, Story } from '@storybook/angular';
-import { FileBrowserComponentsModule } from '../../file-browser-components.module';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.service';
 
-import { SharingDialogComponent } from './sharing-dialog.component';
 import { AccountService } from '@shared/services/account/account.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
 import { ApiService } from '@shared/services/api/api.service';
@@ -11,6 +9,8 @@ import { ArchiveVO, RecordVO, ShareByUrlVO } from '@models/index';
 import { ActivatedRoute } from '@angular/router';
 import { RelationshipService } from '@core/services/relationship/relationship.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FileBrowserComponentsModule } from '../../file-browser-components.module';
+import { SharingDialogComponent } from './sharing-dialog.component';
 
 import {
   MockAccountService,

--- a/src/app/file-browser/file-browser-components.module.ts
+++ b/src/app/file-browser/file-browser-components.module.ts
@@ -11,6 +11,8 @@ import { FileListItemComponent } from '@fileBrowser/components/file-list-item/fi
 import { FileViewerComponent } from '@fileBrowser/components/file-viewer/file-viewer.component';
 import { VideoComponent } from '@shared/components/video/video.component';
 import { SharingComponent } from '@fileBrowser/components/sharing/sharing.component';
+import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faFileArchive, fas } from '@fortawesome/free-solid-svg-icons';
 import { Dialog, DialogChildComponentData } from '../dialog/dialog.service';
 import { DialogModule } from '../dialog/dialog.module';
 import { FolderViewComponent } from './components/folder-view/folder-view.component';
@@ -23,8 +25,6 @@ import { LocationPickerComponent } from './components/location-picker/location-p
 import { SidebarViewOptionComponent } from './components/sidebar-view-option/sidebar-view-option.component';
 import { SharingDialogComponent } from './components/sharing-dialog/sharing-dialog.component';
 
-import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
-import { faFileArchive, fas } from '@fortawesome/free-solid-svg-icons';
 import { DownloadButtonComponent } from './components/download-button/download-button.component';
 
 @NgModule({

--- a/src/app/file-browser/file-browser.module.ts
+++ b/src/app/file-browser/file-browser.module.ts
@@ -10,9 +10,9 @@ import { FileListComponent } from '@fileBrowser/components/file-list/file-list.c
 import { FileListItemComponent } from '@fileBrowser/components/file-list-item/file-list-item.component';
 import { FileViewerComponent } from '@fileBrowser/components/file-viewer/file-viewer.component';
 import { VideoComponent } from '@shared/components/video/video.component';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { DialogModule } from '../dialog/dialog.module';
 import { FileBrowserComponentsModule } from './file-browser-components.module';
-import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
   imports: [

--- a/src/app/gallery/components/gallery/gallery.component.ts
+++ b/src/app/gallery/components/gallery/gallery.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { environment } from '@root/environments/environment';
+import { SecretsService } from '@shared/services/secrets/secrets.service';
 import { FeaturedArchive } from '../../types/featured-archive';
 import { featuredArchives } from '../../data/featured';
-import { SecretsService } from '@shared/services/secrets/secrets.service';
 
 @Component({
   selector: 'pr-gallery',

--- a/src/app/gallery/gallery.module.ts
+++ b/src/app/gallery/gallery.module.ts
@@ -2,9 +2,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { GalleryRoutingModule } from './gallery-routing.module';
-import { GalleryComponent } from './components/gallery/gallery.component';
-import { GalleryHeaderComponent } from './components/gallery-header/gallery-header.component';
 
 import { SharedModule } from '@shared/shared.module';
 import { AccountService } from '@shared/services/account/account.service';
@@ -14,6 +11,9 @@ import {
   FaIconLibrary,
 } from '@fortawesome/angular-fontawesome';
 import { faSearch, faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import { GalleryHeaderComponent } from './components/gallery-header/gallery-header.component';
+import { GalleryComponent } from './components/gallery/gallery.component';
+import { GalleryRoutingModule } from './gallery-routing.module';
 import { FeaturedArchiveComponent } from './components/featured-archive/featured-archive.component';
 
 @NgModule({

--- a/src/app/gallery/gallery.module.ts
+++ b/src/app/gallery/gallery.module.ts
@@ -2,7 +2,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-
 import { SharedModule } from '@shared/shared.module';
 import { AccountService } from '@shared/services/account/account.service';
 import { PublicModule } from '@public/public.module';

--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -3,13 +3,13 @@ import { RecordVO } from '@models/record-vo';
 import { DataStatus } from '@models/data-status.enum';
 import { ShareVO, sortShareVOs } from '@models/share-vo';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
+import { formatDateISOString } from '@shared/utilities/dateTime';
 import { AccessRoleType } from './access-role';
 import { TimezoneVOData } from './timezone-vo';
-import { ItemVO, ArchiveVO } from '.';
 import { FolderType, SortType, FolderLinkType } from './vo-types';
-import { formatDateISOString } from '@shared/utilities/dateTime';
 import { LocnVOData } from './locn-vo';
 import { TagVOData } from './tag-vo';
+import { ItemVO, ArchiveVO } from '.';
 
 export interface HasParentFolder {
   parentDisplayName?: string;

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -1,15 +1,15 @@
 import { BaseVO, BaseVOData, DynamicListChild } from '@models/base-vo';
 import { DataStatus } from '@models/data-status.enum';
 import { ShareVO, sortShareVOs } from '@models/share-vo';
+import { formatDateISOString } from '@shared/utilities/dateTime';
+import { orderBy } from 'lodash';
 import { AccessRoleType } from './access-role';
 import { TimezoneVOData } from './timezone-vo';
 import { ChildItemData, HasParentFolder } from './folder-vo';
 import { RecordType, FolderLinkType } from './vo-types';
-import { formatDateISOString } from '@shared/utilities/dateTime';
 import { LocnVOData } from './locn-vo';
 import { TagVOData } from './tag-vo';
 import { ArchiveVO } from './archive-vo';
-import { orderBy } from 'lodash';
 
 export class RecordVO extends BaseVO implements ChildItemData, HasParentFolder, DynamicListChild {
   public cleanParams = ['recordId', 'archiveNbr', 'folder_linkId', 'parentFolder_linkId', 'parentFolderId', 'uploadFileName'];

--- a/src/app/notifications/components/notification-dialog/notification-dialog.component.ts
+++ b/src/app/notifications/components/notification-dialog/notification-dialog.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit, Inject, ViewChildren, AfterViewInit, OnDestroy, ElementRef, QueryList } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@root/app/dialog/dialog.module';
-import { NotificationService } from '../../services/notification.service';
-import { NotificationComponent } from '../notification/notification.component';
 import { HasSubscriptions, unsubscribeAll } from '@shared/utilities/hasSubscriptions';
 import { Subscription } from 'rxjs';
 import { NotificationVOData } from '@models/notification-vo';
+import { NotificationComponent } from '../notification/notification.component';
+import { NotificationService } from '../../services/notification.service';
 
 @Component({
   selector: 'pr-notification-dialog',

--- a/src/app/notifications/notifications.module.ts
+++ b/src/app/notifications/notifications.module.ts
@@ -1,10 +1,10 @@
 import { NgModule, Optional, ComponentFactoryResolver } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { SharedModule } from '@shared/shared.module';
+import { DialogChildComponentData, Dialog } from '../dialog/dialog.module';
 import { NotificationService } from './services/notification.service';
 import { NotificationComponent } from './components/notification/notification.component';
 import { NotificationDialogComponent } from './components/notification-dialog/notification-dialog.component';
-import { DialogChildComponentData, Dialog } from '../dialog/dialog.module';
-import { SharedModule } from '@shared/shared.module';
 
 @NgModule({
   declarations: [NotificationComponent, NotificationDialogComponent],

--- a/src/app/notifications/services/notification.service.spec.ts
+++ b/src/app/notifications/services/notification.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, fakeAsync, flushMicrotasks, discardPeriodicTasks } from '@angular/core/testing';
 
-import { NotificationService } from './notification.service';
 import { SharedModule } from '@shared/shared.module';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -10,6 +9,7 @@ import { ApiService } from '@shared/services/api/api.service';
 import { NotificationResponse } from '@shared/services/api/index.repo';
 import { NotificationVOData } from '@models/notification-vo';
 import { cloneDeep } from 'lodash';
+import { NotificationService } from './notification.service';
 
 const allNotificationsData: NotificationVOData[] = [
   {

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
@@ -1,10 +1,10 @@
 import { Shallow } from 'shallow-render';
 
-import { CreateNewArchiveComponent } from './create-new-archive.component';
 import { OnboardingModule } from '@onboarding/onboarding.module';
 
 import { ArchiveVO } from '@models/archive-vo';
 import { ApiService } from '@shared/services/api/api.service';
+import { CreateNewArchiveComponent } from './create-new-archive.component';
 
 let calledCreate: boolean = false;
 let createdArchive: ArchiveVO | null;

--- a/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
@@ -2,8 +2,6 @@ import { Shallow } from 'shallow-render';
 import { Location } from '@angular/common';
 import { ActivatedRoute, RouterModule, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { OnboardingComponent } from './onboarding.component';
-import { OnboardingModule } from '../../onboarding.module';
 
 import { ArchiveVO } from '@models/archive-vo';
 import { AccountVO } from '@models/account-vo';
@@ -11,6 +9,8 @@ import { OnboardingScreen } from '@onboarding/shared/onboarding-screen';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
+import { OnboardingModule } from '../../onboarding.module';
+import { OnboardingComponent } from './onboarding.component';
 
 class NullRoute {
   public snapshot = {

--- a/src/app/onboarding/components/welcome-screen/welcome-screen.component.spec.ts
+++ b/src/app/onboarding/components/welcome-screen/welcome-screen.component.spec.ts
@@ -1,8 +1,8 @@
 import { Shallow } from 'shallow-render';
-import { WelcomeScreenComponent } from './welcome-screen.component';
-import { OnboardingModule } from '../../onboarding.module';
-
 import { ArchiveVO } from '@models/archive-vo';
+import { OnboardingModule } from '../../onboarding.module';
+import { WelcomeScreenComponent } from './welcome-screen.component';
+
 
 describe('WelcomeScreenComponent #onboarding', () => {
   let shallow: Shallow<WelcomeScreenComponent>;

--- a/src/app/onboarding/onboarding.module.ts
+++ b/src/app/onboarding/onboarding.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { SharedModule } from '@shared/shared.module';
 import { OnboardingRoutingModule } from './onboarding.routes';
 import { OnboardingComponent } from './components/onboarding/onboarding.component';
 import { WelcomeScreenComponent } from './components/welcome-screen/welcome-screen.component';
 import { CreateNewArchiveComponent } from './components/create-new-archive/create-new-archive.component';
 
-import { SharedModule } from '@shared/shared.module';
 
 @NgModule({
   declarations: [

--- a/src/app/pledge/components/claim-storage/claim-storage.component.ts
+++ b/src/app/pledge/components/claim-storage/claim-storage.component.ts
@@ -11,8 +11,8 @@ import { AccountVO } from '@root/app/models';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AccountService } from '@shared/services/account/account.service';
 import { PledgeService } from '@pledge/services/pledge.service';
-import { PledgeData } from '../new-pledge/new-pledge.component';
 import { ApiService } from '@shared/services/api/api.service';
+import { PledgeData } from '../new-pledge/new-pledge.component';
 
 const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
 

--- a/src/app/pledge/pledge.module.ts
+++ b/src/app/pledge/pledge.module.ts
@@ -6,8 +6,9 @@ import { RouterModule } from '@angular/router';
 import { AngularFireModule } from '@angular/fire/compat';
 import { AngularFireDatabaseModule } from '@angular/fire/compat/database';
 import { CountUpModule } from 'ngx-countup';
-import { PledgeRoutingModule } from './pledge.routes';
 import { environment } from '@root/environments/environment';
+import { SecretsService } from '@shared/services/secrets/secrets.service';
+import { PledgeRoutingModule } from './pledge.routes';
 import { NewPledgeComponent } from './components/new-pledge/new-pledge.component';
 import { PledgeService } from './services/pledge.service';
 import { ClaimStorageLoginComponent } from './components/claim-storage-login/claim-storage-login.component';
@@ -18,7 +19,6 @@ import { ClaimStorageComponent } from './components/claim-storage/claim-storage.
 import { PledgeListComponent } from './components/pledge-list/pledge-list.component';
 import { MissingPledgeComponent } from './components/missing-pledge/missing-pledge.component';
 import { UpdateCardComponent } from './components/update-card/update-card.component';
-import { SecretsService } from '@shared/services/secrets/secrets.service';
 
 @NgModule({
   imports: [

--- a/src/app/public/components/public-search-results/public-search-results.component.spec.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.spec.ts
@@ -1,12 +1,12 @@
 /* @format */
-import { DataService } from '../../../shared/services/data/data.service';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { PublicSearchResultsComponent } from './public-search-results.component';
 import { SearchService } from '@search/services/search.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DataService } from '../../../shared/services/data/data.service';
+import { PublicSearchResultsComponent } from './public-search-results.component';
 
 describe('PublicSearchResultsComponent', () => {
   let component: PublicSearchResultsComponent;

--- a/src/app/public/components/public-search-results/public-search-results.component.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.ts
@@ -1,10 +1,10 @@
 /* @format */
-import { SearchService } from '../../../search/services/search.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { FolderVO, RecordVO } from '@models/index';
+import { SearchService } from '../../../search/services/search.service';
 
 @Component({
   selector: 'pr-public-search-results',

--- a/src/app/public/public.module.ts
+++ b/src/app/public/public.module.ts
@@ -1,27 +1,27 @@
 import { NgModule, Optional, ComponentFactoryResolver } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { PublicRoutingModule } from './public.routes';
 import { RouterModule } from '@angular/router';
+import {
+  FaIconLibrary,
+  FontAwesomeModule,
+} from '@fortawesome/angular-fontawesome';
+import { faSearch, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { DataService } from '@shared/services/data/data.service';
 import { FolderViewService } from '@shared/services/folder-view/folder-view.service';
-import {} from '@core/services/folder-picker/folder-picker.service';
-import { FolderView } from '@shared/services/folder-view/folder-view.enum';
-import { SharedModule } from '@shared/shared.module';
-import { CoreModule } from '@core/core.module';
 import { FileBrowserModule } from '@fileBrowser/file-browser.module';
+import { CoreModule } from '@core/core.module';
+import { SharedModule } from '@shared/shared.module';
+import { FolderView } from '@shared/services/folder-view/folder-view.enum';
+import { DialogModule } from '../dialog/dialog.module';
+import { AnnouncementModule } from '../announcement/announcement.module';
+import { PublicRoutingModule } from './public.routes';
+import {} from '@core/services/folder-picker/folder-picker.service';
 import { PublicComponent } from './components/public/public.component';
 import { ItemNotFoundComponent } from './components/item-not-found/item-not-found.component';
 import { PublicArchiveComponent } from './components/public-archive/public-archive.component';
 import { SearchBoxComponent } from './components/search-box/search-box.component';
 import { PublicProfileComponent } from './components/public-profile/public-profile.component';
 import { PublicProfileService } from './services/public-profile/public-profile.service';
-import { DialogModule } from '../dialog/dialog.module';
-import { AnnouncementModule } from '../announcement/announcement.module';
-import {
-  FaIconLibrary,
-  FontAwesomeModule,
-} from '@fortawesome/angular-fontawesome';
-import { faSearch, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { ArchiveSearchComponent } from './components/archive-search/archive-search.component';
 import { PublicArchiveWebLinksComponent } from './components/public-archive-web-links/public-archive-web-links.component';
 import { PublicSearchResultsComponent } from './components/public-search-results/public-search-results.component';

--- a/src/app/public/public.routes.ts
+++ b/src/app/public/public.routes.ts
@@ -2,6 +2,8 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { LazyLoadFileBrowserSibling } from '@fileBrowser/lazy-load-file-browser-sibling';
+import { RoutesWithData } from '../app.routes';
 import { PublicComponent } from './components/public/public.component';
 import { PublishResolveService } from './resolves/publish-resolve.service';
 import { PublishArchiveResolveService } from './resolves/publish-archive-resolve.service';
@@ -9,10 +11,8 @@ import { ItemNotFoundComponent } from './components/item-not-found/item-not-foun
 import { PublicArchiveComponent } from './components/public-archive/public-archive.component';
 import { PublicArchiveResolveService } from './resolves/public-archive-resolve.service';
 import { PublicRootResolveService } from './resolves/public-root-resolve.service';
-import { LazyLoadFileBrowserSibling } from '@fileBrowser/lazy-load-file-browser-sibling';
 import { PublicProfileItemsResolveService } from './resolves/public-profile-items-resolve.service';
 import { PublicProfileComponent } from './components/public-profile/public-profile.component';
-import { RoutesWithData } from '../app.routes';
 import { PublicSearchResultsComponent } from './components/public-search-results/public-search-results.component';
 import { PublicTagsResolveService } from './resolves/public-tags-resolve.service';
 

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SearchService } from './services/search.service';
 import { SharedModule } from '@shared/shared.module';
-import { GlobalSearchBarComponent } from './components/global-search-bar/global-search-bar.component';
-import { GlobalSearchResultsComponent } from './components/global-search-results/global-search-results.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FileBrowserComponentsModule } from '@fileBrowser/file-browser-components.module';
+import { SearchService } from './services/search.service';
+import { GlobalSearchBarComponent } from './components/global-search-bar/global-search-bar.component';
+import { GlobalSearchResultsComponent } from './components/global-search-results/global-search-results.component';
 
 @NgModule({
   declarations: [GlobalSearchBarComponent, GlobalSearchResultsComponent],

--- a/src/app/share-preview/components/share-preview/share-preview.component.spec.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.spec.ts
@@ -18,9 +18,9 @@ import { cloneDeep } from 'lodash';
 
 import { SharedModule } from '@shared/shared.module';
 import * as Testing from '@root/test/testbedConfig';
-import { SharePreviewComponent } from './share-preview.component';
 import { Dialog } from '@root/app/dialog/dialog.module';
 import { RecordVO } from '@root/app/models';
+import { SharePreviewComponent } from './share-preview.component';
 
 describe('SharePreviewComponent', () => {
   let component: SharePreviewComponent;

--- a/src/app/share-preview/share-preview.module.ts
+++ b/src/app/share-preview/share-preview.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SharePreviewRoutingModule } from './share-preview.routes';
 import { DataService } from '@shared/services/data/data.service';
 import { FolderViewService } from '@shared/services/folder-view/folder-view.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
@@ -8,6 +7,7 @@ import { FolderView } from '@shared/services/folder-view/folder-view.enum';
 import { FormsModule } from '@angular/forms';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { DialogModule } from '../dialog/dialog.module';
+import { SharePreviewRoutingModule } from './share-preview.routes';
 import { CreateAccountDialogComponent } from './components/create-account-dialog/create-account-dialog.component';
 import { SharePreviewFooterComponent } from './components/share-preview-footer/share-preview-footer.component';
 

--- a/src/app/share-preview/share-preview.routes.ts
+++ b/src/app/share-preview/share-preview.routes.ts
@@ -3,24 +3,24 @@ import { NgModule, ComponentFactoryResolver, Optional } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CommonModule } from '@angular/common';
 
+import { SharedModule } from '@shared/shared.module';
+import { FileBrowserComponentsModule } from '@fileBrowser/file-browser-components.module';
+import { FileListComponent } from '@fileBrowser/components/file-list/file-list.component';
+import { DialogChildComponentData } from '@root/app/dialog/dialog.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { LazyLoadFileBrowserSibling } from '@fileBrowser/lazy-load-file-browser-sibling';
+import { Dialog, DialogModule } from '../dialog/dialog.module';
+import { AnnouncementModule } from '../announcement/announcement.module';
 import { SharePreviewComponent } from './components/share-preview/share-preview.component';
 import { PreviewArchiveResolveService } from './resolves/preview-archive-resolve.service';
 import { PreviewResolveService } from './resolves/preview-resolve.service';
-import { SharedModule } from '@shared/shared.module';
-import { FileBrowserComponentsModule } from '@fileBrowser/file-browser-components.module';
 import { PreviewFolderResolveService } from './resolves/preview-folder-resolve.service';
 import { ShareUrlResolveService } from './resolves/share-url-resolve.service';
 import { ShareNotFoundComponent } from './components/share-not-found/share-not-found.component';
 import { CreateAccountDialogComponent } from './components/create-account-dialog/create-account-dialog.component';
-import { FileListComponent } from '@fileBrowser/components/file-list/file-list.component';
 import { InviteShareResolveService } from './resolves/invite-share-resolve.service';
 import { RelationshipShareResolveService } from './resolves/relationship-share-resolve.service';
-import { DialogChildComponentData } from '@root/app/dialog/dialog.module';
 
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { Dialog, DialogModule } from '../dialog/dialog.module';
-import { LazyLoadFileBrowserSibling } from '@fileBrowser/lazy-load-file-browser-sibling';
-import { AnnouncementModule } from '../announcement/announcement.module';
 import { SharePreviewFooterComponent } from './components/share-preview-footer/share-preview-footer.component';
 
 const archiveResolve = {

--- a/src/app/shared/components/archive-picker/archive-picker.component.ts
+++ b/src/app/shared/components/archive-picker/archive-picker.component.ts
@@ -7,13 +7,13 @@ import { ApiService } from '@shared/services/api/api.service';
 import { SearchResponse, InviteResponse } from '@shared/services/api/index.repo';
 import { MessageService } from '@shared/services/message/message.service';
 import { Validators } from '@angular/forms';
-import { FormInputSelectOption } from '../form-input/form-input.component';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
 import { INVITATION_FIELDS, ACCESS_ROLE_FIELD } from '@shared/components/prompt/prompt-fields';
 import { AccountService } from '@shared/services/account/account.service';
 import { clone } from 'lodash';
 import { GoogleAnalyticsService } from '@shared/services/google-analytics/google-analytics.service';
 import { EVENTS } from '@shared/services/google-analytics/events';
+import { FormInputSelectOption } from '../form-input/form-input.component';
 
 export interface ArchivePickerComponentConfig {
   relations?: RelationVO[];

--- a/src/app/shared/components/archive-small/archive-small.component.spec.ts
+++ b/src/app/shared/components/archive-small/archive-small.component.spec.ts
@@ -2,12 +2,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep  } from 'lodash';
 
-import { ArchiveSmallComponent } from './archive-small.component';
 import { BgImageSrcDirective } from '@shared/directives/bg-image-src.directive';
 import { ArchiveVO } from '@root/app/models';
 import { TEST_DATA } from '@core/core.module.spec';
 import { AccountService } from '@shared/services/account/account.service';
 import { StorageService } from '@shared/services/storage/storage.service';
+import { ArchiveSmallComponent } from './archive-small.component';
 
 describe('ArchiveSmallComponent', () => {
   let component: ArchiveSmallComponent;

--- a/src/app/shared/components/breadcrumbs/breadcrumb.component.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumb.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, OnDestroy, ViewEncapsulation, Input, HostListener, HostBinding, Optional } from '@angular/core';
-import { Breadcrumb } from './breadcrumbs.component';
 import { DragTargetDroppableComponent, DragServiceEvent, DragService } from '@shared/services/drag/drag.service';
 import { Subscription } from 'rxjs';
 import debug from 'debug';
+import { Breadcrumb } from './breadcrumbs.component';
 
 @Component({
   selector: 'pr-breadcrumb',

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, tick, fakeAsync, waitForAsync } from '@angular/core/testing';
 
-import { InlineValueEditComponent } from './inline-value-edit.component';
 import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { NgbDatepickerModule, NgbTimepickerModule, NgbDate, NgbTimeStruct } from '@ng-bootstrap/ng-bootstrap';
@@ -10,6 +9,7 @@ import { moment } from 'vis-timeline/standalone';
 import { RecordVO, RecordVOData } from '@models';
 import { getOffsetMomentFromDTString, formatDateISOString, getUtcMomentFromDTString, momentFormatNum, applyTimezoneOffset } from '@shared/utilities/dateTime';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { InlineValueEditComponent } from './inline-value-edit.component';
 
 describe('InlineValueEditComponent', () => {
   let component: InlineValueEditComponent;

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.ts
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.ts
@@ -27,9 +27,9 @@ import {
   getUtcMomentFromOffsetDTString,
 } from '@shared/utilities/dateTime';
 import { ENTER } from '@angular/cdk/keycodes';
-import { FormInputSelectOption } from '../form-input/form-input.component';
 import { NgModel, UntypedFormControl, Validators } from '@angular/forms';
 import { getDate, getMonth, getYear } from 'date-fns';
+import { FormInputSelectOption } from '../form-input/form-input.component';
 
 export type InlineValueEditType =
   | 'text'

--- a/src/app/shared/components/new-archive-form/new-archive-form.component.spec.ts
+++ b/src/app/shared/components/new-archive-form/new-archive-form.component.spec.ts
@@ -1,7 +1,7 @@
 import { Shallow } from 'shallow-render';
-import { ArchiveFormData, NewArchiveFormComponent } from './new-archive-form.component';
 import { SharedModule } from '@shared/shared.module';
 import { ApiService } from '@shared/services/api/api.service';
+import { ArchiveFormData, NewArchiveFormComponent } from './new-archive-form.component';
 
 let created: boolean = false;
 let throwError: boolean = false;

--- a/src/app/shared/components/prompt/prompt-fields.ts
+++ b/src/app/shared/components/prompt/prompt-fields.ts
@@ -5,8 +5,8 @@ import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.s
 import { clone } from 'lodash';
 import { minDateValidator } from '@shared/utilities/forms';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
-import { FormInputSelectOption } from '../form-input/form-input.component';
 import { AccessRoleType } from '@models/access-role';
+import { FormInputSelectOption } from '../form-input/form-input.component';
 
 const prConstants: PrConstantsService = new PrConstantsService();
 

--- a/src/app/shared/components/prompt/prompt.component.spec.ts
+++ b/src/app/shared/components/prompt/prompt.component.spec.ts
@@ -2,8 +2,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep  } from 'lodash';
 
-import { PromptComponent } from './prompt.component';
 import { FormInputComponent } from '@shared/components/form-input/form-input.component';
+import { PromptComponent } from './prompt.component';
 
 describe('PromptComponent', () => {
   let component: PromptComponent;

--- a/src/app/shared/components/video/video.component.spec.ts
+++ b/src/app/shared/components/video/video.component.spec.ts
@@ -2,8 +2,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep  } from 'lodash';
 
-import { VideoComponent } from './video.component';
 import { RecordVO } from '@root/app/models';
+import { VideoComponent } from './video.component';
 
 describe('VideoComponent', () => {
   let component: VideoComponent;

--- a/src/app/shared/directives/scroll-nav.directive.ts
+++ b/src/app/shared/directives/scroll-nav.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, QueryList, ContentChildren, AfterContentInit, ElementRef, HostListener } from '@angular/core';
-import { ScrollSectionDirective } from './scroll-section.directive';
 import debug from 'debug';
 import { find, throttle } from 'lodash';
+import { ScrollSectionDirective } from './scroll-section.directive';
 
 @Directive({
   selector: '[prScrollNav]',

--- a/src/app/shared/pipes/pr-constants.pipe.spec.ts
+++ b/src/app/shared/pipes/pr-constants.pipe.spec.ts
@@ -1,5 +1,5 @@
-import { PrConstantsPipe } from './pr-constants.pipe';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
+import { PrConstantsPipe } from './pr-constants.pipe';
 
 const prConstants = new PrConstantsService();
 

--- a/src/app/shared/pipes/pr-date.pipe.spec.ts
+++ b/src/app/shared/pipes/pr-date.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { TimezoneVOData, TimezoneVO } from '@models';
-import { PrDatePipe } from './pr-date.pipe';
 import { formatDateISOString } from '@shared/utilities/dateTime';
+import { PrDatePipe } from './pr-date.pipe';
 
 describe('PrDatePipe', () => {
   it('create an instance', () => {

--- a/src/app/shared/pipes/public-link.pipe.spec.ts
+++ b/src/app/shared/pipes/public-link.pipe.spec.ts
@@ -1,6 +1,6 @@
+import { FolderVO, RecordVO } from '@models';
 import { PublicLinkPipe } from './public-link.pipe';
 import { PublicRoutePipe } from './public-route.pipe';
-import { FolderVO, RecordVO } from '@models';
 
 describe('PublicLinkPipe', () => {
   let pipe: PublicLinkPipe;

--- a/src/app/shared/pipes/public-route.pipe.spec.ts
+++ b/src/app/shared/pipes/public-route.pipe.spec.ts
@@ -1,5 +1,5 @@
-import { PublicRoutePipe } from './public-route.pipe';
 import { FolderVO, RecordVO } from '@models';
+import { PublicRoutePipe } from './public-route.pipe';
 
 describe('PublicRoutePipe', () => {
   it('create an instance', () => {

--- a/src/app/shared/services/account/account.service.spec.ts
+++ b/src/app/shared/services/account/account.service.spec.ts
@@ -7,8 +7,8 @@ import { Observable } from 'rxjs';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { AuthResponse } from '@shared/services/api/index.repo';
-import { AppModule } from '../../../app.module';
 import { AccountVO, ArchiveVO } from '@root/app/models';
+import { AppModule } from '../../../app.module';
 import { StorageService } from '../storage/storage.service';
 
 describe('AccountService', () => {

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -20,10 +20,10 @@ import {
   AccessRoleType,
   checkMinimumAccess,
 } from '@models/access-role';
+import * as Sentry from '@sentry/browser';
 import { HttpV2Service } from '../http-v2/http-v2.service';
 import { MixpanelService } from '../mixpanel/mixpanel.service';
 
-import * as Sentry from '@sentry/browser';
 
 const ACCOUNT_KEY = 'account';
 const ARCHIVE_KEY = 'archive';

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -24,7 +24,6 @@ import * as Sentry from '@sentry/browser';
 import { HttpV2Service } from '../http-v2/http-v2.service';
 import { MixpanelService } from '../mixpanel/mixpanel.service';
 
-
 const ACCOUNT_KEY = 'account';
 const ARCHIVE_KEY = 'archive';
 const ROOT_KEY = 'root';

--- a/src/app/shared/services/api/archive.repo.ts
+++ b/src/app/shared/services/api/archive.repo.ts
@@ -1,5 +1,4 @@
 /* @format */
-import { TagVOData } from '../../../models/tag-vo';
 import {
   AccountVO,
   AccountPasswordVO,
@@ -9,6 +8,7 @@ import {
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { flatten, isArray } from 'lodash';
 import { ProfileItemVOData } from '@models/profile-item-vo';
+import { TagVOData } from '../../../models/tag-vo';
 
 export class ArchiveRepo extends BaseRepo {
   public get(archives: ArchiveVO[]): Promise<ArchiveResponse> {

--- a/src/app/shared/services/api/directive.repo.spec.ts
+++ b/src/app/shared/services/api/directive.repo.spec.ts
@@ -7,14 +7,14 @@ import {
 import { environment } from '@root/environments/environment';
 
 import { HttpService } from '@shared/services/http/http.service';
-import { DirectiveRepo } from './directive.repo';
-import { HttpV2Service } from '../http-v2/http-v2.service';
 import {
   ArchiveVO,
   Directive,
   DirectiveCreateRequest,
   DirectiveUpdateRequest,
 } from '@models/index';
+import { HttpV2Service } from '../http-v2/http-v2.service';
+import { DirectiveRepo } from './directive.repo';
 
 const apiUrl = (endpoint: string) => `${environment.apiUrl}${endpoint}`;
 

--- a/src/app/shared/services/api/directive.repo.ts
+++ b/src/app/shared/services/api/directive.repo.ts
@@ -6,8 +6,8 @@ import {
   Directive,
   DirectiveUpdateRequest,
 } from '@models/index';
-import { BaseRepo } from './base';
 import { getFirst } from '../http-v2/http-v2.service';
+import { BaseRepo } from './base';
 
 export class DirectiveRepo extends BaseRepo {
   public async get(archive: ArchiveVO): Promise<Directive> {

--- a/src/app/shared/services/drag/drag.service.spec.ts
+++ b/src/app/shared/services/drag/drag.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
-import { DragService } from './drag.service';
 import { BASE_TEST_CONFIG } from '@root/test/testbedConfig';
+import { DragService } from './drag.service';
 
 describe('DragService', () => {
   let service: DragService;

--- a/src/app/shared/services/drag/drag.service.ts
+++ b/src/app/shared/services/drag/drag.service.ts
@@ -4,16 +4,16 @@ import { throttle, find } from 'lodash';
 import { FileListItemComponent } from '@fileBrowser/components/file-list-item/file-list-item.component';
 import { BreadcrumbComponent } from '@shared/components/breadcrumbs/breadcrumb.component';
 import { DOCUMENT } from '@angular/common';
-import { DataService } from '../data/data.service';
 import gsap from 'gsap';
-import { DeviceService } from '../device/device.service';
 import { DragTargetRouterLinkDirective } from '@shared/directives/drag-target-router-link.directive';
 import { PromptService } from '@shared/services/prompt/prompt.service';
 import { MainComponent } from '@core/components/main/main.component';
 import { FolderVO } from '@models';
-import { AccountService } from '../account/account.service';
 import debug from 'debug';
 import { debugSubscribable } from '@shared/utilities/debug';
+import { AccountService } from '../account/account.service';
+import { DeviceService } from '../device/device.service';
+import { DataService } from '../data/data.service';
 
 export type DragTargetType = 'folder' | 'record';
 

--- a/src/app/shared/services/drag/drag.utilities.ts
+++ b/src/app/shared/services/drag/drag.utilities.ts
@@ -1,8 +1,8 @@
-import { DragTargetDroppableComponent } from './drag.service';
 import { ItemVO } from '@models';
 import { FileListItemComponent } from '@fileBrowser/components/file-list-item/file-list-item.component';
 import { BreadcrumbComponent } from '@shared/components/breadcrumbs/breadcrumb.component';
 import { DragTargetRouterLinkDirective } from '@shared/directives/drag-target-router-link.directive';
+import { DragTargetDroppableComponent } from './drag.service';
 
 export function getItemFromDropTarget(dropTarget: DragTargetDroppableComponent) {
   if (dropTarget instanceof FileListItemComponent) {

--- a/src/app/shared/services/folder-view/folder-view.service.ts
+++ b/src/app/shared/services/folder-view/folder-view.service.ts
@@ -2,9 +2,9 @@ import { Injectable, EventEmitter } from '@angular/core';
 
 import { FolderVO, RecordVO } from '@root/app/models';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
-import { StorageService } from '../storage/storage.service';
 import debug from 'debug';
 import { debugSubscribable } from '@shared/utilities/debug';
+import { StorageService } from '../storage/storage.service';
 
 const VIEW_STORAGE_KEY = 'folderView';
 

--- a/src/app/shared/services/guided-tour/guided-tour.service.spec.ts
+++ b/src/app/shared/services/guided-tour/guided-tour.service.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { cloneDeep } from 'lodash';
-import { AccountService } from '../account/account.service';
 import * as Testing from '@root/test/testbedConfig';
 
-import { GuidedTourService } from './guided-tour.service';
 import { AccountVO } from '@models';
 import { ShepherdService } from 'angular-shepherd';
+import { AccountService } from '../account/account.service';
+import { GuidedTourService } from './guided-tour.service';
 
 describe('GuidedTourService', () => {
   let service: GuidedTourService;

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -5,10 +5,10 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { getFirst, HttpV2Service } from './http-v2.service';
 import { environment } from '@root/environments/environment';
 import { StorageService } from '../storage/storage.service';
 import { SecretsService } from '../secrets/secrets.service';
+import { getFirst, HttpV2Service } from './http-v2.service';
 
 const apiUrl = (endpoint: string) => `${environment.apiUrl}${endpoint}`;
 

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -1,11 +1,11 @@
 /* @format */
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { StorageService } from '../storage/storage.service';
 import { environment } from '@root/environments/environment';
 import { Observable, Subject, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Location } from '@angular/common';
+import { StorageService } from '../storage/storage.service';
 import { SecretsService } from '../secrets/secrets.service';
 
 const CSRF_KEY = 'CSRF';

--- a/src/app/shared/services/mixpanel/mixpanel.service.ts
+++ b/src/app/shared/services/mixpanel/mixpanel.service.ts
@@ -1,9 +1,9 @@
 /* @format*/
 import { Injectable } from '@angular/core';
 import mixpanel from 'mixpanel-browser';
-import { SecretsService } from '../secrets/secrets.service';
 import { environment } from '@root/environments/environment';
 import { AccountVO } from '@models/account-vo';
+import { SecretsService } from '../secrets/secrets.service';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/services/profile/profile.service.ts
+++ b/src/app/shared/services/profile/profile.service.ts
@@ -4,10 +4,10 @@ import { ApiService } from '@shared/services/api/api.service';
 import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
 import { RecordVO, ArchiveVO } from '@models';
 import { ArchiveResponse } from '@shared/services/api/index.repo';
-import { MessageService } from '../message/message.service';
 import { FieldNameUI, ProfileItemVOData, ProfileItemVODictionary, FieldNameUIShort } from '@models/profile-item-vo';
-import { PrConstantsService } from '../pr-constants/pr-constants.service';
 import { remove, orderBy, some } from 'lodash';
+import { MessageService } from '../message/message.service';
+import { PrConstantsService } from '../pr-constants/pr-constants.service';
 
 type ProfileItemsStringDataCol =
 'string1' |

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -7,11 +7,27 @@ import { FormInputComponent } from '@shared/components/form-input/form-input.com
 import { ArchiveSmallComponent } from '@shared/components/archive-small/archive-small.component';
 import { LogoComponent } from '@auth/components/logo/logo.component';
 import { BgImageSrcDirective } from '@shared/directives/bg-image-src.directive';
-import { ArchivePickerComponent } from './components/archive-picker/archive-picker.component';
+import { RouterModule, Scroll } from '@angular/router';
+import {
+  NgbDatepickerModule,
+  NgbDatepickerConfig,
+  NgbTimepickerModule,
+  NgbTimepickerConfig,
+  NgbTooltipModule,
+  NgbTooltipConfig,
+  NgbDropdownModule,
+  NgbDropdownConfig,
+  NgbPaginationModule,
+} from '@ng-bootstrap/ng-bootstrap';
+import {
+  FontAwesomeModule,
+  FaIconLibrary,
+} from '@fortawesome/angular-fontawesome';
+import { faFileArchive, fas } from '@fortawesome/free-solid-svg-icons';
 import { Dialog, DialogChildComponentData } from '../dialog/dialog.service';
 import { DialogModule } from '../dialog/dialog.module';
+import { ArchivePickerComponent } from './components/archive-picker/archive-picker.component';
 import { BreadcrumbsComponent } from './components/breadcrumbs/breadcrumbs.component';
-import { RouterModule, Scroll } from '@angular/router';
 import { FileSizePipe } from './pipes/filesize.pipe';
 import { PrConstantsPipe } from './pipes/pr-constants.pipe';
 import { PromptComponent } from './components/prompt/prompt.component';
@@ -26,17 +42,6 @@ import { BreadcrumbComponent } from './components/breadcrumbs/breadcrumb.compone
 import { DragTargetRouterLinkDirective } from './directives/drag-target-router-link.directive';
 import { PublicRoutePipe } from './pipes/public-route.pipe';
 import { FolderViewToggleComponent } from './components/folder-view-toggle/folder-view-toggle.component';
-import {
-  NgbDatepickerModule,
-  NgbDatepickerConfig,
-  NgbTimepickerModule,
-  NgbTimepickerConfig,
-  NgbTooltipModule,
-  NgbTooltipConfig,
-  NgbDropdownModule,
-  NgbDropdownConfig,
-  NgbPaginationModule,
-} from '@ng-bootstrap/ng-bootstrap';
 import { PrDatePipe } from './pipes/pr-date.pipe';
 import { FolderCastPipe, RecordCastPipe } from './pipes/cast.pipe';
 import { FolderContentsPipe } from './pipes/folder-contents.pipe';
@@ -61,11 +66,6 @@ import { NewArchiveFormComponent } from './components/new-archive-form/new-archi
 import { PrependProtocolPipe } from './pipes/prepend-protocol.pipe';
 import { SwitcherComponent } from './components/switcher/switcher.component';
 
-import {
-  FontAwesomeModule,
-  FaIconLibrary,
-} from '@fortawesome/angular-fontawesome';
-import { faFileArchive, fas } from '@fortawesome/free-solid-svg-icons';
 
 @NgModule({
   imports: [

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -66,7 +66,6 @@ import { NewArchiveFormComponent } from './components/new-archive-form/new-archi
 import { PrependProtocolPipe } from './pipes/prepend-protocol.pipe';
 import { SwitcherComponent } from './components/switcher/switcher.component';
 
-
 @NgModule({
   imports: [
     CommonModule,

--- a/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
+++ b/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
@@ -1,7 +1,7 @@
-import {ThumbnailCache, FolderThumbData} from './thumbnail-cache';
 import {StorageService} from '@shared/services/storage/storage.service';
 import {FolderVO} from '@models';
 import {FolderContentsType} from '@fileBrowser/components/file-list-item/file-list-item.component';
+import {ThumbnailCache, FolderThumbData} from './thumbnail-cache';
 
 describe('ThumbnailCache', () => {
   let cache: ThumbnailCache;

--- a/src/app/views/components/timeline-view/timeline-breadcrumbs/timeline-breadcrumbs.component.ts
+++ b/src/app/views/components/timeline-view/timeline-breadcrumbs/timeline-breadcrumbs.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit, Input, OnDestroy, ViewChild, ElementRef, Output, EventEmitter, AfterViewInit } from '@angular/core';
 import { DataService } from '@shared/services/data/data.service';
-import { TimelineGroupTimespan, GetTimespanFromRange, GroupByTimespan, TimelineGroup, TimelineItem, TimelineItemDataType, TimelineDataItem } from '../timeline-util';
 import { Subscription } from 'rxjs';
 import { DataItem } from 'vis-timeline/standalone';
 import { debounce, minBy, remove } from 'lodash';
 import { Router, ActivatedRoute } from '@angular/router';
+import { TimelineGroupTimespan, GetTimespanFromRange, GroupByTimespan, TimelineGroup, TimelineItem, TimelineItemDataType, TimelineDataItem } from '../timeline-util';
 
 export interface TimelineBreadcrumb {
   text: string;

--- a/src/app/views/components/timeline-view/timeline-view.component.ts
+++ b/src/app/views/components/timeline-view/timeline-view.component.ts
@@ -36,6 +36,22 @@ import {
   debounce,
   countBy,
 } from 'lodash';
+import { PrConstantsPipe } from '@shared/pipes/pr-constants.pipe';
+import { Subscription } from 'rxjs';
+import { FolderViewService } from '@shared/services/folder-view/folder-view.service';
+import { DeviceService } from '@shared/services/device/device.service';
+import { slideUpAnimation } from '@shared/animations';
+import { DIALOG_DATA, OUTLET_TEMPLATE } from '@root/app/dialog/dialog.module';
+import { RouteData } from '@root/app/app.routes';
+import {
+  TimelineBreadcrumbsComponent,
+  TimelineBreadcrumb,
+} from './timeline-breadcrumbs/timeline-breadcrumbs.component';
+import {
+  TimelineRecordTemplate,
+  TimelineFolderTemplate,
+  TimelineGroupTemplate,
+} from './timeline-templates';
 import {
   TimelineGroup,
   TimelineItem,
@@ -47,22 +63,6 @@ import {
   GetTimespanFromRange,
   getBestFitTimespanForItems,
 } from './timeline-util';
-import {
-  TimelineRecordTemplate,
-  TimelineFolderTemplate,
-  TimelineGroupTemplate,
-} from './timeline-templates';
-import { PrConstantsPipe } from '@shared/pipes/pr-constants.pipe';
-import { Subscription } from 'rxjs';
-import {
-  TimelineBreadcrumbsComponent,
-  TimelineBreadcrumb,
-} from './timeline-breadcrumbs/timeline-breadcrumbs.component';
-import { FolderViewService } from '@shared/services/folder-view/folder-view.service';
-import { DeviceService } from '@shared/services/device/device.service';
-import { slideUpAnimation } from '@shared/animations';
-import { DIALOG_DATA, OUTLET_TEMPLATE } from '@root/app/dialog/dialog.module';
-import { RouteData } from '@root/app/app.routes';
 
 interface VoDataItem extends DataItem {
   itemVO: ItemVO;

--- a/src/app/views/views.module.ts
+++ b/src/app/views/views.module.ts
@@ -1,9 +1,9 @@
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { Dialog, DialogChildComponentData, DialogModule } from '../dialog/dialog.module';
 import { ViewsComponentsModule } from './views-components.module';
 import { ViewsRoutingModule } from './views.routes';
-import { Dialog, DialogChildComponentData, DialogModule } from '../dialog/dialog.module';
 import { TimelineViewComponent } from './components/timeline-view/timeline-view.component';
 
 @NgModule({

--- a/src/app/views/views.routes.ts
+++ b/src/app/views/views.routes.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { FileViewerComponent } from '@fileBrowser/components/file-viewer/file-viewer.component';
-import { TimelineViewComponent } from './components/timeline-view/timeline-view.component';
 import { LeanFolderResolveService } from '@core/resolves/lean-folder-resolve.service';
 import { RecordResolveService } from '@core/resolves/record-resolve.service';
 import { FileBrowserComponentsModule } from '@fileBrowser/file-browser-components.module';
@@ -10,8 +9,9 @@ import { FileListComponent } from '@fileBrowser/components/file-list/file-list.c
 import { FolderResolveService } from '@core/resolves/folder-resolve.service';
 import { RoutedDialogWrapperComponent } from '@shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component';
 import { SharedModule } from '@shared/shared.module';
-import { RoutesWithData } from '../app.routes';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
+import { RoutesWithData } from '../app.routes';
+import { TimelineViewComponent } from './components/timeline-view/timeline-view.component';
 
 const folderResolve = {
   currentFolder: FolderResolveService


### PR DESCRIPTION
This linting rules enforces a specific convention in the order of import statements. For the web-app, this typically means importing external modules (from dependencies) before importing internal modules (from within our project).

Because of how we have our project set up, I customized the "internal" and "parent" levels to be equivalent to each other, since our "internal" imports are just shorthands for parent imports anyway.