### PR TITLE
PER-8633: Arrow nav

### DIFF
--- a/src/app/file-browser/components/edit-tags/edit-tags.component.html
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.html
@@ -1,67 +1,153 @@
 <ng-container *ngIf="!isDialog">
-  <pr-tags (focus)="startEditing()" tabindex="0" [tags]="itemTags" (click)="startEditing()" [readOnly]="false" [class.clickable]="canEdit && !isEditing"
-    [canEdit]="canEdit" [animate]="isEditing" [isEditing]="isEditing"></pr-tags>
-  <div class="input-group" *ngIf="isEditing" @ngIfScaleAnimation [class.has-tags]="allTags?.length">
-    <input type="text" class="new-tag form-control" [placeholder]="placeholderText" [(ngModel)]="newTagName"
-    (ngModelChange)="onTagType(newTagName)" (keydown.enter)="onInputEnter(newTagName)">
+  <pr-tags
+    (focus)="startEditing()"
+    tabindex="0"
+    [tags]="itemTags"
+    (click)="startEditing()"
+    [readOnly]="false"
+    [class.clickable]="canEdit && !isEditing"
+    [canEdit]="canEdit"
+    [animate]="isEditing"
+    [isEditing]="isEditing"
+  ></pr-tags>
+  <div
+    class="input-group"
+    *ngIf="isEditing"
+    @ngIfScaleAnimation
+    [class.has-tags]="allTags?.length"
+  >
+    <input
+      type="text"
+      class="new-tag form-control"
+      [ngClass]="'new-tag-' + tagType"
+      [placeholder]="placeholderText"
+      [(ngModel)]="newTagName"
+      (ngModelChange)="onTagType(newTagName)"
+      (keydown.enter)="onInputEnter(newTagName)"
+      (keydown)="setFocusToFirstTagOrButton($event)"
+    />
     <div *ngIf="newTagInputError" class="input-vertical-error">
-      {{this.tagType === 'keyword' ? "Tag cannot contain ':'" : "Format must be key:value"}}
+      {{
+        this.tagType === 'keyword'
+          ? "Tag cannot contain ':'"
+          : 'Format must be key:value'
+      }}
     </div>
     <div class="input-group-append">
-      <button class="btn btn-primary" (click)="newTagName ? onInputEnter(newTagName) : endEditing()">{{ newTagName ? 'Add' : 'Done' }}</button>
+      <button
+        class="btn btn-primary"
+        [ngClass]="'add-tag-' + tagType"
+        (click)="newTagName ? onInputEnter(newTagName) : endEditing()"
+        (keydown)="setFocusToFirstTagOrButton($event)"
+      >
+        {{ newTagName ? 'Add' : 'Done' }}
+      </button>
     </div>
   </div>
-  <div class="edit-tags" *ngIf="isEditing && matchingTags?.length" @ngIfScaleAnimation>
-    <div class="edit-tag" *ngFor="let tag of matchingTags" [class.is-selected]="itemTagsById.has(tag.tagId)"
-    (click)="onTagClick(tag)">
+  <div
+    class="edit-tags"
+    *ngIf="isEditing && matchingTags?.length"
+    @ngIfScaleAnimation
+  >
+    <div
+      class="edit-tag"
+      [ngClass]="'edit-tag-' + tagType"
+      *ngFor="let tag of matchingTags; let i = index"
+      [class.is-selected]="itemTagsById.has(tag.tagId)"
+      (click)="onTagClick(tag)"
+      (keydown)="onArrowNav($event, i)"
+      (keydown.enter)="onTagClick(tag)"
+      tabindex="0"
+    >
       <div class="select">
         <div class="select-active"></div>
       </div>
       <div class="tag-name">
-        {{tag.name}}
+        {{ tag.name }}
       </div>
     </div>
   </div>
   <p class="manage-tags-message" *ngIf="isEditing" @ngIfScaleAnimation>
     <span class="manage-tags-link" (click)="onManageTagsClick()">
-      Manage {{this.tagType === 'keyword' ? "tags" : 'custom metadata'}}</span> in archive settings.
+      Manage {{ this.tagType === 'keyword' ? 'tags' : 'custom metadata' }}</span
+    >
+    in archive settings.
   </p>
 </ng-container>
 <ng-container *ngIf="isDialog">
   <div class="dialog-content">
     <div class="dialog-body">
-      <div class="page-title break-all">{{item.displayName}}</div>
+      <div class="page-title break-all">{{ item.displayName }}</div>
       <div class="edit-tags-dialog-body">
-        <pr-tags [tags]="dialogTags" (click)="startEditing()"
-          [canEdit]="true" [animate]="isEditing" [isEditing]="isEditing"></pr-tags>
+        <pr-tags
+          [tags]="dialogTags"
+          (click)="startEditing()"
+          [canEdit]="true"
+          [animate]="isEditing"
+          [isEditing]="isEditing"
+        ></pr-tags>
         <div class="input-group">
-          <input type="text" class="new-tag form-control" [placeholder]="placeholderText" *ngIf="isEditing" @ngIfScaleAnimation
-            [(ngModel)]="newTagName" (keydown.enter)="onInputEnter(newTagName)" (ngModelChange)="onTagType(newTagName)">
+          <input
+            type="text"
+            class="new-tag form-control"
+            [ngClass]="'new-tag-' + tagType"
+            [placeholder]="placeholderText"
+            *ngIf="isEditing"
+            @ngIfScaleAnimation
+            [(ngModel)]="newTagName"
+            (keydown.enter)="onInputEnter(newTagName)"
+            (ngModelChange)="onTagType(newTagName)"
+            (keydown)="setFocusToFirstTagOrButton($event)"
+          />
           <div *ngIf="newTagInputError" class="input-vertical-error">
-            {{this.tagType === 'keyword' ? "Tag cannot contain ':'" : "Format must be key:value"}}
+            {{
+              this.tagType === 'keyword'
+                ? "Tag cannot contain ':'"
+                : 'Format must be key:value'
+            }}
           </div>
           <div class="input-group-append">
-            <button class="btn btn-primary" (click)="onInputEnter(newTagName)" [disabled]="!newTagName">Add</button>
+            <button
+              class="btn btn-primary"
+              [ngClass]="'add-tag-' + tagType"
+              (click)="onInputEnter(newTagName)"
+              [disabled]="!newTagName"
+              (keydown)="setFocusToFirstTagOrButton($event)"
+            >
+              Add
+            </button>
           </div>
         </div>
         <div class="edit-tags" *ngIf="isEditing" @ngIfScaleAnimation>
-          <div class="edit-tag" *ngFor="let tag of matchingTags" [class.is-selected]="itemTagsById.has(tag.tagId)"
-          (click)="onTagClick(tag)">
+          <div
+            class="edit-tag"
+            [ngClass]="'edit-tag-' + tagType"
+            *ngFor="let tag of matchingTags; let i = index"
+            [class.is-selected]="itemTagsById.has(tag.tagId)"
+            (click)="onTagClick(tag)"
+            (keydown)="onArrowNav($event, i)"
+            (keydown.enter)="onTagClick(tag)"
+            tabindex="0"
+          >
             <div class="select">
               <div class="select-active"></div>
             </div>
             <div class="tag-name">
-              {{tag.name}}
+              {{ tag.name }}
             </div>
           </div>
-          <div class="edit-tag" *ngIf="!matchingTags.length">No existing tags found</div>
+          <div class="edit-tag" *ngIf="!matchingTags.length">
+            No existing tags found
+          </div>
         </div>
         <p class="manage-tags-message" *ngIf="isEditing" @ngIfScaleAnimation>
           <span class="manage-tags-link" (click)="onManageTagsClick()">
-            Manage {{this.tagType === 'keyword' ? "tags" : 'custom metadata'}}</span> in archive settings.
+            Manage
+            {{ this.tagType === 'keyword' ? 'tags' : 'custom metadata' }}</span
+          >
+          in archive settings.
         </p>
-    </div>
-
+      </div>
     </div>
     <div class="dialog-footer">
       <button class="btn btn-secondary" (click)="close()">Done</button>

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.html
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.html
@@ -44,10 +44,7 @@
       </button>
     </div>
   </div>
-  <div
-    class="edit-tags"
-    *ngIf="isEditing && matchingTags?.length"
-  >
+  <div class="edit-tags" *ngIf="isEditing && matchingTags?.length">
     <div
       class="edit-tag"
       [ngClass]="'edit-tag-' + tagType"

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.html
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.html
@@ -47,7 +47,6 @@
   <div
     class="edit-tags"
     *ngIf="isEditing && matchingTags?.length"
-    @ngIfScaleAnimation
   >
     <div
       class="edit-tag"

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -1,7 +1,7 @@
 /* @format */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async } from '@angular/core/testing';
 import { Shallow } from 'shallow-render';
-import { Subject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ItemVO, TagVOData, RecordVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
@@ -199,37 +199,52 @@ describe('EditTagsComponent', () => {
   it('should handle ArrowDown event', async () => {
     const { instance: componentInstance } = await defaultRender();
     componentInstance.isEditing = true;
-  
+
     spyOn(componentInstance, 'setFocusToCurrentIndex');
-  
+
     const testIndex = 0;
-    componentInstance.onArrowNav(new KeyboardEvent('keydown', { key: 'ArrowDown' }), testIndex);
-  
+    componentInstance.onArrowNav(
+      new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+      testIndex
+    );
+
     // expect(componentInstance.currentIndex).toBe(testIndex + 1);
-    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(testIndex + 1);
+    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(
+      testIndex + 1
+    );
   });
 
   it('should handle ArrowUp event when the first input is highlighted', async () => {
     const { instance: componentInstance } = await defaultRender();
     componentInstance.isEditing = true;
-  
+
     spyOn(componentInstance, 'setFocusToInputOrButton');
-  
+
     const testIndex = 0;
-    componentInstance.onArrowNav(new KeyboardEvent('keydown', { key: 'ArrowUp' }), testIndex);
-  
-    expect(componentInstance.setFocusToInputOrButton).toHaveBeenCalledWith('new-tag-keyword');
+    componentInstance.onArrowNav(
+      new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+      testIndex
+    );
+
+    expect(componentInstance.setFocusToInputOrButton).toHaveBeenCalledWith(
+      'new-tag-keyword'
+    );
   });
 
   it('should handle ArrowUp event', async () => {
     const { instance: componentInstance } = await defaultRender();
     componentInstance.isEditing = true;
-  
+
     spyOn(componentInstance, 'setFocusToCurrentIndex');
-  
+
     const testIndex = 4;
-    componentInstance.onArrowNav(new KeyboardEvent('keydown', { key: 'ArrowUp' }), testIndex);
-  
-    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(testIndex - 1);
+    componentInstance.onArrowNav(
+      new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+      testIndex
+    );
+
+    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(
+      testIndex - 1
+    );
   });
 });

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -12,9 +12,9 @@ import { SearchService } from '@search/services/search.service';
 import { TagResponse } from '@shared/services/api/tag.repo';
 import { Dialog } from '@root/app/dialog/dialog.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { FileBrowserComponentsModule } from '../../file-browser-components.module';
 import { EditTagsComponent, TagType } from './edit-tags.component';
-import { By } from '@angular/platform-browser';
 
 const defaultTagList: TagVOData[] = [
   {

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -197,57 +197,6 @@ describe('EditTagsComponent', () => {
     expect(dialogOpenSpy.open).toHaveBeenCalled();
   });
 
-  it('should handle ArrowDown event', async () => {
-    const { instance: componentInstance } = await defaultRender();
-    componentInstance.isEditing = true;
-
-    spyOn(componentInstance, 'setFocusToCurrentIndex');
-
-    const testIndex = 0;
-    componentInstance.onArrowNav(
-      new KeyboardEvent('keydown', { key: 'ArrowDown' }),
-      testIndex
-    );
-
-    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(
-      testIndex + 1
-    );
-  });
-
-  it('should handle ArrowUp event when the first input is highlighted', async () => {
-    const { instance: componentInstance } = await defaultRender();
-    componentInstance.isEditing = true;
-
-    spyOn(componentInstance, 'setFocusToInputOrButton');
-
-    const testIndex = 0;
-    componentInstance.onArrowNav(
-      new KeyboardEvent('keydown', { key: 'ArrowUp' }),
-      testIndex
-    );
-
-    expect(componentInstance.setFocusToInputOrButton).toHaveBeenCalledWith(
-      'new-tag-keyword'
-    );
-  });
-
-  it('should handle ArrowUp event', async () => {
-    const { instance: componentInstance } = await defaultRender();
-    componentInstance.isEditing = true;
-
-    spyOn(componentInstance, 'setFocusToCurrentIndex');
-
-    const testIndex = 4;
-    componentInstance.onArrowNav(
-      new KeyboardEvent('keydown', { key: 'ArrowUp' }),
-      testIndex
-    );
-
-    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(
-      testIndex - 1
-    );
-  });
-
   it('should highlight the correct tag on key down', async () => {
     const { fixture, element } = await defaultRender();
 

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -1,7 +1,7 @@
 /* @format */
 import { async } from '@angular/core/testing';
 import { Shallow } from 'shallow-render';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import { ItemVO, TagVOData, RecordVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
@@ -14,6 +14,7 @@ import { Dialog } from '@root/app/dialog/dialog.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FileBrowserComponentsModule } from '../../file-browser-components.module';
 import { EditTagsComponent, TagType } from './edit-tags.component';
+import { By } from '@angular/platform-browser';
 
 const defaultTagList: TagVOData[] = [
   {
@@ -63,7 +64,7 @@ describe('EditTagsComponent', () => {
       .mock(SearchService, { getTagResults: (tag) => defaultTagList })
       .mock(TagsService, {
         getTags: () => defaultTagList,
-        getTags$: () => new Observable<TagVOData[]>(),
+        getTags$: () => of(defaultTagList),
         setItemTags: () => {},
       })
       .mock(MessageService, { showError: () => {} })
@@ -208,7 +209,6 @@ describe('EditTagsComponent', () => {
       testIndex
     );
 
-    // expect(componentInstance.currentIndex).toBe(testIndex + 1);
     expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(
       testIndex + 1
     );
@@ -246,5 +246,58 @@ describe('EditTagsComponent', () => {
     expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(
       testIndex - 1
     );
+  });
+
+  it('should highlight the correct tag on key down', async () => {
+    const { fixture, element } = await defaultRender();
+
+    element.componentInstance.isEditing = true;
+
+    fixture.detectChanges();
+    const tags = fixture.debugElement.queryAll(By.css('.edit-tag'));
+
+    const arrowKeyDown = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+    tags[0].nativeElement.dispatchEvent(arrowKeyDown);
+
+    fixture.detectChanges();
+
+    const focusedElement = document.activeElement as HTMLElement;
+    expect(focusedElement).toBe(tags[1].nativeElement);
+  });
+
+  it('should highlight the correct tag on key up', async () => {
+    const { fixture, element } = await defaultRender();
+
+    element.componentInstance.isEditing = true;
+
+    fixture.detectChanges();
+    const tags = fixture.debugElement.queryAll(By.css('.edit-tag'));
+
+    const arrowKeyDown = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+    tags[1].nativeElement.dispatchEvent(arrowKeyDown);
+
+    fixture.detectChanges();
+
+    const focusedElement = document.activeElement as HTMLElement;
+    expect(focusedElement).toBe(tags[0].nativeElement);
+  });
+
+  it('should highlight the input on key up', async () => {
+    const { fixture, element } = await defaultRender();
+
+    element.componentInstance.isEditing = true;
+
+    fixture.detectChanges();
+    const tag = fixture.debugElement.query(By.css('.edit-tag'));
+
+    const arrowKeyUp = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+    const input = fixture.debugElement.query(By.css('.new-tag'));
+
+    tag.nativeElement.dispatchEvent(arrowKeyUp);
+
+    fixture.detectChanges();
+
+    const focusedElement = document.activeElement as HTMLElement;
+    expect(focusedElement).toEqual(input.nativeElement);
   });
 });

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -195,4 +195,41 @@ describe('EditTagsComponent', () => {
     );
     expect(dialogOpenSpy.open).toHaveBeenCalled();
   });
+
+  it('should handle ArrowDown event', async () => {
+    const { instance: componentInstance } = await defaultRender();
+    componentInstance.isEditing = true;
+  
+    spyOn(componentInstance, 'setFocusToCurrentIndex');
+  
+    const testIndex = 0;
+    componentInstance.onArrowNav(new KeyboardEvent('keydown', { key: 'ArrowDown' }), testIndex);
+  
+    // expect(componentInstance.currentIndex).toBe(testIndex + 1);
+    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(testIndex + 1);
+  });
+
+  it('should handle ArrowUp event when the first input is highlighted', async () => {
+    const { instance: componentInstance } = await defaultRender();
+    componentInstance.isEditing = true;
+  
+    spyOn(componentInstance, 'setFocusToInputOrButton');
+  
+    const testIndex = 0;
+    componentInstance.onArrowNav(new KeyboardEvent('keydown', { key: 'ArrowUp' }), testIndex);
+  
+    expect(componentInstance.setFocusToInputOrButton).toHaveBeenCalledWith('new-tag-keyword');
+  });
+
+  it('should handle ArrowUp event', async () => {
+    const { instance: componentInstance } = await defaultRender();
+    componentInstance.isEditing = true;
+  
+    spyOn(componentInstance, 'setFocusToCurrentIndex');
+  
+    const testIndex = 4;
+    componentInstance.onArrowNav(new KeyboardEvent('keydown', { key: 'ArrowUp' }), testIndex);
+  
+    expect(componentInstance.setFocusToCurrentIndex).toHaveBeenCalledWith(testIndex - 1);
+  });
 });

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -302,7 +302,7 @@ export class EditTagsComponent
       event.preventDefault();
       this.setFocusToInputOrButton(`add-tag-${this.tagType}`);
     }
-    if(event.key === 'ArrowLeft'){
+    if (event.key === 'ArrowLeft') {
       event.preventDefault();
       this.setFocusToInputOrButton(`new-tag-${this.tagType}`);
     }

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -90,11 +90,9 @@ export class EditTagsComponent
           this.endEditing();
         }
 
-        console.log(tags);
 
         this.allTags = this.filterTagsByType(tags);
         this.matchingTags = this.filterTagsByType(tags);
-        console.log(this.matchingTags);
         this.checkItemTags();
       })
     );
@@ -127,7 +125,6 @@ export class EditTagsComponent
     this.allTags = this.filterTagsByType(this.tagsService.getTags());
     this.matchingTags = this.allTags;
 
-    console.log(this.matchingTags);
 
     this.checkItemTags();
     this.lastDataStatus = this.item?.dataStatus;

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -288,7 +288,7 @@ export class EditTagsComponent
     }
   }
 
-  private setFocusToInputOrButton(inputClass) {
+  public setFocusToInputOrButton(inputClass) {
     const input = document.querySelector(`.${inputClass}`);
     (input as HTMLElement).focus();
   }
@@ -308,7 +308,7 @@ export class EditTagsComponent
     }
   }
 
-  private setFocusToCurrentIndex(index) {
+  public setFocusToCurrentIndex(index) {
     const elements = document.querySelectorAll(`.edit-tag-${this.tagType}`);
     (elements[index] as HTMLElement).focus();
   }

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -84,14 +84,17 @@ export class EditTagsComponent
   ) {
     this.subscriptions.push(
       this.tagsService.getTags$().subscribe((tags) => {
-        if (this.allTags.length > tags.length) {
+        if (this.allTags?.length > tags?.length) {
           // The user deleted one of our tags in manage-tags.
           // Let's close the editor.
           this.endEditing();
         }
 
+        console.log(tags);
+
         this.allTags = this.filterTagsByType(tags);
         this.matchingTags = this.filterTagsByType(tags);
+        console.log(this.matchingTags);
         this.checkItemTags();
       })
     );
@@ -123,6 +126,8 @@ export class EditTagsComponent
       this.tagType === 'keyword' ? 'Add new tag' : 'Add new field:value';
     this.allTags = this.filterTagsByType(this.tagsService.getTags());
     this.matchingTags = this.allTags;
+
+    console.log(this.matchingTags);
 
     this.checkItemTags();
     this.lastDataStatus = this.item?.dataStatus;
@@ -230,15 +235,15 @@ export class EditTagsComponent
     this.itemTagsById.clear();
 
     this.itemTags = this.filterTagsByType(
-      this.item.TagVOs.map((tag) =>
-        this.allTags?.find((t) => t.tagId === tag.tagId)
-      ).filter(
-        // Filter out tags that are now null from deletion
-        (tag) => tag?.name
-      )
+      (this.item?.TagVOs || [])
+        .map((tag) => this.allTags?.find((t) => t.tagId === tag.tagId))
+        .filter(
+          // Filter out tags that are now null from deletion
+          (tag) => tag?.name
+        )
     );
 
-    if (!this.item.TagVOs?.length) {
+    if (!this.item?.TagVOs?.length) {
       return;
     }
 
@@ -272,6 +277,7 @@ export class EditTagsComponent
   }
 
   onArrowNav(event: KeyboardEvent, index: number) {
+    event.stopPropagation();
     if (event.key === 'ArrowDown') {
       event.preventDefault();
       if (index < this.matchingTags.length - 1) {
@@ -289,7 +295,7 @@ export class EditTagsComponent
   }
 
   public setFocusToInputOrButton(inputClass) {
-    const input = document.querySelector(`.${inputClass}`);
+    const input = this.elementRef.nativeElement.querySelector(`.${inputClass}`);
     (input as HTMLElement).focus();
   }
 
@@ -299,17 +305,21 @@ export class EditTagsComponent
       this.setFocusToCurrentIndex(0);
     }
     if (event.key === 'ArrowRight') {
+      event.stopPropagation();
       event.preventDefault();
       this.setFocusToInputOrButton(`add-tag-${this.tagType}`);
     }
     if (event.key === 'ArrowLeft') {
+      event.stopPropagation();
       event.preventDefault();
       this.setFocusToInputOrButton(`new-tag-${this.tagType}`);
     }
   }
 
   public setFocusToCurrentIndex(index) {
-    const elements = document.querySelectorAll(`.edit-tag-${this.tagType}`);
+    const elements = this.elementRef.nativeElement.querySelectorAll(
+      `.edit-tag-${this.tagType}`
+    );
     (elements[index] as HTMLElement).focus();
   }
 }

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -90,7 +90,6 @@ export class EditTagsComponent
           this.endEditing();
         }
 
-
         this.allTags = this.filterTagsByType(tags);
         this.matchingTags = this.filterTagsByType(tags);
         this.checkItemTags();
@@ -124,7 +123,6 @@ export class EditTagsComponent
       this.tagType === 'keyword' ? 'Add new tag' : 'Add new field:value';
     this.allTags = this.filterTagsByType(this.tagsService.getTags());
     this.matchingTags = this.allTags;
-
 
     this.checkItemTags();
     this.lastDataStatus = this.item?.dataStatus;

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -69,6 +69,7 @@ export class EditTagsComponent
   private lastDataStatus: DataStatus;
   private lastFolderLinkId: number;
   private dialogTagSubscription: Subscription;
+  private currentIndex: number = 0;
 
   constructor(
     @Optional() @Inject(DIALOG_DATA) public dialogData: any,
@@ -268,5 +269,47 @@ export class EditTagsComponent
 
   close() {
     this.dialogRef.close();
+  }
+
+  onArrowNav(event: KeyboardEvent, index: number) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (index < this.matchingTags.length - 1) {
+        this.currentIndex++;
+        this.setFocusToCurrentIndex(index + 1);
+      }
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (index > 0) {
+        this.setFocusToCurrentIndex(index - 1);
+      } else if (index === 0) {
+        this.setFocusToInputOrButton(`new-tag-${this.tagType}`);
+      }
+    }
+  }
+
+  private setFocusToInputOrButton(inputClass) {
+    const input = document.querySelector(`.${inputClass}`);
+    (input as HTMLElement).focus();
+  }
+
+  public setFocusToFirstTagOrButton(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.setFocusToCurrentIndex(0);
+    }
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      this.setFocusToInputOrButton(`add-tag-${this.tagType}`);
+    }
+    if(event.key === 'ArrowLeft'){
+      event.preventDefault();
+      this.setFocusToInputOrButton(`new-tag-${this.tagType}`);
+    }
+  }
+
+  private setFocusToCurrentIndex(index) {
+    const elements = document.querySelectorAll(`.edit-tag-${this.tagType}`);
+    (elements[index] as HTMLElement).focus();
   }
 }

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -172,8 +172,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   // Keyboard
   @HostListener('document:keydown', ['$event'])
   onKeyDown(event) {
-    const isTagsDialogShownOnScreen = !!document.querySelector('pr-edit-tags');
-    if (!this.fullscreen && !isTagsDialogShownOnScreen) {
+    if (!this.fullscreen) {
       switch (event.key) {
         case Key.ArrowLeft:
           this.incrementCurrentRecord(true);

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -172,7 +172,8 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   // Keyboard
   @HostListener('document:keydown', ['$event'])
   onKeyDown(event) {
-    if (!this.fullscreen) {
+    const isTagsDialogShownOnScreen = !!document.querySelector('pr-edit-tags');
+    if (!this.fullscreen && !isTagsDialogShownOnScreen) {
       switch (event.key) {
         case Key.ArrowLeft:
           this.incrementCurrentRecord(true);


### PR DESCRIPTION
Allow the user to use the arrows to navigate through tags

I have also disabled the navigation with the arrows when the file viewer is open and the tags dialog is showing.

Steps to test:

1.Open the tags in the side bar or the file viewer.
2. Highlight the input with tab or by clicking it.
3. Use the arrows to navigate.