### PR TITLE
Fix scroll bug after clicking share link dialog

### DIFF
--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.html
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.html
@@ -21,10 +21,13 @@
         Learn more about Permanent
       </a>
     </p>
-    <a [routerLink]="['/app', 'signup']" class="btn btn-primary"
+    <a
+      [routerLink]="['/app', 'signup']"
+      (click)="close()"
+      class="btn btn-primary"
       >Create Account</a
     >
-    <a [routerLink]="['/app', 'login']" class="login"
+    <a [routerLink]="['/app', 'login']" (click)="close()" class="login"
       >Already have an account?</a
     >
   </div>

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.spec.ts
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.spec.ts
@@ -4,12 +4,11 @@ import {
   TestBed,
   TestModuleMetadata,
 } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { cloneDeep } from 'lodash';
-
 import { SharedModule } from '@shared/shared.module';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
 import * as Testing from '@root/test/testbedConfig';
-import { InviteVO } from '@root/app/models';
 import { CreateAccountDialogComponent } from './create-account-dialog.component';
 
 describe('CreateAccountDialogComponent', () => {
@@ -28,6 +27,12 @@ describe('CreateAccountDialogComponent', () => {
     dialogRef = new DialogRef(1, null);
 
     config.imports.push(SharedModule);
+    config.imports.push(
+      RouterTestingModule.withRoutes([
+        { path: 'app/signup', redirectTo: '' },
+        { path: 'app/login', redirectTo: '' },
+      ])
+    );
     config.declarations.push(CreateAccountDialogComponent);
     config.providers.push({
       provide: DIALOG_DATA,
@@ -63,4 +68,38 @@ describe('CreateAccountDialogComponent', () => {
 
     expect(dialogRefSpy).toHaveBeenCalled();
   });
+
+  it('should call the close method when signup link is clicked', async () => {
+    const dialogRefSpy = spyOn(dialogRef, 'close');
+    const button = findLink(fixture, 'a.btn.btn-primary');
+
+    expectLinkClosesDialog(button, '/app/signup', dialogRefSpy);
+  });
+
+  it('should call the close method when login link is clicked', () => {
+    const dialogRefSpy = spyOn(dialogRef, 'close');
+    const link = findLink(fixture, '.login');
+
+    expectLinkClosesDialog(link, '/app/login', dialogRefSpy);
+  });
+
+  function findLink(
+    fixture: ComponentFixture<CreateAccountDialogComponent>,
+    selector: string
+  ) {
+    const element: HTMLElement = fixture.nativeElement;
+    const button = element.querySelector(selector) as HTMLAnchorElement;
+    expect(button).toBeTruthy();
+    return button;
+  }
+
+  function expectLinkClosesDialog(
+    link: HTMLAnchorElement,
+    expectedPath: string,
+    dialogRefSpy: jasmine.Spy<jasmine.Func>
+  ) {
+    expect(link.href).toContain(expectedPath);
+    link.click();
+    expect(dialogRefSpy).toHaveBeenCalled();
+  }
 });


### PR DESCRIPTION
The current dialog system locks the browser from scrolling while a dialog is active. This caused a bug in the new dialog that pops up on the Share Link page. Normally dialogs are closed out in the app and can reset this scrolling lock, but this specific dialog has routerLinks that navigate away from the page without closing the dialog, thus leaving the scrolling lock active. This prevents users from completing onboarding if the page contents need to be scrolled, since they can't click buttons to progress. Fix this by closing the dialog when either of the links is clicked.

**Steps To Test:**
1. Go to an already existing account and share something (create a share link)
2. Follow that link in an incognito browser and sign up from the link
3. Progress to the choose archive type page of onboarding. On the current main branch, observe that you cannot see the buttons to move forward or backwards and you cannot scroll. On this branch, observe that the scrolling issue is fixed.