### PR TITLE
Enable and fix @angular-eslint/component-selector lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,9 +71,16 @@ module.exports = {
             ],
           },
         ],
+        '@angular-eslint/component-selector': [
+          'error',
+          {
+            prefix: 'pr',
+            style: 'kebab-case',
+            type: 'element',
+          },
+        ],
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        '@angular-eslint/component-selector': 'off',
         '@angular-eslint/directive-selector': 'off',
         '@angular-eslint/no-conflicting-lifecycle': 'off',
         '@angular-eslint/no-host-metadata-property': 'off',
@@ -163,6 +170,7 @@ module.exports = {
       rules: {
         'import/no-default-export': 'off',
         'import/no-extraneous-dependencies': 'off',
+        '@angular-eslint/component-selector': 'off',
       },
     },
   ],

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { MessageService } from '@shared/services/message/message.service';
 declare var iosInnerHeight: Function;
 
 @Component({
-  selector: 'app-root',
+  selector: 'pr-app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Component, OnInit, HostBinding } from '@angular/core';
 import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
@@ -8,15 +9,20 @@ declare var iosInnerHeight: Function;
 @Component({
   selector: 'pr-app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit {
   @HostBinding('class.mobile-safari') isMobileSafari = false;
   @HostBinding('class.mobile-safari-menu-bar-showing') isMenuBarShowing = false;
 
-  constructor(private api: ApiService, private account: AccountService, private message: MessageService) {
+  constructor(
+    private api: ApiService,
+    private account: AccountService,
+    private message: MessageService
+  ) {
     const isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);
-    const iPhone = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window['MSStream'];
+    const iPhone =
+      /iPad|iPhone|iPod/.test(navigator.userAgent) && !window['MSStream'];
     this.isMobileSafari = isSafari && iPhone;
     this.isMenuBarShowing = window.innerHeight !== iosInnerHeight();
 
@@ -25,9 +31,7 @@ export class AppComponent implements OnInit {
         this.isMenuBarShowing = window.innerHeight !== iosInnerHeight();
       });
     }
-
   }
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 }

--- a/src/app/dialog/dialog.service.spec.ts
+++ b/src/app/dialog/dialog.service.spec.ts
@@ -1,28 +1,25 @@
+/* @format */
 import { Component, NgModule, ApplicationRef } from '@angular/core';
 import { TestBed, inject } from '@angular/core/testing';
 import { Dialog } from './dialog.service';
 
 @Component({
   selector: 'pr-mock-app-root',
-  template: ''
+  template: '',
 })
 class MockAppComponent {
-  constructor() {
-  }
+  constructor() {}
 }
 
 @NgModule({
-  declarations: [
-    MockAppComponent
-  ]
+  declarations: [MockAppComponent],
 })
 class MockAppModule {
-  constructor() {
-  }
+  constructor() {}
 }
 
 describe('Dialog', () => {
-  beforeEach(async() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [MockAppModule],
       providers: [Dialog],
@@ -34,7 +31,6 @@ describe('Dialog', () => {
     const fixture = TestBed.createComponent(MockAppComponent);
     appRef.components.push(fixture.componentRef);
   });
-
 
   it('should be created', inject([Dialog], (service: Dialog) => {
     expect(service).toBeTruthy();

--- a/src/app/dialog/dialog.service.spec.ts
+++ b/src/app/dialog/dialog.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { Dialog } from './dialog.service';
 
 @Component({
-  selector: 'app-root',
+  selector: 'pr-mock-app-root',
   template: ''
 })
 class MockAppComponent {

--- a/src/app/share-preview/components/share-preview-footer/share-preview-footer.component.ts
+++ b/src/app/share-preview/components/share-preview-footer/share-preview-footer.component.ts
@@ -55,7 +55,7 @@ export class SharePreviewFooterComponent implements OnInit, OnDestroy {
             if (tagName === 'pr-dialog') {
               return;
             }
-            if (tagName === 'app-root') {
+            if (tagName === 'pr-app-root') {
               break;
             }
             target = target.parentElement;

--- a/src/app/share-preview/components/share-preview-footer/share-preview-footer.component.ts
+++ b/src/app/share-preview/components/share-preview-footer/share-preview-footer.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { transition, trigger, style, animate } from '@angular/animations';
 import {
   Component,

--- a/src/index.html
+++ b/src/index.html
@@ -32,9 +32,9 @@
   </script>
 </head>
 <body>
-  <app-root>
+  <pr-app-root>
     <div class="lds-dual-ring"></div>
-  </app-root>
+  </pr-app-root>
   <script src="https://js.stripe.com/v3/"></script>
 </body>
 </html>

--- a/src/index/dev/index.html
+++ b/src/index/dev/index.html
@@ -32,9 +32,9 @@
   </script>
 </head>
 <body>
-  <app-root>
+  <pr-app-root>
     <div class="lds-dual-ring"></div>
-  </app-root>
+  </pr-app-root>
   <script src="https://js.stripe.com/v3/"></script>
 </body>
 </html>

--- a/src/index/prod/index.html
+++ b/src/index/prod/index.html
@@ -33,9 +33,9 @@
   </script>
 </head>
 <body>
-  <app-root>
+  <pr-app-root>
     <div class="lds-dual-ring"></div>
-  </app-root>
+  </pr-app-root>
   <script src="https://js.stripe.com/v3/"></script>
 </body>
 </html>

--- a/src/index/staging/index.html
+++ b/src/index/staging/index.html
@@ -32,9 +32,9 @@
   </script>
 </head>
 <body>
-  <app-root>
+  <pr-app-root>
     <div class="lds-dual-ring"></div>
-  </app-root>
+  </pr-app-root>
   <script src="https://js.stripe.com/v3/"></script>
 </body>
 </html>

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,11 +1,13 @@
-html, body {
+/* @format */
+html,
+body {
   min-height: 100%;
   height: 100%;
   position: relative;
   background: none;
 }
 
-pr-app-root{
+pr-app-root {
   display: block;
   position: relative;
   min-height: 100%;

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -5,7 +5,7 @@ html, body {
   background: none;
 }
 
-app-root{
+pr-app-root{
   display: block;
   position: relative;
   min-height: 100%;


### PR DESCRIPTION
The @angular-eslint/component-selector linting rule enforces a consistent prefix for Angular component selectors within a project, to ensure that they are valid custom HTML elements. Enable the rule and set the prefix to "pr", which is the standard we use in our codebase.

Since we've already been consistent with this rule, this does not affect many components, however two components did need to be updated:
1. An empty mock component only defined and used in one test file wasn't given a prefix, and now has its selector updated to match linting standards
2. The base component, `<app-root>` was renamed to `<pr-app-root>`. This required changes to the various `index.html` files as well as a few other files that referenced the selector.

This rule is disabled in Storybook directories since Storybook provides example components with different prefixes.