### PR TITLE
Report upload time

### DIFF
--- a/src/app/core/services/upload/upload.service.spec.ts
+++ b/src/app/core/services/upload/upload.service.spec.ts
@@ -4,17 +4,74 @@ import { cloneDeep  } from 'lodash';
 
 import { UploadService } from '@core/services/upload/upload.service';
 import { DataService } from '@shared/services/data/data.service';
+import { UploadSession, UploadSessionStatus } from './upload.session';
+import { MessageService } from '@shared/services/message/message.service';
+
+class TestUploadSession extends UploadSession {
+  public emit(status: UploadSessionStatus): void {
+    this.progress.emit({
+      sessionStatus: status,
+      statistics: {
+        current: 0,
+        completed: 0,
+        total: 0,
+        error: 0,
+      },
+    });
+  }
+}
+
+class TestUploadService extends UploadService {
+  private uploadEnd: Date;
+
+  public getUploadStartTime(): Date {
+    return this.uploadStart;
+  }
+
+  public getElapsedUploadTime(): number {
+    if (this.uploadEnd) {
+      return this.uploadEnd.getTime() - this.uploadStart.getTime();
+    }
+    return NaN;
+  }
+
+  protected reportUploadTime(): void {
+    this.uploadEnd = new Date();
+  }
+}
+
+class MessageStub {
+  public showMessage(_msg: string): void {}
+}
 
 describe('UploadService', () => {
+  let service: TestUploadService;
+  let session: TestUploadSession;
+
   beforeEach(() => {
     const config = cloneDeep(Testing.BASE_TEST_CONFIG);
     const providers = config.providers as any[];
-    providers.push(UploadService);
+    providers.push({provide: UploadService, useClass: TestUploadService});
     providers.push(DataService);
+    providers.push({provide: MessageService, useClass: MessageStub});
+    providers.push({provide: UploadSession, useClass: TestUploadSession});
     TestBed.configureTestingModule(config);
+    service = TestBed.inject(UploadService) as TestUploadService;
+    session = TestBed.inject(UploadSession) as TestUploadSession;
   });
 
-  it('should be created', inject([UploadService], (service: UploadService) => {
+  it('should be created', () => {
     expect(service).toBeTruthy();
-  }));
+  });
+
+  it('should register upload session start time', () => {
+    session.emit(UploadSessionStatus.Start);
+    expect(service.getUploadStartTime()).not.toBeUndefined();
+  });
+
+  it('should output upload session elapsed time after upload is finished', () => {
+    session.emit(UploadSessionStatus.Start);
+    session.emit(UploadSessionStatus.Done);
+    expect(service.getElapsedUploadTime()).toBeGreaterThan(-1);
+  });
 });

--- a/src/app/core/services/upload/upload.service.spec.ts
+++ b/src/app/core/services/upload/upload.service.spec.ts
@@ -1,11 +1,12 @@
-import { TestBed, inject } from '@angular/core/testing';
+/* @format */
+import { TestBed } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
-import { cloneDeep  } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { UploadService } from '@core/services/upload/upload.service';
 import { DataService } from '@shared/services/data/data.service';
-import { UploadSession, UploadSessionStatus } from './upload.session';
 import { MessageService } from '@shared/services/message/message.service';
+import { UploadSession, UploadSessionStatus } from './upload.session';
 
 class TestUploadSession extends UploadSession {
   public emit(status: UploadSessionStatus): void {
@@ -51,10 +52,10 @@ describe('UploadService', () => {
   beforeEach(() => {
     const config = cloneDeep(Testing.BASE_TEST_CONFIG);
     const providers = config.providers as any[];
-    providers.push({provide: UploadService, useClass: TestUploadService});
+    providers.push({ provide: UploadService, useClass: TestUploadService });
     providers.push(DataService);
-    providers.push({provide: MessageService, useClass: MessageStub});
-    providers.push({provide: UploadSession, useClass: TestUploadSession});
+    providers.push({ provide: MessageService, useClass: MessageStub });
+    providers.push({ provide: UploadSession, useClass: TestUploadSession });
     TestBed.configureTestingModule(config);
     service = TestBed.inject(UploadService) as TestUploadService;
     session = TestBed.inject(UploadSession) as TestUploadSession;

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -317,7 +317,8 @@ export class UploadService implements HasSubscriptions, OnDestroy {
   }
 
   protected reportUploadTime(): void {
-    const elapsedSeconds = (new Date().getTime() - this.uploadStart.getTime()) / 1000;
+    const elapsedSeconds =
+      (new Date().getTime() - this.uploadStart.getTime()) / 1000;
     // eslint-disable-next-line no-console
     console.log(`Total Upload Time: ${elapsedSeconds}s`);
   }

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -45,6 +45,8 @@ export class UploadService implements HasSubscriptions, OnDestroy {
 
   subscriptions: Subscription[] = [];
 
+  protected uploadStart: Date;
+
   private debug = debug('service:upload');
 
   constructor(
@@ -73,9 +75,11 @@ export class UploadService implements HasSubscriptions, OnDestroy {
             this.message.showMessage(
               "Please don't close your browser until the upload is complete."
             );
+            this.uploadStart = new Date();
             break;
           case UploadSessionStatus.Done:
             this.accountService.refreshAccountDebounced();
+            this.reportUploadTime();
             break;
           case UploadSessionStatus.DefaultError:
             this.message.showError(
@@ -310,5 +314,11 @@ export class UploadService implements HasSubscriptions, OnDestroy {
       this.component.dismiss();
     }
     this.progressVisible.emit(false);
+  }
+
+  protected reportUploadTime(): void {
+    const elapsedSeconds = (new Date().getTime() - this.uploadStart.getTime()) / 1000;
+    // eslint-disable-next-line no-console
+    console.log(`Total Upload Time: ${elapsedSeconds}s`);
   }
 }


### PR DESCRIPTION
To measure upload speed and compare it to SFTP accurately, output upload time in console when upload sessions complete.

**Steps 2 Test:**
1. Open browser dev console
2. Upload items
3. See that elapsed time is output in the console.