### PR TITLE
Don't redirect invalid session on Public Gallery

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -12,6 +12,7 @@ import {
   ArchiveResponse,
   FolderResponse,
 } from '@shared/services/api/index.repo';
+import { LocationStrategy } from '@angular/common';
 import { Router } from '@angular/router';
 import { Dialog } from '@root/app/dialog/dialog.module';
 import {
@@ -67,7 +68,8 @@ export class AccountService {
     private dialog: Dialog,
     private router: Router,
     private httpv2: HttpV2Service,
-    private mixpanel: MixpanelService
+    private mixpanel: MixpanelService,
+    private location: LocationStrategy
   ) {
     const cachedAccount = this.getStorage(ACCOUNT_KEY);
 
@@ -217,16 +219,29 @@ export class AccountService {
             throw loggedIn;
           }
         } catch {
-          this.logOut();
-          this.clear();
-          this.router.navigate(['/login']);
+          this.logOutAndRedirectToLogin();
         }
       })
       .catch(() => {
-        this.logOut();
-        this.clear();
-        this.router.navigate(['/login']);
+        this.logOutAndRedirectToLogin();
       });
+  }
+
+  private logOutAndRedirectToLogin(): void {
+    this.logOut();
+    this.clear();
+    if (!this.isOnPublicGallery()) {
+      this.router.navigate(['/login']);
+    }
+  }
+
+  private isOnPublicGallery(): boolean {
+    const firstUrlPiece = this.location
+      .path()
+      .split('/')
+      .filter((p) => p)
+      .shift();
+    return firstUrlPiece === 'p' || firstUrlPiece === 'gallery';
   }
 
   public refreshArchive() {

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -208,12 +208,10 @@ export class AccountService {
         const loggedIn = await this.checkSession();
         if (loggedIn) {
           const newArchive = response.getArchiveVO();
+          const newAccount = response.getAccountVO();
+          this.account.update(newAccount);
           this.archive.update(newArchive);
-          if (this.account.keepLoggedIn) {
-            this.storage.local.set(ARCHIVE_KEY, this.archive);
-          } else {
-            this.storage.session.set(ARCHIVE_KEY, this.archive);
-          }
+          this.setStorage(this.account.keepLoggedIn, ARCHIVE_KEY, this.archive);
         } else {
           throw loggedIn;
         }

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -205,21 +205,17 @@ export class AccountService {
           throw response;
         }
         // Verify that server agrees that the user is logged in
-        try {
-          const loggedIn = await this.checkSession();
-          if (loggedIn) {
-            const newArchive = response.getArchiveVO();
-            this.archive.update(newArchive);
-            if (this.account.keepLoggedIn) {
-              this.storage.local.set(ARCHIVE_KEY, this.archive);
-            } else {
-              this.storage.session.set(ARCHIVE_KEY, this.archive);
-            }
+        const loggedIn = await this.checkSession();
+        if (loggedIn) {
+          const newArchive = response.getArchiveVO();
+          this.archive.update(newArchive);
+          if (this.account.keepLoggedIn) {
+            this.storage.local.set(ARCHIVE_KEY, this.archive);
           } else {
-            throw loggedIn;
+            this.storage.session.set(ARCHIVE_KEY, this.archive);
           }
-        } catch {
-          this.logOutAndRedirectToLogin();
+        } else {
+          throw loggedIn;
         }
       })
       .catch(() => {

--- a/src/app/shared/services/account/tests/account.service.spec.ts
+++ b/src/app/shared/services/account/tests/account.service.spec.ts
@@ -9,9 +9,9 @@ import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { AuthResponse } from '@shared/services/api/index.repo';
 import { AccountVO, ArchiveVO, FolderVO, RecordVO } from '@root/app/models';
-import { AppModule } from '../../../app.module';
-import { StorageService } from '../storage/storage.service';
-import { EditService } from '../../../core/services/edit/edit.service';
+import { AppModule } from '../../../../app.module';
+import { StorageService } from '../../storage/storage.service';
+import { EditService } from '../../../../core/services/edit/edit.service';
 
 describe('AccountService', () => {
   let shallow: Shallow<AccountService>;

--- a/src/app/shared/services/account/tests/refreshAccount.spec.ts
+++ b/src/app/shared/services/account/tests/refreshAccount.spec.ts
@@ -1,0 +1,252 @@
+/* @format */
+import { Shallow } from 'shallow-render';
+import { AccountVO } from '@models/account-vo';
+import { Observable, Subject } from 'rxjs';
+import { AuthResponse } from '@shared/services/api/auth.repo';
+import { AppModule } from '@root/app/app.module';
+import { ApiService } from '@shared/services/api/api.service';
+import { StorageService } from '@shared/services/storage/storage.service';
+import { Router } from '@angular/router';
+import { ArchiveVO } from '@models/index';
+import { AccountResponse } from '@shared/services/api/account.repo';
+import { LocationStrategy } from '@angular/common';
+import { AccountService } from '../account.service';
+
+class AccountRepoStub {
+  public get(_account: AccountVO) {
+    return Promise.resolve();
+  }
+}
+
+class AuthRepoStub {
+  public static loggedIn: boolean = true;
+  public static failRequest: boolean = false;
+
+  public logOut() {
+    return new Observable<AuthResponse>();
+  }
+
+  public async isLoggedIn() {
+    if (AuthRepoStub.failRequest) {
+      throw 'test error';
+    }
+    return new AuthResponse({
+      isSuccessful: true,
+      Results: [
+        {
+          data: [
+            {
+              SimpleVO: {
+                key: 'bool',
+                value: AuthRepoStub.loggedIn,
+                createdDT: null,
+                updatedDT: null,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  }
+}
+
+const dummyStorageService = {
+  local: {
+    get: () => {},
+    set: () => {},
+    delete: () => {},
+  },
+  session: {
+    get: () => {},
+    set: () => {},
+    delete: () => {},
+  },
+};
+
+describe('AccountService: refreshAccount', () => {
+  let shallow: Shallow<AccountService>;
+  let accountRepo: AccountRepoStub;
+  let authRepo: AuthRepoStub;
+
+  beforeEach(() => {
+    AuthRepoStub.loggedIn = true;
+    AuthRepoStub.failRequest = false;
+    accountRepo = new AccountRepoStub();
+    authRepo = new AuthRepoStub();
+    shallow = new Shallow(AccountService, AppModule)
+      .dontMock(ApiService)
+      .provide({
+        provide: ApiService,
+        useValue: { auth: authRepo, account: accountRepo },
+      })
+      .mock(StorageService, dummyStorageService);
+  });
+
+  function setUpSpies(
+    services: {
+      apiService: ApiService;
+      router: Router;
+      location: LocationStrategy;
+      instance: AccountService;
+    },
+    url: string = '/app/private'
+  ) {
+    services.router.navigate = jasmine
+      .createSpy('router.navigate')
+      .and.callFake(() => {});
+
+    const logOutSpy = spyOn(
+      services.apiService.auth,
+      'logOut'
+    ).and.callThrough();
+    spyOn(services.location, 'path').and.returnValue(url);
+
+    services.instance.setArchive(new ArchiveVO({}));
+    services.instance.setAccount(new AccountVO({}));
+    spyOn(services.apiService.account, 'get').and.resolveTo(
+      new AccountResponse({
+        isSuccessful: true,
+        Results: [
+          {
+            data: [
+              {
+                AccountVO: {
+                  primaryEmail: 'test@permanent.org',
+                  fullName: 'Test User',
+                },
+                ArchiveVO: {
+                  archiveNbr: '0001-0000',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    return { logOutSpy };
+  }
+  it('should be able to check if the user is logged in', async () => {
+    const { instance, inject } = shallow.createService();
+    const router = inject(Router);
+
+    const { logOutSpy } = setUpSpies({
+      apiService: inject(ApiService),
+      router,
+      location: inject(LocationStrategy),
+      instance,
+    });
+
+    await instance.refreshAccount();
+    expect(logOutSpy).not.toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+  it('should redirect the user to the login page if their session expires', async () => {
+    const { instance, inject } = shallow.createService();
+    const router = inject(Router);
+
+    const { logOutSpy } = setUpSpies({
+      apiService: inject(ApiService),
+      router,
+      location: inject(LocationStrategy),
+      instance,
+    });
+
+    AuthRepoStub.loggedIn = false;
+    await instance.refreshAccount();
+    expect(logOutSpy).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalled();
+  });
+  it('should not redirect the user to login page if their session expires on a public archive', async () => {
+    const { instance, inject } = shallow.createService();
+    const router = inject(Router);
+
+    const { logOutSpy } = setUpSpies(
+      {
+        apiService: inject(ApiService),
+        router,
+        location: inject(LocationStrategy),
+        instance,
+      },
+      '///p/0001-0000/?ksljflkasjlf'
+    );
+
+    AuthRepoStub.loggedIn = false;
+    await instance.refreshAccount();
+    expect(logOutSpy).toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+  it('should not redirect the user to login page if their session expires in the public gallery', async () => {
+    const { instance, inject } = shallow.createService();
+    const router = inject(Router);
+
+    const { logOutSpy } = setUpSpies(
+      {
+        apiService: inject(ApiService),
+        router,
+        location: inject(LocationStrategy),
+        instance,
+      },
+      '///gallery/////'
+    );
+
+    AuthRepoStub.loggedIn = false;
+    await instance.refreshAccount();
+    expect(logOutSpy).toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+  it('should redirect the user if the loggedIn call fails', async () => {
+    const { instance, inject } = shallow.createService();
+    const router = inject(Router);
+
+    const { logOutSpy } = setUpSpies({
+      apiService: inject(ApiService),
+      router,
+      location: inject(LocationStrategy),
+      instance,
+    });
+
+    AuthRepoStub.failRequest = true;
+    await instance.refreshAccount();
+    expect(logOutSpy).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalled();
+  });
+  it('should not redirect the user if the loggedIn call fails on the public archive', async () => {
+    const { instance, inject } = shallow.createService();
+    const router = inject(Router);
+
+    const { logOutSpy } = setUpSpies(
+      {
+        apiService: inject(ApiService),
+        router,
+        location: inject(LocationStrategy),
+        instance,
+      },
+      '/p/0001-0000/'
+    );
+
+    AuthRepoStub.failRequest = true;
+    await instance.refreshAccount();
+    expect(logOutSpy).toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+  it('should not redirect the user if the loggedIn call fails on the public gallery', async () => {
+    const { instance, inject } = shallow.createService();
+    const router = inject(Router);
+
+    const { logOutSpy } = setUpSpies(
+      {
+        apiService: inject(ApiService),
+        router,
+        location: inject(LocationStrategy),
+        instance,
+      },
+      '/gallery/'
+    );
+
+    AuthRepoStub.failRequest = true;
+    await instance.refreshAccount();
+    expect(logOutSpy).toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fix a bug where an invalid session on the public gallery could redirect the user to the login screen. Since authentication is not needed in the public gallery, they do not need to be redirected.

While this fixes some bug that deals with redirections to login, it's unclear if this is actually fixing the bug referred to in PER-9409. The invalid session redirect is one of the few pathways available for redirection to the login screen on the public gallery, and it seems to be the only one that does not provide an error message as seen in the one video recording we have of the bug in action. However, it's unclear how this specific code would be triggered in a brand new browser that doesn't have any session data in it to begin with, which is what was observed in the video.

To keep the AccountService tests more organized, the tests for this change were put in a separate file since the main AccountService spec file was already getting very long. Because of the way Angular unit testing works, there's a limit to how much code duplication we can eliminate, so we may have to split additional tests into their own files to keep things more organized.

**Steps to Recreate Bug:**
1. Log into Permanent
2. Open a page on a public archive.
3. Open up developer tools or browser settings and delete *only* the cookies for the current Permanent environment.
4. Refresh the page and verify that you are redirected to login instead of seeing the public archive.
5. Also verify that no error message is displayed to the user

**Steps to test this PR:**
1. Recreate the bug as described below.
2. Verify that the user is not redirected.

Resolves PER-9409.