### PR TITLE
Per 9139 publish modal shows extra slash

### DIFF
--- a/src/app/file-browser/components/publish/publish.component.ts
+++ b/src/app/file-browser/components/publish/publish.component.ts
@@ -54,7 +54,6 @@ export class PublishComponent implements OnInit {
   ) {
     this.sourceItem = this.data.item as FolderVO | RecordVO;
 
-    console.log(this.sourceItem.folder_linkType)
     if (this.sourceItem.folder_linkType.includes('public')) {
       this.publicItem = this.sourceItem;
       this.publicLink = this.linkPipe.transform(this.publicItem);

--- a/src/app/file-browser/components/publish/publish.component.ts
+++ b/src/app/file-browser/components/publish/publish.component.ts
@@ -54,6 +54,7 @@ export class PublishComponent implements OnInit {
   ) {
     this.sourceItem = this.data.item as FolderVO | RecordVO;
 
+    console.log(this.sourceItem.folder_linkType)
     if (this.sourceItem.folder_linkType.includes('public')) {
       this.publicItem = this.sourceItem;
       this.publicLink = this.linkPipe.transform(this.publicItem);

--- a/src/app/shared/pipes/public-link.pipe.spec.ts
+++ b/src/app/shared/pipes/public-link.pipe.spec.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { FolderVO, RecordVO } from '@models';
 import { PublicLinkPipe } from './public-link.pipe';
 import { PublicRoutePipe } from './public-route.pipe';
@@ -16,7 +17,7 @@ describe('PublicLinkPipe', () => {
   it('returns correct link for folder', () => {
     const folder = new FolderVO({
       folder_linkId: 100,
-      archiveNbr: '0001-00gh'
+      archiveNbr: '0001-00gh',
     });
     const route = pipe.transform(folder);
     expect(route).toBeDefined();
@@ -32,10 +33,33 @@ describe('PublicLinkPipe', () => {
         }),
       ],
       folder_linkId: 1001,
-      archiveNbr: '0001-00gp'
+      archiveNbr: '0001-00gp',
     });
     const route = pipe.transform(record);
     expect(route).toBeDefined();
-    expect(route.endsWith('/p/archive/0001-0000/0001-meow/1234/record/0001-00gp')).toBeTruthy();
+    expect(
+      route.endsWith('/p/archive/0001-0000/0001-meow/1234/record/0001-00gp')
+    ).toBeTruthy();
+  });
+
+  it('adds only one slash in the url before p/archive', () => {
+    const folder = new FolderVO({
+      folder_linkId: 100,
+      archiveNbr: '0001-00gh',
+    });
+
+    const route = pipe.transform(folder);
+
+    const pArchiveIndex = route.indexOf('p/archive');
+
+    if (pArchiveIndex === -1) {
+      fail('URL format is unexpected');
+      return;
+    }
+
+    const substringBefore = route.substring(0, pArchiveIndex);
+
+    expect(substringBefore.endsWith('/')).toBe(true);
+    expect(substringBefore.endsWith('//')).toBe(false);
   });
 });

--- a/src/app/shared/pipes/public-link.pipe.spec.ts
+++ b/src/app/shared/pipes/public-link.pipe.spec.ts
@@ -56,10 +56,8 @@ describe('PublicLinkPipe', () => {
       fail('URL format is unexpected');
       return;
     }
-
-    const substringBefore = route.substring(0, pArchiveIndex);
-
-    expect(substringBefore.endsWith('/')).toBe(true);
-    expect(substringBefore.endsWith('//')).toBe(false);
+    
+    const url = new URL(pipe.transform(folder));
+    expect(url.pathname).not.toContain('//');
   });
 });

--- a/src/app/shared/pipes/public-link.pipe.spec.ts
+++ b/src/app/shared/pipes/public-link.pipe.spec.ts
@@ -48,15 +48,6 @@ describe('PublicLinkPipe', () => {
       archiveNbr: '0001-00gh',
     });
 
-    const route = pipe.transform(folder);
-
-    const pArchiveIndex = route.indexOf('p/archive');
-
-    if (pArchiveIndex === -1) {
-      fail('URL format is unexpected');
-      return;
-    }
-    
     const url = new URL(pipe.transform(folder));
     expect(url.pathname).not.toContain('//');
   });

--- a/src/app/shared/pipes/public-link.pipe.ts
+++ b/src/app/shared/pipes/public-link.pipe.ts
@@ -16,7 +16,9 @@ export class PublicLinkPipe implements PipeTransform {
 
   transform(value: RecordVO | FolderVO, args?: any): string {
     const route = this.routePipe.transform(value, args).join("/");
-    return `${baseUrl}/${route}`;
+    console.log(baseUrl)
+    console.log(route)
+    return `${baseUrl}${route}`;
   }
 
 }

--- a/src/app/shared/pipes/public-link.pipe.ts
+++ b/src/app/shared/pipes/public-link.pipe.ts
@@ -16,8 +16,6 @@ export class PublicLinkPipe implements PipeTransform {
 
   transform(value: RecordVO | FolderVO, args?: any): string {
     const route = this.routePipe.transform(value, args).join("/");
-    console.log(baseUrl)
-    console.log(route)
     return `${baseUrl}${route}`;
   }
 


### PR DESCRIPTION
Stepts to test: 

1.Select a record.
2. Click share
3. The generated url should have only one slash before p/archive