### PR TITLE
Enable and configure @angular-eslint/directive-selector lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,9 +79,16 @@ module.exports = {
             type: 'element',
           },
         ],
+        '@angular-eslint/directive-selector': [
+          'error',
+          {
+            prefix: 'pr',
+            style: 'camelCase',
+            type: 'attribute',
+          },
+        ],
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        '@angular-eslint/directive-selector': 'off',
         '@angular-eslint/no-conflicting-lifecycle': 'off',
         '@angular-eslint/no-host-metadata-property': 'off',
         '@angular-eslint/no-output-native': 'off',


### PR DESCRIPTION
The @angular-eslint/component-selector linting rule enforces a consistent prefix for Angular directive selectors within a project. Our project already has a consistent naming scheme for directives with no outliers, so this rule only needed to be enabled and configured to match the format. You can optionally test this configuration is correct by mutating one of the properties in the configuration ("prefix", "style", or "type") and verifying that `npm run lint` suddenly fails.