### PR TITLE
Add sign up MixPanel event

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -532,6 +532,7 @@ export class AccountService {
             const newAccount = response;
             newAccount.isNew = true;
             this.setAccount(newAccount);
+            this.mixpanel.track('Sign up', { accountId: newAccount.accountId });
             return newAccount;
           })
         )

--- a/src/app/shared/services/mixpanel/mixpanel.service.ts
+++ b/src/app/shared/services/mixpanel/mixpanel.service.ts
@@ -40,6 +40,12 @@ export class MixpanelService {
     }
   }
 
+  public track(eventName: string, data: Object): void {
+    if (this.enabled) {
+      mixpanel.track(eventName, data);
+    }
+  }
+
   public isEnabled(): boolean {
     return this.enabled;
   }


### PR DESCRIPTION
Fire a "Sign up" event when a user has signed up for Permanent. This happens before any onboarding is completed, as adding analytics to onboarding will be handled in a separate ticket.

I picked "Sign up" for the event name as it matches the MixPanel events table made in confluence, and there is no other established standard for event names right now. This can be changed easily though.

**Steps To Test:**
1. Have MixPanel enabled by making sure the MixPanel token is added to the `.env` file
2. Sign up for an account with the developer console open. Verify that, while in debug mode, Mixpanel outputs a "Sign up" event after initially creating an account.