### PR TITLE
PER-8785: Search results not appearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "debug": "4.1.1",
         "firebase": "^9.9.3",
         "firebase-functions": "^3.6.0",
-        "fuse.js": "^5.2.3",
+        "fuse.js": "^6.6.2",
         "gsap": "^3.6.0",
         "hammerjs": "^2.0.8",
         "handlebars": "^4.7.7",
@@ -15225,9 +15225,9 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-5.2.3.tgz",
-      "integrity": "sha512-ld3AEgKtKnnXCtJavtygAb+aLlD5aVvLwTocXXBSStLA6JGFI6oMxTvumwh46N2/3gs3A7JNDu1px5F1/cq84g==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
       "engines": {
         "node": ">=10"
       }
@@ -40335,9 +40335,9 @@
       "dev": true
     },
     "fuse.js": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-5.2.3.tgz",
-      "integrity": "sha512-ld3AEgKtKnnXCtJavtygAb+aLlD5aVvLwTocXXBSStLA6JGFI6oMxTvumwh46N2/3gs3A7JNDu1px5F1/cq84g=="
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "fuzzy": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "debug": "4.1.1",
     "firebase": "^9.9.3",
     "firebase-functions": "^3.6.0",
-    "fuse.js": "^5.2.3",
+    "fuse.js": "^6.6.2",
     "gsap": "^3.6.0",
     "hammerjs": "^2.0.8",
     "handlebars": "^4.7.7",

--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -1,16 +1,106 @@
-// import { TestBed } from '@angular/core/testing';
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
 
-// import { SearchService } from './search.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { DataService } from '@shared/services/data/data.service';
+import { TagsService } from '@core/services/tags/tags.service';
+import { TagVO, TagVOData } from '@models/tag-vo';
+import { SearchService } from './search.service';
 
-// describe('SearchService', () => {
-//   let service: SearchService;
+class MockApiService {}
+class MockDataService {
+  public currentFolderChange = new Subject<void>();
+}
+class MockTagsService {
+  private tags: TagVOData[] = [];
+  private tagsSubject = new Subject<TagVOData[]>();
 
-//   beforeEach(() => {
-//     TestBed.configureTestingModule({});
-//     service = TestBed.inject(SearchService);
-//   });
+  public getTags$(): Subject<TagVOData[]> {
+    return this.tagsSubject;
+  }
 
-//   it('should be created', () => {
-//     expect(service).toBeTruthy();
-//   });
-// });
+  public getTagByName(name: string): TagVOData {
+    return this.tags.find((t) => t.name === name);
+  }
+
+  public setTags(tags: TagVOData[]): void {
+    this.tags = tags;
+    this.tagsSubject.next(this.tags);
+  }
+}
+
+describe('SearchService', () => {
+  let service: SearchService;
+  let tags: MockTagsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SearchService],
+    });
+    TestBed.overrideProvider(ApiService, { useValue: new MockApiService() });
+    TestBed.overrideProvider(DataService, { useValue: new MockDataService() });
+    TestBed.overrideProvider(TagsService, { useValue: new MockTagsService() });
+    service = TestBed.inject(SearchService);
+    tags = TestBed.inject(TagsService) as any as MockTagsService;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('ParseSearchTerm', () => {
+    it('should generate a data structure for an empty search', () => {
+      expectSearchToBe(service.parseSearchTerm(''), '', []);
+    });
+
+    it('should generate data for a basic search', () => {
+      expectSearchToBe(service.parseSearchTerm('Potato'), 'Potato', []);
+    });
+
+    it('should remove tag tokens from search', () => {
+      expectSearchToBe(
+        service.parseSearchTerm('tag:"NonExistentTag"'),
+        undefined,
+        []
+      );
+    });
+
+    it('should load tag tokens into the tags array', () => {
+      tags.setTags([{ name: 'Potato' }]);
+      expectSearchToBe(service.parseSearchTerm('tag:"Potato"'), undefined, [
+        { name: 'Potato' },
+      ]);
+    });
+
+    it('should preserve the rest of the search', () => {
+      tags.setTags([{ name: 'Potato' }]);
+      expectSearchToBe(
+        service.parseSearchTerm('Hello tag:"Potato" World'),
+        'Hello World',
+        [{ name: 'Potato' }]
+      );
+      expectSearchToBe(
+        service.parseSearchTerm('tag:"Potato" Hello World tag:"Potato"'),
+        'Hello World',
+        [{ name: 'Potato' }, { name: 'Potato' }]
+      );
+    });
+
+    it('handles tag edge cases', () => {
+      tags.setTags([{ name: 'tag:Test' }]);
+      expectSearchToBe(service.parseSearchTerm('tag:"tag:"Test""'), undefined, [
+        { name: 'tag:Test' },
+      ]);
+    });
+
+    function expectSearchToBe(
+      search: [string, TagVOData[]],
+      expectedSearch: string,
+      expectedTags: TagVOData[]
+    ) {
+      expect(search[0]).toBe(expectedSearch);
+      expect(search[1]).toEqual(expectedTags);
+    }
+  });
+});

--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -1,19 +1,27 @@
 /* @format */
 import { TestBed } from '@angular/core/testing';
-import { Subject } from 'rxjs';
-
+import { Observable, Subject } from 'rxjs';
+import { TagsService } from '@core/services/tags/tags.service';
+import { TagVOData } from '@models/tag-vo';
+import { FolderVO, ItemVO, RecordVO } from '@models/index';
 import { ApiService } from '@shared/services/api/api.service';
 import { DataService } from '@shared/services/data/data.service';
-import { TagsService } from '@core/services/tags/tags.service';
-import { TagVO, TagVOData } from '@models/tag-vo';
 import { SearchService } from './search.service';
-import { FolderVO, ItemVO, RecordVO } from '@models/index';
 
 interface ItemVOData {
   displayName: string;
 }
 
-class MockApiService {}
+class MockApiService {
+  public search = {
+    itemsByNameObservable() {
+      return new Observable<void>();
+    },
+    itemsByNameInPublicArchiveObservable() {
+      return new Observable<void>();
+    },
+  };
+}
 class MockDataService {
   public currentFolderChange = new Subject<void>();
   public currentFolder: FolderVO = new FolderVO({});
@@ -45,6 +53,7 @@ describe('SearchService', () => {
   let service: SearchService;
   let tags: MockTagsService;
   let data: MockDataService;
+  let api: MockApiService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -56,6 +65,7 @@ describe('SearchService', () => {
     service = TestBed.inject(SearchService);
     tags = TestBed.inject(TagsService) as any as MockTagsService;
     data = TestBed.inject(DataService) as any as MockDataService;
+    api = TestBed.inject(ApiService) as any as MockApiService;
   });
 
   it('should be created', () => {
@@ -213,5 +223,17 @@ describe('SearchService', () => {
     function search(term: string, limit?: number): TagVOData[] {
       return service.getTagResults(term, limit);
     }
+  });
+
+  it('can do a complete archive search', () => {
+    const apiSpy = spyOn(api.search, 'itemsByNameObservable');
+    service.getResultsInCurrentArchive('Test', []);
+    expect(apiSpy).toHaveBeenCalled();
+  });
+
+  it('can do a public archive search', () => {
+    const apiSpy = spyOn(api.search, 'itemsByNameInPublicArchiveObservable');
+    service.getResultsInPublicArchive('Test', [], '1');
+    expect(apiSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -38,7 +38,10 @@ export class SearchService {
     });
   }
 
-  getResultsInCurrentFolder(searchTerm: string, limit?: number): ItemVO[] {
+  public getResultsInCurrentFolder(
+    searchTerm: string,
+    limit?: number
+  ): ItemVO[] {
     if (!searchTerm) {
       return [];
     }
@@ -54,7 +57,7 @@ export class SearchService {
     });
   }
 
-  parseSearchTerm(termString: string): [string, TagVOData[]] {
+  public parseSearchTerm(termString: string): [string, TagVOData[]] {
     const splitByTerm = new RegExp(/\s(?=(?:[^"]+(["])[^"]+\1)*[^"]*$)/g);
     const getTagName = new RegExp(/"(.+)"/g);
     let queryString: string;
@@ -89,7 +92,7 @@ export class SearchService {
     return [queryString, parsedTags];
   }
 
-  getResultsInCurrentArchive(
+  public getResultsInCurrentArchive(
     searchTerm: string,
     tags: TagVOData[],
     limit?: number
@@ -97,7 +100,7 @@ export class SearchService {
     return this.api.search.itemsByNameObservable(searchTerm, tags, limit);
   }
 
-  getResultsInPublicArchive(
+  public getResultsInPublicArchive(
     searchTerm: string,
     tags: TagVOData[],
     archiveId: string,
@@ -111,7 +114,7 @@ export class SearchService {
     );
   }
 
-  getTagResults(searchTerm: string, limit?: number) {
+  public getTagResults(searchTerm: string, limit?: number) {
     if (!searchTerm) {
       return [];
     }
@@ -127,7 +130,7 @@ export class SearchService {
     });
   }
 
-  indexCurrentFolder() {
+  private indexCurrentFolder() {
     if (this.data.currentFolder?.ChildItemVOs) {
       this.fuse.setCollection(this.data.currentFolder.ChildItemVOs);
     } else {
@@ -135,7 +138,7 @@ export class SearchService {
     }
   }
 
-  indexTags(tags: TagVOData[]) {
+  private indexTags(tags: TagVOData[]) {
     if (!tags?.length) {
       this.tagsFuse.setCollection([]);
     } else {

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Injectable } from '@angular/core';
 import { ApiService } from '@shared/services/api/api.service';
 import { DataService } from '@shared/services/data/data.service';
@@ -102,7 +103,12 @@ export class SearchService {
     archiveId: string,
     limit?: number
   ) {
-    return this.api.search.itemsByNameInPublicArchiveObservable(searchTerm, tags,archiveId, limit);
+    return this.api.search.itemsByNameInPublicArchiveObservable(
+      searchTerm,
+      tags,
+      archiveId,
+      limit
+    );
   }
 
   getTagResults(searchTerm: string, limit?: number) {

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -42,19 +42,11 @@ export class SearchService {
     searchTerm: string,
     limit?: number
   ): ItemVO[] {
-    if (!searchTerm) {
-      return [];
-    }
+    return this.searchWithFuse(this.fuse, searchTerm, limit);
+  }
 
-    let results = this.fuse.search(searchTerm);
-
-    if (limit) {
-      results = results.slice(0, limit);
-    }
-
-    return results.map((i) => {
-      return i.item;
-    });
+  public getTagResults(searchTerm: string, limit?: number): TagVOData[] {
+    return this.searchWithFuse(this.tagsFuse, searchTerm, limit);
   }
 
   public parseSearchTerm(termString: string): [string, TagVOData[]] {
@@ -114,20 +106,18 @@ export class SearchService {
     );
   }
 
-  public getTagResults(searchTerm: string, limit?: number) {
+  private searchWithFuse<T>(
+    fuse: Fuse<T>,
+    searchTerm: string,
+    limit?: number
+  ): T[] {
     if (!searchTerm) {
       return [];
     }
-
-    let results = this.tagsFuse.search(searchTerm);
-
-    if (limit) {
-      results = results.slice(0, limit);
-    }
-
-    return results.map((i) => {
-      return i.item as TagVOData;
-    });
+    return fuse
+      .search(searchTerm)
+      .slice(0, limit)
+      .map((i) => i.item);
   }
 
   private indexCurrentFolder() {

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -12,12 +12,14 @@ export class SearchService {
   private fuseOptions: Fuse.IFuseOptions<ItemVO> = {
     keys: ['displayName'],
     threshold: 0.1,
+    ignoreLocation: true,
   };
   private fuse = new Fuse([], this.fuseOptions);
 
-  private tagsFuseOptions: Fuse.IFuseOptions<ItemVO> = {
+  private tagsFuseOptions: Fuse.IFuseOptions<TagVOData> = {
     keys: ['name'],
     threshold: 0.1,
+    ignoreLocation: true,
   };
   private tagsFuse = new Fuse([], this.tagsFuseOptions);
 


### PR DESCRIPTION
I have updated fuse.js to the latest version and also updated the fuse config objects, setting the ignoreLocation property to true. This will consider the patter a match anywhere in the string, as per fuse.js documentation.

Steps to test:

1. Search any term in the search bar considering there are records uploaded that contain that value.
2. The items should appear in the "In this folder" section.