### PR TITLE
Per 9373 enter multiple emails gifting screen

### DIFF
--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.html
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.html
@@ -14,7 +14,9 @@
       Once you send gift storage to someone else, it can’t be reclaimed.
     </p>
     <div class="buttons">
-      <button class="btn btn-sm btn-secondary" (click)="onDoneClick()">Cancel</button>
+      <button class="btn btn-sm btn-secondary" (click)="onDoneClick()">
+        Cancel
+      </button>
 
       <button class="btn btn-sm btn-primary" (click)="onConfirmClick()">
         Yes, gift storage

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.html
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.html
@@ -8,17 +8,17 @@
   </div>
   <div class="content">
     <p class="popup-text">
-      <b
-        >Are you sure you would like to gift {{ amount }} GB of storage to
-        {{ email }}?</b
-      >
+      <b> Are you sure you’d like to gift storage?</b>
     </p>
     <p class="popup-text">
-      Once confirmed, the gift storage cannot be reclaimed.
-      <button class="btn btn-sm btn-primary" (click)="onConfirmClick()">
-        Confirm
-      </button>
-      <button class="btn btn-sm" (click)="onDoneClick()">Go back</button>
+      Once you send gift storage to someone else, it can’t be reclaimed.
     </p>
+    <div class="buttons">
+      <button class="btn btn-sm btn-secondary" (click)="onDoneClick()">Cancel</button>
+
+      <button class="btn btn-sm btn-primary" (click)="onConfirmClick()">
+        Yes, gift storage
+      </button>
+    </div>
   </div>
 </div>

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.scss
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.scss
@@ -1,3 +1,4 @@
+/* @format */
 @import 'variables';
 
 :host {
@@ -54,9 +55,16 @@ pr-archive-small {
     border-radius: 4px;
     margin: 0 10px;
     width: 15%;
+
+    @include beforeDesktop{
+      width: 20%;
+    }
   }
 
   & .btn-primary {
     width: 30%;
+    @include beforeDesktop{
+      width: 35%;
+    }
   }
 }

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.scss
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.scss
@@ -11,7 +11,7 @@
 
 .content {
   @include tabbedDialogContent;
-  flex-direction: column
+  flex-direction: column;
 }
 
 .tabs {
@@ -43,4 +43,20 @@ pr-archive-small {
 .popup-text {
   text-align: center;
   padding: 20px;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  & .btn {
+    padding: 10px;
+    border-radius: 4px;
+    margin: 0 10px;
+    width: 15%;
+  }
+
+  & .btn-primary {
+    width: 30%;
+  }
 }

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.scss
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.scss
@@ -56,14 +56,14 @@ pr-archive-small {
     margin: 0 10px;
     width: 15%;
 
-    @include beforeDesktop{
+    @include beforeDesktop {
       width: 20%;
     }
   }
 
   & .btn-primary {
     width: 30%;
-    @include beforeDesktop{
+    @include beforeDesktop {
       width: 35%;
     }
   }

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
@@ -12,6 +12,7 @@ import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep } from 'lodash';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { ApiService } from '@shared/services/api/api.service';
+import { GiftingResponse } from '@shared/services/api/billing.repo';
 import { MessageService } from '@shared/services/message/message.service';
 import { ConfirmGiftDialogComponent } from './confirm-gift-dialog.component';
 
@@ -46,7 +47,10 @@ describe('ConfirmGiftDialogComponent', () => {
     },
   };
 
-  const mockGiftResult = new BehaviorSubject<boolean>(false);
+  const mockGiftResult = new BehaviorSubject<{
+    isSuccessful: boolean;
+    response: GiftingResponse;
+  }>({ isSuccessful: false, response: null });
 
   beforeEach(async () => {
     const config: TestModuleMetadata = cloneDeep(Testing.BASE_TEST_CONFIG);
@@ -122,14 +126,27 @@ describe('ConfirmGiftDialogComponent', () => {
   it('should close the dialog and send the data back when confirm method is called', fakeAsync(() => {
     const dialogRefSpy = spyOn(dialogRef, 'close');
     const giftResultSpy = spyOn(mockGiftResult, 'next');
-    mockApiService.billing.giftStorage.and.returnValue(Promise.resolve());
+    const giftingResponse = new GiftingResponse({
+      storageGifted: 10,
+      alreadyInvited: [],
+      invitationSent: [],
+      giftDelivered: [],
+    });
+
+    const response = mockApiService.billing.giftStorage.and.returnValue(
+      Promise.resolve(giftingResponse)
+    );
 
     component.onConfirmClick();
 
     tick();
 
     expect(dialogRefSpy).toHaveBeenCalled();
-    expect(giftResultSpy).toHaveBeenCalledWith(true);
+
+    expect(giftResultSpy).toHaveBeenCalledWith({
+      isSuccessful: true,
+      response: giftingResponse,
+    });
   }));
 
   it('should handle failure in onConfirmClick', fakeAsync(() => {
@@ -149,7 +166,10 @@ describe('ConfirmGiftDialogComponent', () => {
     expect(showErrorSpy).toHaveBeenCalledWith(
       'Something went wrong! Please try again.'
     );
-    expect(giftResultSpy).toHaveBeenCalledWith(false);
+    expect(giftResultSpy).toHaveBeenCalledWith({
+      isSuccessful: false,
+      response: null,
+    });
 
     expect(dialogRefSpy).toHaveBeenCalled();
   }));

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
@@ -65,7 +65,7 @@ describe('ConfirmGiftDialogComponent', () => {
     config.providers.push({
       provide: DIALOG_DATA,
       useValue: {
-        email: 'test@example.com',
+        emails: ['test@example.com', 'test2@example.com'],
         amount: 10,
         message: 'test message',
         giftResult: mockGiftResult,
@@ -100,7 +100,7 @@ describe('ConfirmGiftDialogComponent', () => {
   });
 
   it('should take the email from the dialog data', () => {
-    expect(component.emails).toEqual('test@example.com');
+    expect(component.emails).toEqual(['test@example.com', 'test2@example.com']);
   });
 
   it('should take the amount from the dialog data', () => {

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
@@ -100,7 +100,7 @@ describe('ConfirmGiftDialogComponent', () => {
   });
 
   it('should take the email from the dialog data', () => {
-    expect(component.email).toEqual('test@example.com');
+    expect(component.emails).toEqual('test@example.com');
   });
 
   it('should take the amount from the dialog data', () => {

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
@@ -34,9 +34,15 @@ export class ConfirmGiftDialogComponent {
 
   public async onConfirmClick() {
     try {
-      await this.api.billing.giftStorage(this.emails, Number(this.amount));
+      const res = await this.api.billing.giftStorage(
+        this.emails,
+        Number(this.amount),
+        this.message
+      );
+      console.log(res)
       this.giftResult.next(true);
     } catch (e) {
+      console.log(e)
       this.msg.showError('Something went wrong! Please try again.');
       this.giftResult.next(false);
     }

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
@@ -11,7 +11,7 @@ import { BehaviorSubject } from 'rxjs';
   styleUrls: ['./confirm-gift-dialog.component.scss'],
 })
 export class ConfirmGiftDialogComponent {
-  email: string;
+  emails: string[];
   amount: number;
   message: string;
   giftResult: BehaviorSubject<boolean>;
@@ -22,8 +22,8 @@ export class ConfirmGiftDialogComponent {
     @Inject(DIALOG_DATA) public data: any,
     private msg: MessageService
   ) {
-    this.email = this.data.email;
-    this.amount = this.data.amount;
+    this.emails = this.data.emails;
+    this.amount = this.data.fullAmount;
     this.message = this.data.message;
     this.giftResult = this.data.giftResult;
   }
@@ -34,7 +34,7 @@ export class ConfirmGiftDialogComponent {
 
   public async onConfirmClick() {
     try {
-      await this.api.billing.giftStorage(this.email, Number(this.amount));
+      await this.api.billing.giftStorage(this.emails, Number(this.amount));
       this.giftResult.next(true);
     } catch (e) {
       this.msg.showError('Something went wrong! Please try again.');

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
@@ -23,7 +23,7 @@ export class ConfirmGiftDialogComponent {
     private msg: MessageService
   ) {
     this.emails = this.data.emails;
-    this.amount = this.data.fullAmount;
+    this.amount = this.data.amount;
     this.message = this.data.message;
     this.giftResult = this.data.giftResult;
   }

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
@@ -43,14 +43,12 @@ export class ConfirmGiftDialogComponent {
         Number(this.amount),
         this.message
       );
-      console.log(res);
       const response = {
         isSuccessful: true,
         response: res,
       };
       this.giftResult.next(response);
     } catch (e) {
-      console.log(e);
       this.msg.showError('Something went wrong! Please try again.');
       this.giftResult.next({ isSuccessful: false, response: null });
     }

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.ts
@@ -4,6 +4,7 @@ import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
 import { BehaviorSubject } from 'rxjs';
+import { GiftingResponse } from '@shared/services/api/billing.repo';
 
 @Component({
   selector: 'pr-confirm-gift-dialog',
@@ -14,7 +15,10 @@ export class ConfirmGiftDialogComponent {
   emails: string[];
   amount: number;
   message: string;
-  giftResult: BehaviorSubject<boolean>;
+  giftResult: BehaviorSubject<{
+    isSuccessful: boolean;
+    response: GiftingResponse | null;
+  }>;
 
   constructor(
     private dialogRef: DialogRef,
@@ -39,12 +43,16 @@ export class ConfirmGiftDialogComponent {
         Number(this.amount),
         this.message
       );
-      console.log(res)
-      this.giftResult.next(true);
+      console.log(res);
+      const response = {
+        isSuccessful: true,
+        response: res,
+      };
+      this.giftResult.next(response);
     } catch (e) {
-      console.log(e)
+      console.log(e);
       this.msg.showError('Something went wrong! Please try again.');
-      this.giftResult.next(false);
+      this.giftResult.next({ isSuccessful: false, response: null });
     }
     this.dialogRef?.close();
   }

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -29,9 +29,12 @@
           placeholder="email@email.com"
         />
       </div>
-      <p class="input-error" *ngIf="giftForm.get('email').errors?.email">
-        The email you have entered is not valid.
-      </p>
+      <div *ngFor="let invalidEmail of emailValidationErrors">
+        <img src="assets/svg/alert.svg" />
+        <span class="input-error"
+          >{{ invalidEmail }} is not a valid email address.</span
+        >
+      </div>
       <div class="dialog-form-field dialog-form-field-amount">
         <div class="text">
           <label class="label" for="amount">Storage Gift Amount</label>
@@ -56,10 +59,19 @@
       <p class="input-error" *ngIf="giftForm.get('amount').errors?.max">
         Amount must be less than or equal to {{ availableSpace }} GB.
       </p>
+      <p *ngIf="giftForm.get('amount').errors?.positiveValidation" class="success-message">
+        {{ giftForm.get('amount').errors?.successMessage }}
+      </p>
+      <div *ngIf="giftForm.get('amount').errors?.isGreaterThanAvailableSpace">
+        <img src="assets/svg/alert.svg" />
+        <span class="input-error">{{ getAmountErrorMessage() }}</span>
+      </div>
       <div class="dialog-form-field">
         <div class="text">
           <label class="label" for="amount">Note to recipient</label>
-          <span class="label-info optional">Optional; sent to all recipients</span>
+          <span class="label-info optional"
+            >Optional; sent to all recipients</span
+          >
         </div>
         <textarea
           class="form-control form-control-textarea"

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -68,12 +68,15 @@
       </div>
       <div
         *ngIf="giftForm.get('amount').errors?.notInteger"
-        class="error-message"
+        class="error-message not-integer"
       >
         <img src="assets/svg/alert.svg" />
         <p class="input-error">Storage can only be gifted in 1GB increments.</p>
       </div>
-      <p *ngIf="successMessage" class="error-message success-message">
+      <p
+        *ngIf="successMessage && !giftForm.get('amount').errors?.notInteger"
+        class="error-message success-message"
+      >
         {{ successMessage }}
       </p>
       <div

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -135,8 +135,10 @@
       </defs>
     </svg>
 
-    <p class="panel-title">Storage successfully gifted</p>
-    <p>
+    <p *ngIf="emailsSentTo.length" class="panel-title">
+      Storage successfully gifted
+    </p>
+    <p *ngIf="emailsSentTo.length">
       Success! You sent {{ giftForm.value.amount }} GB of Permanent storage to:
     </p>
     <ul>

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -140,7 +140,15 @@
       Success! You sent {{ giftForm.value.amount }} GB of Permanent storage to:
     </p>
     <ul>
-      <li class="email" *ngFor="let email of emails">
+      <li class="email" *ngFor="let email of emailsSentTo">
+        {{ email }}
+      </li>
+    </ul>
+    <p *ngIf="alreadyInvited.length">
+      The following emails were already invited
+    </p>
+    <ul>
+      <li class="email" *ngFor="let email of alreadyInvited">
         {{ email }}
       </li>
     </ul>

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -147,7 +147,9 @@
       </li>
     </ul>
     <p *ngIf="alreadyInvited.length">
-      The following emails were already invited
+      The following emails have already been invited and were not sent storage.
+      They must accept their invitation before they can be sent additional
+      storage.
     </p>
     <ul>
       <li class="email" *ngFor="let email of alreadyInvited">

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -13,7 +13,13 @@
       class="dialog-form"
       (submit)="submitStorageGiftForm(giftForm.value)"
     >
-      <div class="dialog-form-field">
+      <div
+        class="dialog-form-field dialog-form-field-emails"
+        [ngClass]="{
+          'dialog-form-field-with-error':
+            duplicateEmails.length || emailValidationErrors.length
+        }"
+      >
         <div class="text">
           <label class="label" for="email">Recipient Email(s)</label>
           <span class="label-info"
@@ -38,7 +44,11 @@
           >{{ invalidEmail }} is not a valid email address.</span
         >
       </div>
-      <div class="dialog-form-field dialog-form-field-amount">
+      <div class="error-message" *ngFor="let duplicate of duplicateEmails">
+        <img src="assets/svg/alert.svg" />
+        <span class="input-error">{{ duplicate }} has already been added.</span>
+      </div>
+      <div class="dialog-form-field dialog-form-field-amount" [ngClass]="">
         <div class="text">
           <label class="label" for="amount">Storage Gift Amount</label>
           <span class="label-info">{{ this.availableSpace }} GB available</span>
@@ -124,9 +134,13 @@
 
     <p class="panel-title">Storage successfully gifted</p>
     <p>
-      Success! You sent {{ giftForm.value.amount }} GB of Permanent storage to
-      {{ giftForm.value.email }}.
+      Success! You sent {{ giftForm.value.amount }} GB of Permanent storage to:
     </p>
+    <ul>
+      <li class="email" *ngFor="let email of emails">
+        {{ email }}
+      </li>
+    </ul>
     <p>
       You have
       {{ (+availableSpace).toFixed(2) }} GB of storage available.

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -29,7 +29,10 @@
           placeholder="email@email.com"
         />
       </div>
-      <div *ngFor="let invalidEmail of emailValidationErrors">
+      <div
+        class="error-message"
+        *ngFor="let invalidEmail of emailValidationErrors"
+      >
         <img src="assets/svg/alert.svg" />
         <span class="input-error"
           >{{ invalidEmail }} is not a valid email address.</span
@@ -53,16 +56,20 @@
         />
         <span class="gigabytes">gigabytes per recipient</span>
       </div>
-      <p class="input-error" *ngIf="giftForm.get('amount').errors?.notInteger">
-        Storage can only be gifted in 1GB increments.
+      <div
+        *ngIf="giftForm.get('amount').errors?.notInteger"
+        class="error-message"
+      >
+        <img src="assets/svg/alert.svg" />
+        <p class="input-error">Storage can only be gifted in 1GB increments.</p>
+      </div>
+      <p *ngIf="successMessage" class="error-message success-message">
+        {{ successMessage }}
       </p>
-      <p class="input-error" *ngIf="giftForm.get('amount').errors?.max">
-        Amount must be less than or equal to {{ availableSpace }} GB.
-      </p>
-      <p *ngIf="giftForm.get('amount').errors?.positiveValidation" class="success-message">
-        {{ giftForm.get('amount').errors?.successMessage }}
-      </p>
-      <div *ngIf="giftForm.get('amount').errors?.isGreaterThanAvailableSpace">
+      <div
+        class="error-message"
+        *ngIf="giftForm.get('amount').errors?.isGreaterThanAvailableSpace"
+      >
         <img src="assets/svg/alert.svg" />
         <span class="input-error">{{ getAmountErrorMessage() }}</span>
       </div>

--- a/src/app/core/components/gift-storage/gift-storage.component.html
+++ b/src/app/core/components/gift-storage/gift-storage.component.html
@@ -15,7 +15,10 @@
     >
       <div class="dialog-form-field">
         <div class="text">
-          <label class="label" for="email">Recipient Email</label>
+          <label class="label" for="email">Recipient Email(s)</label>
+          <span class="label-info"
+            >Separate multiple email addresses with commas</span
+          >
         </div>
         <input
           type="text"
@@ -45,7 +48,7 @@
             'form-control-error': giftForm.get('amount').errors?.notInteger
           }"
         />
-        <span class="gigabytes">gigabytes</span>
+        <span class="gigabytes">gigabytes per recipient</span>
       </div>
       <p class="input-error" *ngIf="giftForm.get('amount').errors?.notInteger">
         Storage can only be gifted in 1GB increments.
@@ -56,7 +59,7 @@
       <div class="dialog-form-field">
         <div class="text">
           <label class="label" for="amount">Note to recipient</label>
-          <span class="label-info">Optional</span>
+          <span class="label-info optional">Optional; sent to all recipients</span>
         </div>
         <textarea
           class="form-control form-control-textarea"

--- a/src/app/core/components/gift-storage/gift-storage.component.scss
+++ b/src/app/core/components/gift-storage/gift-storage.component.scss
@@ -100,4 +100,5 @@
 .input-error {
   margin-bottom: 1rem;
   color: $red;
+  font-style: italic;
 }

--- a/src/app/core/components/gift-storage/gift-storage.component.scss
+++ b/src/app/core/components/gift-storage/gift-storage.component.scss
@@ -128,3 +128,10 @@
 .success-message {
   font-style: italic;
 }
+
+.not-integer {
+  display: flex;
+  & > p {
+    margin-bottom: 0px;
+  }
+}

--- a/src/app/core/components/gift-storage/gift-storage.component.scss
+++ b/src/app/core/components/gift-storage/gift-storage.component.scss
@@ -102,3 +102,11 @@
   color: $red;
   font-style: italic;
 }
+.error-message {
+  margin-left: 200px;
+  margin-bottom: 20px;
+}
+
+.success-message {
+  font-style: italic;
+}

--- a/src/app/core/components/gift-storage/gift-storage.component.scss
+++ b/src/app/core/components/gift-storage/gift-storage.component.scss
@@ -12,6 +12,10 @@
   display: flex;
   margin-bottom: 23px;
 
+  &-amount > input {
+    width: 300px !important;
+  }
+
   @include beforeDesktop {
     flex-direction: column;
 
@@ -40,17 +44,22 @@
     line-height: 17px;
   }
 
+  & .optional {
+    width: 100px;
+  }
+
   & .gigabytes {
     display: inline-flex;
     align-items: center;
 
     font-family: 'Open Sans';
-    font-style: normal;
+    font-style: italic;
     font-weight: 400;
     font-size: 16px;
     line-height: 17px;
     color: $gray-dark;
     margin-left: 10px;
+    width: 100px;
 
     @include beforeDesktop {
       margin-left: 0;

--- a/src/app/core/components/gift-storage/gift-storage.component.scss
+++ b/src/app/core/components/gift-storage/gift-storage.component.scss
@@ -12,8 +12,12 @@
   display: flex;
   margin-bottom: 23px;
 
-  &-amount > input {
-    width: 300px !important;
+  &-with-error {
+    margin-bottom: 0px;
+
+    @include beforeDesktop {
+      margin-bottom: 10px;
+    }
   }
 
   @include beforeDesktop {
@@ -74,6 +78,16 @@
     height: 42px;
   }
 
+  &-emails > .form-control {
+    @include beforeDesktop {
+      width: 350px;
+    }
+  }
+
+  &-amount > .form-control {
+    width: 300px;
+  }
+
   & > .form-control-textarea {
     height: 150px;
     resize: none;
@@ -105,6 +119,10 @@
 .error-message {
   margin-left: 200px;
   margin-bottom: 20px;
+
+  @include beforeDesktop {
+    margin-left: 0px;
+  }
 }
 
 .success-message {

--- a/src/app/core/components/gift-storage/gift-storage.component.spec.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.spec.ts
@@ -1,3 +1,4 @@
+import { async } from '@angular/core/testing';
 /* @format */
 import { Shallow } from 'shallow-render';
 import { HttpClient, HttpHandler } from '@angular/common/http';
@@ -50,12 +51,30 @@ describe('GiftStorageComponent', () => {
     expect(button.disabled).toBe(false);
   });
 
-  it('disables the submit button if the email is not valid', async () => {
+  it('disables the submit button if at least one email is not valid', async () => {
     const { find, instance, fixture } = await shallow.render();
 
     instance.availableSpace = '5';
 
-    instance.giftForm.controls.email.setValue('test');
+    instance.giftForm.controls.email.setValue('test@example.com, test');
+    instance.giftForm.controls.amount.setValue('1');
+
+    instance.giftForm.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = find('.btn-primary').nativeElement;
+
+    expect(button.disabled).toBe(true);
+  });
+
+  it('disables the submit button if the there is a duplicate email', async () => {
+    const { find, instance, fixture } = await shallow.render();
+
+    instance.availableSpace = '5';
+
+    instance.giftForm.controls.email.setValue(
+      'test@example.com, test@example.com'
+    );
     instance.giftForm.controls.amount.setValue('1');
 
     instance.giftForm.updateValueAndValidity();
@@ -73,6 +92,44 @@ describe('GiftStorageComponent', () => {
 
     await instance.giftForm.controls.email.setValue('test@example.com');
     instance.giftForm.controls.amount.setValue('10');
+
+    instance.giftForm.updateValueAndValidity();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const button: HTMLButtonElement = find('.btn-primary').nativeElement;
+
+    expect(button.disabled).toBe(true);
+  });
+
+  it('displays the total amount gifted based on the number of emails', async () => {
+    const { instance, fixture } = await shallow.render();
+
+    instance.availableSpace = '5';
+
+    await instance.giftForm.controls.email.setValue(
+      'test@example.com,test1@example.com'
+    );
+    instance.giftForm.controls.amount.setValue('2');
+
+    instance.giftForm.updateValueAndValidity();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(instance.successMessage).toEqual('Total gifted storage: 4 GB');
+  });
+
+  it('disables the submit button if the amount multiplied by the number of emails exceeds the available amount', async () => {
+    const { find, instance, fixture } = await shallow.render();
+
+    instance.availableSpace = '5';
+
+    await instance.giftForm.controls.email.setValue(
+      'test@example.com,test1@example.com'
+    );
+    instance.giftForm.controls.amount.setValue('4');
 
     instance.giftForm.updateValueAndValidity();
 
@@ -113,5 +170,29 @@ describe('GiftStorageComponent', () => {
 
     expect(mockAccountService.setAccount).toHaveBeenCalled();
     expect(instance.availableSpace).toBe('50.00');
+  });
+  it('parses the email string correctly', async () => {
+    const { instance } = await shallow.render();
+
+    const result = instance.parseEmailString(
+      'test@example.com, test1@example.com'
+    );
+
+    expect(result).toEqual(['test@example.com', 'test1@example.com']);
+  });
+
+  it('returns all the duplicate emails', async (done) => {
+    const { instance } = await shallow.render();
+
+    const testEmailString =
+      'test@example.com,test@example.com,test2@example.com';
+    const expectedDuplicates = ['test@example.com'];
+
+    instance
+      .checkForDuplicateEmails(testEmailString)
+      .subscribe((duplicates) => {
+        expect(duplicates).toEqual(expectedDuplicates);
+        done();
+      });
   });
 });

--- a/src/app/core/components/gift-storage/gift-storage.component.spec.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.spec.ts
@@ -1,4 +1,3 @@
-import { async } from '@angular/core/testing';
 /* @format */
 import { Shallow } from 'shallow-render';
 import { HttpClient, HttpHandler } from '@angular/common/http';

--- a/src/app/core/components/gift-storage/gift-storage.component.spec.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.spec.ts
@@ -6,6 +6,7 @@ import { Dialog } from '@root/app/dialog/dialog.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { AccountVO } from '../../../models/account-vo';
 import { GiftStorageComponent } from './gift-storage.component';
+import { GiftingResponse } from '@shared/services/api/billing.repo';
 
 describe('GiftStorageComponent', () => {
   let shallow: Shallow<GiftStorageComponent>;
@@ -165,7 +166,10 @@ describe('GiftStorageComponent', () => {
     instance.giftForm.controls.email.setValue('test@example.com');
     instance.giftForm.controls.amount.setValue('50');
 
-    instance.giftResult.next(true);
+    instance.giftResult.next({
+      isSuccessful: true,
+      response: new GiftingResponse({}),
+    });
 
     expect(mockAccountService.setAccount).toHaveBeenCalled();
     expect(instance.availableSpace).toBe('50.00');

--- a/src/app/core/components/gift-storage/gift-storage.component.spec.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.spec.ts
@@ -4,9 +4,9 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import { CoreModule } from '@core/core.module';
 import { Dialog } from '@root/app/dialog/dialog.service';
 import { AccountService } from '@shared/services/account/account.service';
+import { GiftingResponse } from '@shared/services/api/billing.repo';
 import { AccountVO } from '../../../models/account-vo';
 import { GiftStorageComponent } from './gift-storage.component';
-import { GiftingResponse } from '@shared/services/api/billing.repo';
 
 describe('GiftStorageComponent', () => {
   let shallow: Shallow<GiftStorageComponent>;

--- a/src/app/core/components/gift-storage/gift-storage.component.spec.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.spec.ts
@@ -168,7 +168,12 @@ describe('GiftStorageComponent', () => {
 
     instance.giftResult.next({
       isSuccessful: true,
-      response: new GiftingResponse({}),
+      response: new GiftingResponse({
+        storageGifted: 50,
+        giftDelivered: [],
+        invitationSent: [],
+        alreadyInvited: [],
+      }),
     });
 
     expect(mockAccountService.setAccount).toHaveBeenCalled();
@@ -197,5 +202,25 @@ describe('GiftStorageComponent', () => {
         expect(duplicates).toEqual(expectedDuplicates);
         done();
       });
+  });
+
+  it('filters out the duplicates from the giftDelivered and invitationSent of the response', async () => {
+    const { instance } = await shallow.render();
+
+    await instance.giftResult.next({
+      isSuccessful: true,
+      response: new GiftingResponse({
+        storageGifted: 50,
+        giftDelivered: ['test@example.com', 'test1@example.com'],
+        invitationSent: ['test@example.com', 'test2@example.com'],
+        alreadyInvited: [],
+      }),
+    });
+
+    expect(instance.emailsSentTo).toEqual([
+      'test@example.com',
+      'test2@example.com',
+      'test1@example.com',
+    ]);
   });
 });

--- a/src/app/core/components/gift-storage/gift-storage.component.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.ts
@@ -271,7 +271,10 @@ export class GiftStorageComponent implements OnDestroy {
 
     Object.keys(emailCount).forEach((key) => {
       if (emailCount[key] > 1) {
-        duplicates.push(key);
+        const mailControl = new FormControl(key, Validators.email);
+        if (mailControl.valid) {
+          duplicates.push(key);
+        }
       }
     });
 

--- a/src/app/core/components/gift-storage/gift-storage.component.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.ts
@@ -89,22 +89,20 @@ export class GiftStorageComponent implements OnDestroy {
           this.emailsSentTo = [
             ...new Set([
               ...response.response.invitationSent,
-              ...response.response.invitationSent,
+              ...response.response.giftDelivered,
             ]),
           ];
           this.alreadyInvited = response.response.alreadyInvited;
           const giftedAmount = response.response.storageGifted;
           const remainingSpaceAfterGift =
-            Number(this.availableSpace) -
-            this.emailsSentTo.length * giftedAmount;
-          this.availableSpace = String(remainingSpaceAfterGift);
+            Number(this.availableSpace) - giftedAmount;
+          this.availableSpace = String(remainingSpaceAfterGift.toFixed(2));
 
           const remainingSpaceInBytes =
             remainingSpaceAfterGift * this.bytesPerGigabyte;
 
           const totalSpace =
-            this.account.spaceTotal -
-            giftedAmount * this.emailsSentTo.length * this.bytesPerGigabyte;
+            this.account.spaceTotal - giftedAmount * this.bytesPerGigabyte;
 
           const newAccount = new AccountVO({
             ...this.account,

--- a/src/app/core/components/gift-storage/gift-storage.component.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.ts
@@ -113,8 +113,8 @@ export class GiftStorageComponent implements OnDestroy {
           this.accountService.setAccount(newAccount);
           this.isSuccessful = response.isSuccessful;
         }
-      })
-    ),
+      }),
+
       this.giftForm.get('email')?.valueChanges.subscribe((value) => {
         this.successMessage = '';
         this.giftForm.get('amount')?.updateValueAndValidity();
@@ -127,7 +127,8 @@ export class GiftStorageComponent implements OnDestroy {
             this.duplicateEmails = [];
           }
         }
-      });
+      })
+    );
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/components/gift-storage/gift-storage.component.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.ts
@@ -35,6 +35,7 @@ export class GiftStorageComponent implements OnDestroy {
   );
   private subscriptions: Subscription[] = [];
   public isAsyncValidating: boolean;
+  public successMessage: string = '';
 
   constructor(
     private fb: UntypedFormBuilder,
@@ -70,7 +71,6 @@ export class GiftStorageComponent implements OnDestroy {
     this.subscriptions.push(
       this.giftResult.subscribe((isSuccessful) => {
         if (isSuccessful) {
-          console.log(this.giftForm.value.email);
           const giftedAmount = Number(this.giftForm.value.amount);
           const remainingSpaceAfterGift =
             Number(this.availableSpace) - giftedAmount;
@@ -92,6 +92,7 @@ export class GiftStorageComponent implements OnDestroy {
       })
     ),
       this.giftForm.get('email')?.valueChanges.subscribe(() => {
+        this.successMessage = '';
         this.giftForm.get('amount')?.updateValueAndValidity();
       });
   }
@@ -165,7 +166,7 @@ export class GiftStorageComponent implements OnDestroy {
         map((invalidEmails) => {
           this.emailValidationErrors = invalidEmails || [];
           this.isAsyncValidating = false;
-          return invalidEmails ? { invalidEmails: invalidEmails } : null;
+          return invalidEmails ? { invalidEmails: true } : null;
         })
       );
     };
@@ -175,6 +176,7 @@ export class GiftStorageComponent implements OnDestroy {
     return (control: AbstractControl): ValidationErrors | null => {
       const emailControl = control.parent?.get('email');
       if (!control.value || !emailControl.value) {
+        this.successMessage = '';
         return null;
       }
 
@@ -184,16 +186,15 @@ export class GiftStorageComponent implements OnDestroy {
         const giftedAmount = numberOfEmails * Number(control.value);
         const availableSpace = Number(this.availableSpace);
         if (giftedAmount > availableSpace) {
+          this.successMessage = '';
+
           return {
             isGreaterThanAvailableSpace: true,
             requiredSpace: giftedAmount,
           };
         }
         if (giftedAmount <= availableSpace) {
-          return {
-            positiveValidation: true,
-            successMessage: `Total gifted storage: ${giftedAmount} GB`,
-          };
+          this.successMessage = `Total gifted storage: ${giftedAmount} GB`;
         }
       }
 

--- a/src/app/core/components/storage-dialog/storage-dialog.component.ts
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.ts
@@ -2,12 +2,13 @@
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { IsTabbedDialog, DialogRef } from '@root/app/dialog/dialog.module';
+
+import { PromoVOData, AccountVO } from '@models';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
   Validators,
 } from '@angular/forms';
-import { PromoVOData, AccountVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
 import {
   BillingResponse,
@@ -75,6 +76,10 @@ export class StorageDialogComponent implements OnInit, IsTabbedDialog {
       const bytes = promo.sizeInMB * (1024 * 1024);
       this.account.addStorageBytes(bytes);
       const pipe = new FileSizePipe();
+      this.message.showMessage(
+        `Gift code redeemed for ${pipe.transform(bytes)} of storage`,
+        'success'
+      );
       this.message.showMessage(
         `Gift code redeemed for ${pipe.transform(bytes)} of storage`,
         'success'

--- a/src/app/shared/services/api/billing.repo.ts
+++ b/src/app/shared/services/api/billing.repo.ts
@@ -71,13 +71,18 @@ export class BillingRepo extends BaseRepo {
     );
   }
 
-  public giftStorage(recipientEmail, storageAmount) {
+  public giftStorage(
+    recipientEmails: string[],
+    storageAmount: number,
+    note: string
+  ) {
     const data = {
-      recipientEmail,
+      recipientEmails,
       storageAmount,
+      note
     };
 
-    return this.httpV2.post('/billing/giftStorage', data).toPromise();
+    return this.httpV2.post('v2/billing/gift', data).toPromise();
   }
 }
 

--- a/src/app/shared/services/api/billing.repo.ts
+++ b/src/app/shared/services/api/billing.repo.ts
@@ -7,6 +7,7 @@ import {
 } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { BillingPaymentVO } from '@models';
+import { getFirst } from '../http-v2/http-v2.service';
 
 export class BillingRepo extends BaseRepo {
   public claimPledge(billingPaymentVO: BillingPaymentVO, pledgeId: string) {
@@ -74,15 +75,17 @@ export class BillingRepo extends BaseRepo {
   public giftStorage(
     recipientEmails: string[],
     storageAmount: number,
-    note: string
-  ) {
+    note?: string
+  ): Promise<GiftingResponse> {
     const data = {
       recipientEmails,
       storageAmount,
-      note
+      ...(note ? { note } : {}),
     };
 
-    return this.httpV2.post('v2/billing/gift', data).toPromise();
+    return getFirst(
+      this.httpV2.post('v2/billing/gift', data, GiftingResponse)
+    ).toPromise();
   }
 }
 
@@ -112,5 +115,18 @@ export class BillingResponse extends BaseResponse {
     }
 
     return data[0][0].PromoVO as PromoVOData;
+  }
+}
+
+export class GiftingResponse {
+  storageGifted: number;
+  giftDelivered: string[];
+  invitationSent: string[];
+  alreadyInvited: string[];
+
+  constructor(props: Object) {
+    for (const prop in props) {
+      this[prop] = props[prop];
+    }
   }
 }

--- a/src/assets/svg/alert.svg
+++ b/src/assets/svg/alert.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.75 15.75H17.25L9 1.5L0.75 15.75ZM9.75 13.5H8.25V12H9.75V13.5ZM9.75 10.5H8.25V7.5H9.75V10.5Z" fill="#A10000"/>
+</svg>


### PR DESCRIPTION
This pr adds the bulk gifting functionality to the gifting interface. Compared to the previous gifting interface, the user can now add multiple emails in the input separated by commas, gifting each user the same amount of GBs. 

Stepts to test: 

1. Go to the gifting storage tab
2. Add as many valid emails as you would like. Make sure to not exceed your storage
3. Add the gift amount
4. Send the storage.

