### PR TITLE
Fix usage of HttpClient in tests

### DIFF
--- a/src/app/file-browser/components/download-button/download-button.component.spec.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.spec.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { HttpClient, HttpHandler } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DataService } from '@shared/services/data/data.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -13,7 +13,8 @@ describe('DownloadButtonComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DownloadButtonComponent],
-      providers: [DataService, MessageService, HttpClient, HttpHandler],
+      imports: [HttpClientTestingModule],
+      providers: [DataService, MessageService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DownloadButtonComponent);

--- a/src/app/public/components/archive-search/archive-search.component.spec.ts
+++ b/src/app/public/components/archive-search/archive-search.component.spec.ts
@@ -1,4 +1,5 @@
-import { HttpClient, HttpHandler } from '@angular/common/http';
+/* @format */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -11,10 +12,10 @@ describe('ArchiveSearchComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ArchiveSearchComponent ],
-      providers:[FormBuilder,HttpClient,HttpHandler,Router]
-    })
-    .compileComponents();
+      declarations: [ArchiveSearchComponent],
+      imports: [HttpClientTestingModule],
+      providers: [FormBuilder, Router],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/src/app/shared/services/payer/payer.service.spec.ts
+++ b/src/app/shared/services/payer/payer.service.spec.ts
@@ -1,4 +1,5 @@
-import { HttpClient, HttpHandler } from '@angular/common/http';
+/* @format */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { AccountService } from '../account/account.service';
 import { PayerService } from './payer.service';
@@ -8,7 +9,8 @@ describe('PayerService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [HttpClient, AccountService, HttpHandler],
+      imports: [HttpClientTestingModule],
+      providers: [AccountService],
     });
     service = TestBed.inject(PayerService);
   });


### PR DESCRIPTION
The HttpClient shouldn't be imported in tests as this can cause some unexpected behavior. Angular provides the HttpClientTestingModule to import into unit tests which provide testing versions of HttpClient and HttpHandler which should be used instead. I believe that the improper usage of the testing module created some strange race conditions which caused tests to *sometimes* fail but eventually pass with enough retries.

It should be noted that Angular generated these usages of HttpClient to begin with as part of its `ng generate` boilerplate, with no import of the testing library! Thanks for the broken tests, Angular!