### PR TITLE
PER-9339: Add human readable transaction types

### DIFF
--- a/constants/master_en.json
+++ b/constants/master_en.json
@@ -608,7 +608,9 @@
         "invite_accepted_from": "Sent invitation accepted",
         "invite_accepted_to": "Invitation accepted",
         "promo_code": "Gift code entered",
-        "system_to_account": "Gift from system to account"
+        "system_to_account": "Gift from system to account",
+        "purchase": "Gift purchase",
+        "received": "Gift received"
       }
     },
     "board_member": {

--- a/src/app/core/components/transaction-history/transaction-history.component.ts
+++ b/src/app/core/components/transaction-history/transaction-history.component.ts
@@ -42,7 +42,7 @@ export class TransactionHistoryComponent implements OnInit {
       this.ledgerItemCount = ledgerItems.length;
       this.ledgerItemPages = chunk(ledgerItems, this.pageSize);
     } catch (err) {
-      this.message.showError('There was a problem loading your file history.');
+      this.message.showError('There was a problem loading your transaction history.');
       this.error = true;
       throw err;
     } finally {


### PR DESCRIPTION
With two new backend purchase types, we need corresponding human-readable names to appear in the transaction history. Also fix a (presumed) copy-paste error and fix the error message that appears if the transaction history doesn't load.

Needed for the changes in https://github.com/PermanentOrg/back-end/pull/514.