### PR TITLE
PER-9219 Allow sftp deletion tab.

### DIFF
--- a/src/app/core/components/account-settings-dialog/account-settings-dialog.component.html
+++ b/src/app/core/components/account-settings-dialog/account-settings-dialog.component.html
@@ -48,9 +48,20 @@
       >
         Delete Account
       </div>
+      <div
+        class="settings-tab"
+        (click)="setTab('advanced-settings')"
+        [class.active]="activeTab === 'advanced-settings'"
+      >
+        Advanced Settings
+      </div>
     </div>
+
     <div class="settings-panel">
       <ng-container [ngSwitch]="activeTab">
+        <pr-advanced-settings
+          *ngSwitchCase="'advanced-settings'"
+        ></pr-advanced-settings>
         <pr-account-settings *ngSwitchCase="'account'"></pr-account-settings>
         <pr-billing-settings *ngSwitchCase="'billing'"></pr-billing-settings>
         <pr-notification-preferences

--- a/src/app/core/components/account-settings-dialog/account-settings-dialog.component.ts
+++ b/src/app/core/components/account-settings-dialog/account-settings-dialog.component.ts
@@ -14,7 +14,8 @@ export type SettingsTab =
   | 'notification'
   | 'billing'
   | 'legacy-contact'
-  | 'delete';
+  | 'delete'
+  | 'advanced-settings';
 
 @Component({
   selector: 'pr-account-settings-dialog',

--- a/src/app/core/components/advanced-settings/advanced-settings.component.html
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.html
@@ -1,0 +1,36 @@
+<!-- @format  -->
+<div class="advanced-settings">
+  <p class="title">Advanced settings</p>
+  <div class="settings-item">
+    <label>Allow SFTP Deletion</label>
+    <div class="form-check form-check-inline">
+      <input
+        class="form-check-input"
+        type="radio"
+        name="allowSFTPDeletion"
+        id="allowSFTPDeletionOn"
+        [value]="1"
+        [disabled]="updating"
+        [(ngModel)]="allowSFTPDeletion"
+        (ngModelChange)="onAllowSFTPDeletion()"
+      />
+      <label class="form-check-label" for="allowDownloadsToggleOn">On</label>
+    </div>
+    <div class="form-check form-check-inline">
+      <input
+        class="form-check-input"
+        type="radio"
+        name="allowSFTPDeletion"
+        id="allowSFTPDeletionOff"
+        [value]="0"
+        [disabled]="updating"
+        [(ngModel)]="allowSFTPDeletion"
+        (ngModelChange)="onAllowSFTPDeletion()"
+      />
+      <label class="form-check-label" for="allowDownloadsToggleOff">Off</label>
+    </div>
+  </div>
+  <small class="text-muted">
+    When deletion is on, files will be deleted from your archive while using SFTP if the file is not in your repository.
+  </small>
+</div>

--- a/src/app/core/components/advanced-settings/advanced-settings.component.html
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.html
@@ -31,6 +31,7 @@
     </div>
   </div>
   <small class="text-muted">
-    When deletion is on, files will be deleted from your archive while using SFTP if the file is not in your repository.
+    When deletion is on, files will be deleted from your archive while using
+    SFTP if the file is not in your repository.
   </small>
 </div>

--- a/src/app/core/components/advanced-settings/advanced-settings.component.scss
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.scss
@@ -1,0 +1,14 @@
+/* @format */
+.title {
+  font-weight: 700;
+  height: 2.5rem;
+  line-height: 2.5rem;
+}
+
+.settings-item {
+  & > label {
+    font-weight: 600;
+    margin: 0;
+    margin-right: 1.25rem;
+  }
+}

--- a/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
@@ -1,0 +1,73 @@
+/* @format */
+import { AccountService } from '@shared/services/account/account.service';
+import { AccountVO } from '@root/app/models';
+import { CoreModule } from '@core/core.module';
+import { MessageService } from '@shared/services/message/message.service';
+import { Shallow } from 'shallow-render';
+import { AccountResponse } from '../../../shared/services/api/account.repo';
+import { ApiService } from '../../../shared/services/api/api.service';
+import { AdvancedSettingsComponent } from './advanced-settings.component';
+
+const mockAccountService = {
+  getAccount: () => {
+    return new AccountVO({ accountId: 1, allowSftpDeletion: true });
+  },
+  setAccount: (account: AccountVO) => {},
+};
+
+const mockApiService = {
+  account: {
+    update: (account: AccountVO) => {
+      return Promise.resolve(new AccountResponse({}));
+    },
+  },
+};
+
+describe('AdvancedSettingsComponent', () => {
+  let shallow: Shallow<AdvancedSettingsComponent>;
+  let component: AdvancedSettingsComponent;
+  let messageShown = false;
+
+  beforeEach(async () => {
+    shallow = new Shallow(AdvancedSettingsComponent, CoreModule)
+      .mock(MessageService, {
+        showError: () => {
+          messageShown = true;
+        },
+      })
+      .mock(ApiService, mockApiService)
+      .mock(AccountService, mockAccountService);
+  });
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance).not.toBeNull();
+  });
+
+  it('initializes allowSFTPDeletion from the account service', async () => {
+    const { instance } = await shallow.render();
+    expect(instance.allowSFTPDeletion).toEqual(1);
+  });
+
+  it('updates account on calling onAllowSFTPDeletion', async () => {
+    const { instance, inject } = await shallow.render();
+    const apiService = inject(ApiService);
+    const spy = spyOn(apiService.account, 'update').and.returnValue(Promise.resolve(new AccountResponse({})));
+
+    await instance.onAllowSFTPDeletion();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('handles errors in onAllowSFTPDeletion', async () => {
+    const { instance, inject } = await shallow.render();
+    const messageService = inject(MessageService);
+
+    spyOn(inject(ApiService).account, 'update').and.throwError('test error');
+
+    await instance.onAllowSFTPDeletion();
+
+    expect(messageShown).toBe(true);
+  });
+});

--- a/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
@@ -53,7 +53,9 @@ describe('AdvancedSettingsComponent', () => {
   it('updates account on calling onAllowSFTPDeletion', async () => {
     const { instance, inject } = await shallow.render();
     const apiService = inject(ApiService);
-    const spy = spyOn(apiService.account, 'update').and.returnValue(Promise.resolve(new AccountResponse({})));
+    const spy = spyOn(apiService.account, 'update').and.returnValue(
+      Promise.resolve(new AccountResponse({}))
+    );
 
     await instance.onAllowSFTPDeletion();
 

--- a/src/app/core/components/advanced-settings/advanced-settings.component.ts
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.ts
@@ -1,0 +1,41 @@
+/* @format */
+import { AccountVO } from '@root/app/models';
+import { AccountService } from '@shared/services/account/account.service';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../shared/services/api/api.service';
+import { MessageService } from '../../../shared/services/message/message.service';
+
+@Component({
+  selector: 'pr-advanced-settings',
+  templateUrl: './advanced-settings.component.html',
+  styleUrls: ['./advanced-settings.component.scss'],
+})
+export class AdvancedSettingsComponent implements OnInit {
+  public allowSFTPDeletion: number;
+  public updating: boolean = false;
+  private account: AccountVO;
+
+  constructor(
+    private accountService: AccountService,
+    private api: ApiService,
+    private messageService: MessageService
+  ) {}
+
+  ngOnInit() {
+    this.account = this.accountService.getAccount();
+    this.allowSFTPDeletion = +this.account.allowSftpDeletion;
+  }
+
+  public async onAllowSFTPDeletion() {
+    this.account.allowSftpDeletion = !!this.allowSFTPDeletion;
+    try {
+      this.updating = true;
+      await this.api.account.update(this.account);
+      this.accountService.setAccount(this.account);
+    } catch (error) {
+      this.messageService.showError('Something went wrong!');
+    } finally {
+      this.updating = false;
+    }
+  }
+}

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -64,6 +64,7 @@ import { ArchiveStoragePayerComponent } from './components/archive-storage-payer
 import { SkipOnboardingDialogComponent } from './components/skip-onboarding-dialog/skip-onboarding-dialog.component';
 import { GiftStorageComponent } from './components/gift-storage/gift-storage.component';
 import { ConfirmGiftDialogComponent } from './components/confirm-gift-dialog/confirm-gift-dialog.component';
+import { AdvancedSettingsComponent } from './components/advanced-settings/advanced-settings.component';
 
 @NgModule({
   imports: [
@@ -118,6 +119,7 @@ import { ConfirmGiftDialogComponent } from './components/confirm-gift-dialog/con
     SkipOnboardingDialogComponent,
     GiftStorageComponent,
     ConfirmGiftDialogComponent,
+    AdvancedSettingsComponent
   ],
   providers: [
     DataService,

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -119,7 +119,7 @@ import { AdvancedSettingsComponent } from './components/advanced-settings/advanc
     SkipOnboardingDialogComponent,
     GiftStorageComponent,
     ConfirmGiftDialogComponent,
-    AdvancedSettingsComponent
+    AdvancedSettingsComponent,
   ],
   providers: [
     DataService,

--- a/src/app/models/account-vo.ts
+++ b/src/app/models/account-vo.ts
@@ -49,6 +49,7 @@ export interface AccountVOData extends BaseVOData {
   emailStatus?: any;
   phoneStatus?: any;
   notificationPreferences?: NotificationPreferencesI;
+  allowSftpDeletion?: boolean
 }
 
 export interface NotificationPreferencesI {
@@ -91,6 +92,7 @@ export class AccountVO extends BaseVO {
   public emailStatus;
   public phoneStatus;
   public notificationPreferences: NotificationPreferencesI;
+  public allowSftpDeletion;
 
   constructor(voData: AccountVOData) {
     super(voData);


### PR DESCRIPTION
Create new component and a new tab for advanced settings.

In the advanced settings tab handle the sftp deletion toggler. The toggler is similar to the display download button toggler.

Steps to test:

1. Open the account dropdown and navigate to the new "Advanced Settings" tab.
2. The toggle should work setting the option on or off.