### PR TITLE
PER-9353: Search with qutation marks

### DIFF
--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -81,14 +81,6 @@ describe('SearchService', () => {
       expectSearchToBe(service.parseSearchTerm('Potato'), 'Potato', []);
     });
 
-    it('should remove tag tokens from search', () => {
-      expectSearchToBe(
-        service.parseSearchTerm('tag:"NonExistentTag"'),
-        undefined,
-        []
-      );
-    });
-
     it('should load tag tokens into the tags array', () => {
       tags.setTags([{ name: 'Potato' }]);
       expectSearchToBe(service.parseSearchTerm('tag:"Potato"'), undefined, [
@@ -108,28 +100,6 @@ describe('SearchService', () => {
         'Hello World',
         [{ name: 'Potato' }, { name: 'Potato' }]
       );
-    });
-
-    it('removes quotation marks from tag names', () => {
-      /*
-        This test probably represents erroneous behavior that we want to change
-        at some point. For now, this represents the original functionality of
-        the SearchService as it was written.
-      */
-      tags.setTags([
-        { name: 'Potato', tagId: 0 },
-        { name: '"Potato"', tagId: 1 },
-      ]);
-      const searchTokens = service.parseSearchTerm('tag:""Potato""');
-      expect(searchTokens[1].length).toBe(1);
-      expect(searchTokens[1][0].tagId).toBe(0);
-    });
-
-    it('handles tag edge cases', () => {
-      tags.setTags([{ name: 'tag:Test' }]);
-      expectSearchToBe(service.parseSearchTerm('tag:"tag:"Test""'), undefined, [
-        { name: 'tag:Test' },
-      ]);
     });
 
     function expectSearchToBe(

--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -110,6 +110,32 @@ describe('SearchService', () => {
       expect(search[0]).toBe(expectedSearch);
       expect(search[1]).toEqual(expectedTags);
     }
+
+    it('removes the first and last quotation marks from tag names', () => {
+      tags.setTags([
+        { name: 'Potato', tagId: 0 },
+        { name: '"Potato"', tagId: 1 },
+      ]);
+      const searchTokens = service.parseSearchTerm('tag:""Potato""');
+      expect(searchTokens[1].length).toBe(1);
+      expect(searchTokens[1][0].tagId).toBe(1);
+    });
+
+    it('handles tag edge cases', () => {
+      tags.setTags([{ name: 'tag:Test' }]);
+      expectSearchToBe(
+        service.parseSearchTerm('tag:"tag:"Test""'),
+        'tag:"tag:"Test""',
+        []
+      );
+    });
+
+    it('handles returns the tags correctly if they have quotation marks', () => {
+      tags.setTags([{ name: 'tag:"Test"' }]);
+      expectSearchToBe(service.parseSearchTerm('tag:"tag:"Test""'), undefined, [
+        { name: 'tag:"Test"' },
+      ]);
+    });
   });
 
   describe('getResultsInCurrentFolder', () => {

--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -102,16 +102,7 @@ describe('SearchService', () => {
       );
     });
 
-    function expectSearchToBe(
-      search: [string, TagVOData[]],
-      expectedSearch: string,
-      expectedTags: TagVOData[]
-    ) {
-      expect(search[0]).toBe(expectedSearch);
-      expect(search[1]).toEqual(expectedTags);
-    }
-
-    it('removes the first and last quotation marks from tag names', () => {
+    it('handles quotation marks in tag names properly', () => {
       tags.setTags([
         { name: 'Potato', tagId: 0 },
         { name: '"Potato"', tagId: 1 },
@@ -232,4 +223,21 @@ describe('SearchService', () => {
     service.getResultsInPublicArchive('Test', [], '1');
     expect(apiSpy).toHaveBeenCalled();
   });
+
+  it('cannot handle tags with quotation marks followed by search terms with quotation marks', () => {
+    tags.setTags([{ name: '"A Multiword Tag"', tagId: 0 }]);
+    const searchTokens = service.parseSearchTerm(
+      'tag:""A Multiword Tag"" "potato"'
+    );
+    expect(searchTokens[1].length).toBe(0);
+  });
+
+  function expectSearchToBe(
+    search: [string, TagVOData[]],
+    expectedSearch: string,
+    expectedTags: TagVOData[]
+  ) {
+    expect(search[0]).toBe(expectedSearch);
+    expect(search[1]).toEqual(expectedTags);
+  }
 });

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -86,14 +86,8 @@ export class SearchService {
     return [queryString, parsedTags];
   }
 
-  private removeFirstAndLastQuotes(str) {
-    if (str.startsWith('"')) {
-      str = str.substr(1);
-    }
-    if (str.endsWith('"')) {
-      str = str.substring(0, str.length - 1);
-    }
-    return str;
+  private removeFirstAndLastQuotes(str: string): string {
+    return str.replace(/^"|"$/g, '');
   }
 
   public getResultsInCurrentArchive(

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -63,14 +63,14 @@ export class SearchService {
           const tagNames = part.match(getTagName) || [];
           for (const tagName of tagNames) {
             if (tagName) {
-              const name = this.removeFirstAndLastQuotes(tagName)
+              const name = this.removeFirstAndLastQuotes(tagName);
               const tag = this.tags.getTagByName(name);
               if (tag) {
                 parsedTags.push(tag);
               }
             }
           }
-          if(!parsedTags.length){
+          if (!parsedTags.length) {
             queryString = termString;
           }
         } else {
@@ -85,16 +85,16 @@ export class SearchService {
     }
     return [queryString, parsedTags];
   }
-  
+
   private removeFirstAndLastQuotes(str) {
     if (str.startsWith('"')) {
-        str = str.substr(1);
+      str = str.substr(1);
     }
     if (str.endsWith('"')) {
-        str = str.substring(0, str.length - 1);
+      str = str.substring(0, str.length - 1);
     }
     return str;
-}
+  }
 
   public getResultsInCurrentArchive(
     searchTerm: string,

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -63,12 +63,15 @@ export class SearchService {
           const tagNames = part.match(getTagName) || [];
           for (const tagName of tagNames) {
             if (tagName) {
-              const name = tagName.replace(/"/g, '');
+              const name = this.removeFirstAndLastQuotes(tagName)
               const tag = this.tags.getTagByName(name);
               if (tag) {
                 parsedTags.push(tag);
               }
             }
+          }
+          if(!parsedTags.length){
+            queryString = termString;
           }
         } else {
           queryParts.push(part);
@@ -80,9 +83,18 @@ export class SearchService {
     } else {
       queryString = termString;
     }
-
     return [queryString, parsedTags];
   }
+  
+  private removeFirstAndLastQuotes(str) {
+    if (str.startsWith('"')) {
+        str = str.substr(1);
+    }
+    if (str.endsWith('"')) {
+        str = str.substring(0, str.length - 1);
+    }
+    return str;
+}
 
   public getResultsInCurrentArchive(
     searchTerm: string,


### PR DESCRIPTION
Replaced the regex match that was removing all the qutation marks with a new function which removes only the first and last qutation marks.

@meisekimiu please let me know if this current behaviour is the wanted one. This is what I understood. Thanks!