### PR TITLE
Per 9248 panning issues

### DIFF
--- a/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
@@ -2,7 +2,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ThumbnailComponent } from '@shared/components/thumbnail/thumbnail.component';
 import { RecordVO } from '@models';
-import * as OpenSeaDragon from 'openseadragon';
 import { DataStatus } from '@models/data-status.enum';
 import { Component, ViewChild } from '@angular/core';
 import { GetAltTextPipe } from '../../pipes/get-alt-text.pipe';

--- a/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
@@ -2,6 +2,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ThumbnailComponent } from '@shared/components/thumbnail/thumbnail.component';
 import { RecordVO } from '@models';
+import * as OpenSeaDragon from 'openseadragon';
 import { DataStatus } from '@models/data-status.enum';
 import { Component, ViewChild } from '@angular/core';
 import { GetAltTextPipe } from '../../pipes/get-alt-text.pipe';

--- a/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -104,6 +104,12 @@ export class ThumbnailComponent implements DoCheck, OnDestroy, AfterViewInit {
         } else {
           this.disableSwipe.emit(false);
         }
+
+        if (zoom <= 1) {
+          this.enablePanning(false);
+        } else {
+          this.enablePanning(true);
+        }
       });
 
       this.viewer.addHandler('full-screen', (event: FullScreenEvent) => {
@@ -231,5 +237,10 @@ export class ThumbnailComponent implements DoCheck, OnDestroy, AfterViewInit {
     } else {
       return record.FileVOs[0]?.fileURL;
     }
+  }
+
+  public enablePanning(flag: boolean): void {
+    (this.viewer as OpenSeaDragon.Options).panHorizontal = flag;
+    (this.viewer as OpenSeaDragon.Options).panVertical = flag;
   }
 }

--- a/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -99,7 +99,7 @@ export class ThumbnailComponent implements DoCheck, OnDestroy, AfterViewInit {
           this.initialZoom = zoom;
         }
 
-        if (zoom !== this.initialZoom) {
+        if (zoom > this.initialZoom) {
           this.disableSwipe.emit(true);
         } else {
           this.disableSwipe.emit(false);


### PR DESCRIPTION
Disable the panning when the zoom level of the image in the viewer is the first level or if it is zoomed out.

Stepts to test: 
1. Choose any image and display it full-screen.
2. Zoom out or leave it at the first zoom level
3. It should not pan when dragging it around.