### PR TITLE
PER-9362 tags dissapearing for folders

### DIFF
--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -216,6 +216,7 @@ export interface FolderVOData extends BaseVOData {
   AccessVOs?: any;
   posStart?: any;
   posLimit?: any;
+  isFolder?: boolean;
 }
 
 export interface FolderSizeVOData {

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -197,4 +197,5 @@ export interface RecordVOData extends BaseVOData {
   RecordExifVO?: any;
   ShareVOs?: any;
   AccessVO?: any;
+  isFolder?:boolean;
 }

--- a/src/app/shared/services/data/data.service.spec.ts
+++ b/src/app/shared/services/data/data.service.spec.ts
@@ -1,6 +1,7 @@
+/* @format */
 import { TestBed, inject } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
-import { cloneDeep  } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { DataService } from '@shared/services/data/data.service';
 import { ApiService } from '@shared/services/api/api.service';
@@ -16,8 +17,13 @@ const navigateMinData = require('@root/test/responses/folder.navigateMin.success
 const getLeanItemsData = require('@root/test/responses/folder.getLeanItems.success.json');
 const getFullRecordsData = require('@root/test/responses/record.get.multiple.success.json');
 
-const testFolder = new FolderVO({folderId: 1, displayName: 'test folder'});
-const testRecord = new RecordVO({recordId: 1, displayName: 'test record', folder_linkId: 4, archiveNbr: 'archivenbr'});
+const testFolder = new FolderVO({ folderId: 1, displayName: 'test folder' });
+const testRecord = new RecordVO({
+  recordId: 1,
+  displayName: 'test record',
+  folder_linkId: 4,
+  archiveNbr: 'archivenbr',
+});
 
 describe('DataService', () => {
   beforeEach(() => {
@@ -33,113 +39,171 @@ describe('DataService', () => {
     expect(service).toBeTruthy();
   }));
 
-  it('should set the current folder', inject([DataService], (service: DataService) => {
-    service.setCurrentFolder(testFolder);
-    expect(service.currentFolder).toEqual(testFolder);
-  }));
-
-  it('should emit when the current folder is set', inject([DataService], (service: DataService) => {
-    service.setCurrentFolder(null);
-    expect(service.currentFolder).toBeNull();
-    const subscription = service.currentFolderChange.subscribe((newFolder: FolderVO) => {
-      expect(newFolder).toEqual(testFolder);
+  it('should set the current folder', inject(
+    [DataService],
+    (service: DataService) => {
+      service.setCurrentFolder(testFolder);
       expect(service.currentFolder).toEqual(testFolder);
-    });
-    service.setCurrentFolder(testFolder);
-  }));
+    }
+  ));
 
-  it('should register an item, return the item, and unregister the item', inject([DataService], (service: DataService) => {
-    service.setCurrentFolder(testFolder);
-    service.registerItem(testRecord);
-    expect(service.getItemByFolderLinkId(testRecord.folder_linkId)).toBe(testRecord);
-    service.unregisterItem(testRecord);
-    expect(service.getItemByFolderLinkId(testRecord.folder_linkId)).toBeUndefined();
-  }));
+  it('should emit when the current folder is set', inject(
+    [DataService],
+    (service: DataService) => {
+      service.setCurrentFolder(null);
+      expect(service.currentFolder).toBeNull();
+      const subscription = service.currentFolderChange.subscribe(
+        (newFolder: FolderVO) => {
+          expect(newFolder).toEqual(testFolder);
+          expect(service.currentFolder).toEqual(testFolder);
+        }
+      );
+      service.setCurrentFolder(testFolder);
+    }
+  ));
 
-  it('should fetch lean data for placeholder items', inject([DataService], (service: DataService) => {
-    const httpMock = TestBed.get(HttpTestingController);
-    const navigateResponse = new FolderResponse(navigateMinData);
-    const currentFolder = navigateResponse.getFolderVO(true);
-    service.setCurrentFolder(currentFolder);
+  it('should register an item, return the item, and unregister the item', inject(
+    [DataService],
+    (service: DataService) => {
+      service.setCurrentFolder(testFolder);
+      service.registerItem(testRecord);
+      expect(service.getItemByFolderLinkId(testRecord.folder_linkId)).toBe(
+        testRecord
+      );
+      service.unregisterItem(testRecord);
+      expect(
+        service.getItemByFolderLinkId(testRecord.folder_linkId)
+      ).toBeUndefined();
+    }
+  ));
 
-    currentFolder.ChildItemVOs.forEach((item: RecordVO | FolderVO) => {
-      service.registerItem(item);
-    });
+  it('should fetch lean data for placeholder items', inject(
+    [DataService],
+    (service: DataService) => {
+      const httpMock = TestBed.get(HttpTestingController);
+      const navigateResponse = new FolderResponse(navigateMinData);
+      const currentFolder = navigateResponse.getFolderVO(true);
+      service.setCurrentFolder(currentFolder);
 
-    service.fetchLeanItems(currentFolder.ChildItemVOs)
-      .then(() => {
+      currentFolder.ChildItemVOs.forEach((item: RecordVO | FolderVO) => {
+        service.registerItem(item);
+      });
+
+      service.fetchLeanItems(currentFolder.ChildItemVOs).then(() => {
         currentFolder.ChildItemVOs.map((item) => {
           expect(item.dataStatus).toEqual(DataStatus.Lean);
         });
       });
 
-    const req = httpMock.expectOne(`${environment.apiUrl}/folder/getLeanItems`);
-    req.flush(getLeanItemsData);
-  }));
+      const req = httpMock.expectOne(
+        `${environment.apiUrl}/folder/getLeanItems`
+      );
+      req.flush(getLeanItemsData);
+    }
+  ));
 
-  it('should handle an empty array when fetching lean data', inject([DataService], (service: DataService) => {
-    const navigateResponse = new FolderResponse(navigateMinData);
-    const currentFolder = navigateResponse.getFolderVO(true);
-    service.setCurrentFolder(currentFolder);
+  it('should handle an empty array when fetching lean data', inject(
+    [DataService],
+    (service: DataService) => {
+      const navigateResponse = new FolderResponse(navigateMinData);
+      const currentFolder = navigateResponse.getFolderVO(true);
+      service.setCurrentFolder(currentFolder);
 
-    service.fetchLeanItems([])
-      .then((count) => {
-        expect(count).toBe(0);
-      })
-      .catch(() => {
-        fail();
+      service
+        .fetchLeanItems([])
+        .then((count) => {
+          expect(count).toBe(0);
+        })
+        .catch(() => {
+          fail();
+        });
+    }
+  ));
+
+  it('should fetch full data for placeholder items', inject(
+    [DataService],
+    (service: DataService) => {
+      const httpMock = TestBed.get(HttpTestingController);
+      const navigateResponse = new FolderResponse(navigateMinData);
+      const currentFolder = navigateResponse.getFolderVO(true);
+      service.setCurrentFolder(currentFolder);
+
+      currentFolder.ChildItemVOs.forEach((item: RecordVO | FolderVO) => {
+        service.registerItem(item);
       });
-  }));
 
-  it('should fetch full data for placeholder items', inject([DataService], (service: DataService) => {
-    const httpMock = TestBed.get(HttpTestingController);
-    const navigateResponse = new FolderResponse(navigateMinData);
-    const currentFolder = navigateResponse.getFolderVO(true);
-    service.setCurrentFolder(currentFolder);
+      const records = currentFolder.ChildItemVOs.filter(
+        (item) => item.isRecord
+      );
 
-    currentFolder.ChildItemVOs.forEach((item: RecordVO | FolderVO) => {
-      service.registerItem(item);
-    });
-
-    const records = currentFolder.ChildItemVOs.filter((item) => item.isRecord);
-
-    service.fetchFullItems(records)
-      .then(() => {
+      service.fetchFullItems(records).then(() => {
         records.map((item) => {
           expect(item.dataStatus).toEqual(DataStatus.Full);
         });
       });
 
-    const req = httpMock.expectOne(`${environment.apiUrl}/record/get`);
-    req.flush(getFullRecordsData);
-  }));
+      const req = httpMock.expectOne(`${environment.apiUrl}/record/get`);
+      req.flush(getFullRecordsData);
+    }
+  ));
 
-  it('should handle an empty array when fetching full data', inject([DataService], (service: DataService) => {
-    const navigateResponse = new FolderResponse(navigateMinData);
-    const currentFolder = navigateResponse.getFolderVO(true);
-    service.setCurrentFolder(currentFolder);
+  it('should handle an empty array when fetching full data', inject(
+    [DataService],
+    (service: DataService) => {
+      const navigateResponse = new FolderResponse(navigateMinData);
+      const currentFolder = navigateResponse.getFolderVO(true);
+      service.setCurrentFolder(currentFolder);
 
-    service.fetchFullItems([])
-      .catch(() => {
+      service.fetchFullItems([]).catch(() => {
         fail();
       });
-  }));
+    }
+  ));
 
-  it('should refresh the current folder with latest data', inject([DataService], (service: DataService) => {
-    const httpMock = TestBed.get(HttpTestingController);
-    const navigateResponse = new FolderResponse(navigateMinData);
-    const currentFolder = navigateResponse.getFolderVO(true) as FolderVO;
-    const childItemCount = currentFolder.ChildItemVOs.length;
+  it('should refresh the current folder with latest data', inject(
+    [DataService],
+    (service: DataService) => {
+      const httpMock = TestBed.get(HttpTestingController);
+      const navigateResponse = new FolderResponse(navigateMinData);
+      const currentFolder = navigateResponse.getFolderVO(true) as FolderVO;
+      const childItemCount = currentFolder.ChildItemVOs.length;
 
-    currentFolder.ChildItemVOs = [];
-    service.setCurrentFolder(currentFolder);
+      currentFolder.ChildItemVOs = [];
+      service.setCurrentFolder(currentFolder);
 
-    service.refreshCurrentFolder()
-      .then(() => {
+      service.refreshCurrentFolder().then(() => {
         expect(currentFolder.ChildItemVOs.length).toBe(childItemCount);
       });
 
-    const req = httpMock.expectOne(`${environment.apiUrl}/folder/navigateMin`);
-    req.flush(navigateMinData);
-  }));
+      const req = httpMock.expectOne(
+        `${environment.apiUrl}/folder/navigateMin`
+      );
+      req.flush(navigateMinData);
+    }
+  ));
+
+  it('should add items to thumbRefreshQueue that meet the criteria', inject(
+    [DataService],
+    (service: DataService) => {
+      const httpMock = TestBed.get(HttpTestingController);
+      const navigateResponse = new FolderResponse(navigateMinData);
+      const currentFolder = navigateResponse.getFolderVO(true);
+      service.setCurrentFolder(currentFolder);
+
+      currentFolder.ChildItemVOs.forEach((item: RecordVO | FolderVO) => {
+        service.registerItem(item);
+      });
+
+      service.fetchLeanItems(currentFolder.ChildItemVOs).then(() => {
+        currentFolder.ChildItemVOs.map((item) => {
+          expect(service.getThumbRefreshQueue()).not.toContain(item);
+        });
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.apiUrl}/folder/getLeanItems`
+      );
+      req.flush(getLeanItemsData);
+    }
+  ));
 });

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -694,5 +694,5 @@ export class DataService {
 
   public getThumbRefreshQueue(): Array<ItemVO> {
     return this.thumbRefreshQueue;
-  }  
+  }
 }

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -691,4 +691,8 @@ export class DataService {
   public beginPreparingForNavigate() {
     this.eventSubject.next(true);
   }
+
+  public getThumbRefreshQueue(): Array<ItemVO> {
+    return this.thumbRefreshQueue;
+  }  
 }

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -227,6 +227,7 @@ export class DataService {
             item.fetched = null;
 
             if (
+              !item.isFolder &&
               !item.thumbURL200 &&
               item.parentFolderId === this.currentFolder.folderId
             ) {


### PR DESCRIPTION
Added an additional check so fetchLeanItems does not get called each time preventing empty folders to be fetched.

@meisekimiu considering that records are being fetched if they do not have the thumbURL yet, shouldn't there be a condition for folders too? I will write tests for this but I just want to get the answer to this question so i can test that scenario.