### PR TITLE
PER-8826-archive-members-with-viewer-role-cannot-get-link

### DIFF
--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
@@ -177,6 +177,10 @@ export class FileListControlsComponent
 
     this.can.download = true;
 
+    if (this.isPublic) {
+      this.can.publish = true;
+    }
+
     if (!this.account.checkMinimumArchiveAccess(AccessRole.Curator)) {
       return;
     }

--- a/src/app/file-browser/components/publish/publish.component.html
+++ b/src/app/file-browser/components/publish/publish.component.html
@@ -1,34 +1,99 @@
+<!-- @format  -->
 <div class="dialog-content">
   <div class="dialog-body">
     <div class="page-title break-all">
-      {{this.sourceItem.folder_linkType.includes('public') ? 'Get public link for' : 'Publish'}} {{sourceItem.displayName}}</div>
+      {{
+        this.sourceItem.folder_linkType.includes('public')
+          ? 'Get public link for'
+          : 'Publish'
+      }}
+      {{ sourceItem.displayName }}
+    </div>
     <div class="public-link" *ngIf="publicLink">
       <p>This item can be viewed by anyone using the link provided</p>
-        <input type="text" class="form-control" readonly [value]="publicLink" #publicLinkInput>
-        <div class="buttons">
-          <button class="btn btn-primary" [disabled]="linkCopied" (click)="copyPublicLink()">{{ linkCopied ? 'Link copied' : 'Copy link'}}</button>
-          <button class="btn btn-primary" (click)="onViewOnWebClick()">View on web</button>
-        </div>
+      <input
+        type="text"
+        class="form-control"
+        readonly
+        [value]="publicLink"
+        #publicLinkInput
+      />
+      <div class="buttons">
+        <button
+          class="btn btn-primary"
+          [disabled]="linkCopied"
+          (click)="copyPublicLink()"
+        >
+          {{ linkCopied ? 'Link copied' : 'Copy link' }}
+        </button>
+        <button class="btn btn-primary" (click)="onViewOnWebClick()">
+          View on web
+        </button>
+      </div>
     </div>
     <div class="public-link-button" *ngIf="!publicItem || !publicLink">
-      <p>Create a publicly viewable copy of this item in your Public workspace and get a public link to share with anyone.</p>
-      <button class="btn btn-primary" (click)="publishItem()" [disabled]="waiting">Publish</button>
+      <p>
+        Create a publicly viewable copy of this item in your Public workspace
+        and get a public link to share with anyone.
+      </p>
+      <button
+        class="btn btn-primary"
+        (click)="publishItem()"
+        [disabled]="waiting"
+      >
+        Publish
+      </button>
     </div>
     <ng-container *ngIf="publicItem" [ngSwitch]="publishIa">
       <hr />
-      <img src="assets/img/internetarchive/IALogo.png" alt="Internet Archive" class="internet-archive-logo" />
+      <img
+        src="assets/img/internetarchive/IALogo.png"
+        alt="Internet Archive"
+        class="internet-archive-logo"
+      />
       <div class="public-link-button" *ngSwitchCase="null">
-        <p>This item can also be published to the Internet Archive. <a href="https://desk.zoho.com/portal/permanent/en/kb/articles/publishing-to-the-internet-archive" target="_blank">Learn more about publishing to the Internet Archive.</a></p>
-        <button class="btn btn-primary" (click)="publishItemToInternetArchive()" [disabled]="waiting">Publish to Internet Archive</button>
+        <p>
+          This item can also be published to the Internet Archive.
+          <a
+            href="https://desk.zoho.com/portal/permanent/en/kb/articles/publishing-to-the-internet-archive"
+            target="_blank"
+            >Learn more about publishing to the Internet Archive.</a
+          >
+        </p>
+        <button
+          class="btn btn-primary publish-to-archive"
+          (click)="publishItemToInternetArchive()"
+          [disabled]="waiting || !isAtleastManager"
+        >
+          Publish to Internet Archive
+        </button>
       </div>
       <div class="public-link" *ngSwitchDefault>
-        <p>When processed, you can view this item on the Internet Archive with the link provided. Processing may take several minutes.</p>
-        <input type="text" class="form-control" readonly [value]="publishIa.permalink" #iaLinkInput>
+        <p>
+          When processed, you can view this item on the Internet Archive with
+          the link provided. Processing may take several minutes.
+        </p>
+        <input
+          type="text"
+          class="form-control"
+          readonly
+          [value]="publishIa.permalink"
+          #iaLinkInput
+        />
         <div class="buttons">
-          <button class="btn btn-primary" [disabled]="iaLinkCopied" (click)="copyInternetArchiveLink()">
-            {{ iaLinkCopied ? 'Link copied' : 'Copy link'}}
+          <button
+            class="btn btn-primary"
+            [disabled]="iaLinkCopied"
+            (click)="copyInternetArchiveLink()"
+          >
+            {{ iaLinkCopied ? 'Link copied' : 'Copy link' }}
           </button>
-          <a class="btn btn-primary" [href]="publishIa.permalink" target="_blank">View on web</a>
+          <a
+            class="btn btn-primary"
+            [href]="publishIa.permalink"
+            target="_blank"
+            >View on web</a
+          >
         </div>
       </div>
       <hr />

--- a/src/app/file-browser/components/publish/publish.component.spec.ts
+++ b/src/app/file-browser/components/publish/publish.component.spec.ts
@@ -1,25 +1,71 @@
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+/* @format */
+import { Shallow } from 'shallow-render';
+import { PublishComponent } from './publish.component';
+import { AccountService } from '@shared/services/account/account.service';
+import { FolderVO, RecordVO } from '@models/index';
+import { FolderResponse } from '@shared/services/api/folder.repo';
+import { Observable } from 'rxjs';
+import { MessageService } from '@shared/services/message/message.service';
+import { ArchiveVO } from '../../../models/archive-vo';
+import { FileBrowserComponentsModule } from '../../file-browser-components.module';
+import { DialogRef, DIALOG_DATA } from '../../../dialog/dialog.service';
+import { ApiService } from '../../../shared/services/api/api.service';
 
-// import { PublishComponent } from './publish.component';
+const mockAccountService = {
+  getArchive: () => {
+    const archive = new ArchiveVO({ accessRole: 'access.role.viewer' });
+    return archive;
+  },
+};
 
-// describe('PublishComponent', () => {
-//   let component: PublishComponent;
-//   let fixture: ComponentFixture<PublishComponent>;
+const mockApiService = {
+  folder: {
+    copy: (
+      folderVOs: FolderVO[],
+      destination: FolderVO
+    ): Promise<FolderResponse> => {
+      return Promise.resolve(new FolderResponse({}));
+    },
+    navigateLean: (folder: FolderVO): Observable<FolderResponse> => {
+      return new Observable<FolderResponse>();
+    },
+  },
+};
 
-//   beforeEach(async(() => {
-//     TestBed.configureTestingModule({
-//       declarations: [ PublishComponent ]
-//     })
-//     .compileComponents();
-//   }));
+describe('PublishComponent', () => {
+  let shallow: Shallow<PublishComponent>;
+  let messageShown = false;
 
-//   beforeEach(() => {
-//     fixture = TestBed.createComponent(PublishComponent);
-//     component = fixture.componentInstance;
-//     fixture.detectChanges();
-//   });
+  beforeEach(() => {
+    shallow = new Shallow(PublishComponent, FileBrowserComponentsModule)
+      .mock(AccountService, mockAccountService)
+      .mock(ApiService, mockApiService)
+      .mock(DIALOG_DATA, {
+        item: { folder_linkType: 'linkType' },
+      })
+      .provide({ provide: DialogRef, useValue: new DialogRef(1, null) })
+      .mock(MessageService, {
+        showError: () => {
+          messageShown = true;
+        },
+      });
+  });
 
-//   it('should create', () => {
-//     expect(component).toBeTruthy();
-//   });
-// });
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+    expect(instance).toBeTruthy();
+  });
+
+  it('should disaple the public to internet archive button if the user does not have the correct access role', async () => {
+    const { instance,find,fixture } = await shallow.render();
+    instance.publicItem = new RecordVO({ recordId: 1 });
+    instance.publishIa = null;
+    instance.publicLink = null;
+
+    fixture.detectChanges();
+
+    const button = find('.publish-to-archive');
+
+    expect(button.nativeElement.disabled).toBeTruthy();
+  })
+});

--- a/src/app/file-browser/components/publish/publish.component.spec.ts
+++ b/src/app/file-browser/components/publish/publish.component.spec.ts
@@ -1,6 +1,5 @@
 /* @format */
 import { Shallow } from 'shallow-render';
-import { PublishComponent } from './publish.component';
 import { AccountService } from '@shared/services/account/account.service';
 import { FolderVO, RecordVO } from '@models/index';
 import { FolderResponse } from '@shared/services/api/folder.repo';
@@ -10,6 +9,7 @@ import { ArchiveVO } from '../../../models/archive-vo';
 import { FileBrowserComponentsModule } from '../../file-browser-components.module';
 import { DialogRef, DIALOG_DATA } from '../../../dialog/dialog.service';
 import { ApiService } from '../../../shared/services/api/api.service';
+import { PublishComponent } from './publish.component';
 
 const mockAccountService = {
   getArchive: () => {

--- a/src/app/file-browser/components/publish/publish.component.spec.ts
+++ b/src/app/file-browser/components/publish/publish.component.spec.ts
@@ -57,7 +57,7 @@ describe('PublishComponent', () => {
   });
 
   it('should disaple the public to internet archive button if the user does not have the correct access role', async () => {
-    const { instance,find,fixture } = await shallow.render();
+    const { instance, find, fixture } = await shallow.render();
     instance.publicItem = new RecordVO({ recordId: 1 });
     instance.publishIa = null;
     instance.publicLink = null;
@@ -67,5 +67,5 @@ describe('PublishComponent', () => {
     const button = find('.publish-to-archive');
 
     expect(button.nativeElement.disabled).toBeTruthy();
-  })
+  });
 });

--- a/src/app/file-browser/components/publish/publish.component.ts
+++ b/src/app/file-browser/components/publish/publish.component.ts
@@ -36,6 +36,7 @@ export class PublishComponent implements OnInit {
   public waiting = false;
   public linkCopied = false;
   public iaLinkCopied = false;
+  public isAtleastManager = false;
 
   @ViewChild('publicLinkInput', { static: false }) publicLinkInput: ElementRef;
   @ViewChild('iaLinkInput', { static: false }) iaLinkInput: ElementRef;
@@ -54,7 +55,10 @@ export class PublishComponent implements OnInit {
   ) {
     this.sourceItem = this.data.item as FolderVO | RecordVO;
 
-    if (this.sourceItem.folder_linkType.includes('public')) {
+    this.isAtleastManager =
+      this.getRole().includes('manager') || this.getRole().includes('owner');
+
+    if (this.sourceItem?.folder_linkType?.includes('public')) {
       this.publicItem = this.sourceItem;
       this.publicLink = this.linkPipe.transform(this.publicItem);
       this.checkInternetArchiveLink();
@@ -186,5 +190,9 @@ export class PublishComponent implements OnInit {
 
   close() {
     this.dialogRef.close();
+  }
+
+  private getRole(): string {
+    return this.accountService.getArchive().accessRole;
   }
 }

--- a/src/app/public/components/public-search-results/public-search-results.component.spec.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.spec.ts
@@ -5,8 +5,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SearchService } from '@search/services/search.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { DataService } from '../../../shared/services/data/data.service';
 import { PublicSearchResultsComponent } from './public-search-results.component';
+import { DataService } from '../../../shared/services/data/data.service';
 
 describe('PublicSearchResultsComponent', () => {
   let component: PublicSearchResultsComponent;

--- a/src/app/public/components/public-search-results/public-search-results.component.spec.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.spec.ts
@@ -5,8 +5,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SearchService } from '@search/services/search.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { PublicSearchResultsComponent } from './public-search-results.component';
 import { DataService } from '../../../shared/services/data/data.service';
+import { PublicSearchResultsComponent } from './public-search-results.component';
 
 describe('PublicSearchResultsComponent', () => {
   let component: PublicSearchResultsComponent;


### PR DESCRIPTION
Enable the get link button for viewers, but disable the publish to internet archive button.

Steps to test:
1. Invite an account as a viewer to your archive.
2. Switch to that account
3. Go to the public files tab
4. The get link button should work