### PR TITLE
Enable jasmine/new-line-before-expect lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
       env: { jasmine: true },
       rules: {
         // We intend to enable these eventually:
-        'jasmine/new-line-before-expect': 'off',
         'jasmine/new-line-between-declarations': 'off',
         'jasmine/no-disabled-tests': 'off',
         'jasmine/no-promise-without-done-fail': 'off',

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
@@ -43,21 +43,25 @@ describe('AndroidAppNotifyComponent', () => {
   });
   it('should exist', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
   it('should be invisible before `beforeinstallprompt` event', async () => {
     const { find } = await shallow.render();
+
     expect(find('div').length).toBe(0);
   });
   it('should appear when the `beforeinstallprompt` fires', async () => {
     const { find, fixture } = await shallow.render();
     await waitForPromptEvent(fixture);
+
     expect(find('div').length).toBeGreaterThan(0);
   });
   it('has a clickable button that shows the prompt', async () => {
     const { find, fixture } = await shallow.render();
     await waitForPromptEvent(fixture);
     find('.prompt-button')[0].triggerEventHandler('click', {});
+
     expect(prompted).toBeTruthy();
   });
   it('should dismiss itself after the App Install Banner appears', async () => {
@@ -67,6 +71,7 @@ describe('AndroidAppNotifyComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(find('div').length).toBe(0);
   });
   it('should be dismissable from a close button', async () => {
@@ -75,16 +80,19 @@ describe('AndroidAppNotifyComponent', () => {
     find('.dismiss-button')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(find('div').length).toBe(0);
     const dismissed = localStorage.getItem(
       AndroidAppNotifyComponent.storageKey
     );
+
     expect(dismissed).toBeTruthy();
   });
   it('should not show up if previously dismissed', async () => {
     localStorage.setItem(AndroidAppNotifyComponent.storageKey, 'true');
     const { find, fixture } = await shallow.render();
     await waitForPromptEvent(fixture);
+
     expect(find('div').length).toBe(0);
   });
 });

--- a/src/app/announcement/components/announcement/announcement.component.spec.ts
+++ b/src/app/announcement/components/announcement/announcement.component.spec.ts
@@ -52,19 +52,23 @@ describe('AnnouncementComponent', () => {
   });
   it('should take in test data', async () => {
     const { element } = await defaultRender([currentTestEvent]);
+
     expect(element).not.toBeNull();
   });
   it('should display the message', async () => {
     const { find, element } = await defaultRender([currentTestEvent]);
+
     expect(find('.announcement').length).toBeGreaterThan(0);
     expect(element.nativeElement.innerText).toContain('Test Event!!!');
   });
   it('should hide itself if event is in the future', async () => {
     const { find } = await defaultRender([futureTestEvent]);
+
     expect(find('.announcement').length).toBe(0);
   });
   it('should hide itself if the event is already over', async () => {
     const { find } = await defaultRender([pastTestEvent]);
+
     expect(find('.announcement').length).toBe(0);
   });
   it('should support multiple event definitions', async () => {
@@ -73,21 +77,26 @@ describe('AnnouncementComponent', () => {
       currentTestEvent,
       futureTestEvent,
     ]);
+
     expect(find('.announcement').length).toBe(1);
     expect(element.nativeElement.innerText).toContain('Test Event!!!');
   });
   it('should be dismissable', async () => {
     const { find, fixture, element } = await defaultRender([currentTestEvent]);
+
     expect(find('.dismiss-button').length).toBe(1);
     find('.dismiss-button').nativeElement.click();
     fixture.detectChanges();
+
     expect(find('.announcement').length).toBe(0);
   });
   it('should set dismissed setting in localStorage', async () => {
     const { find, fixture, instance } = await defaultRender([currentTestEvent]);
+
     expect(find('.dismiss-button').length).toBe(1);
     find('.dismiss-button').nativeElement.click();
     fixture.detectChanges();
+
     expect(window.localStorage.getItem('announcementDismissed')).toBe(
       currentTestEvent.start.toString()
     );
@@ -98,19 +107,23 @@ describe('AnnouncementComponent', () => {
       currentTestEvent.start.toString()
     );
     const { find } = await defaultRender([currentTestEvent]);
+
     expect(find('.announcement').length).toBe(0);
   });
   it('should still be able to show a new announcement after dismissing a previous one', async () => {
     window.localStorage.setItem('announcementDismissed', 'pastevent');
     const { find } = await defaultRender([currentTestEvent]);
+
     expect(find('.announcement').length).toBe(1);
   });
   it('should be able to handle an empty data array', async () => {
     const { find } = await defaultRender([]);
+
     expect(find('.announcement').length).toBe(0);
   });
   it('should be able to handle the null case', async () => {
     const { find } = await defaultRender();
+
     expect(find('.announcement').length).toBe(0);
   });
   describe('Layout Adjustment', () => {
@@ -128,6 +141,7 @@ describe('AnnouncementComponent', () => {
       find: (s: string) => QueryMatch<DebugElement>
     ) {
       const adjustedElements = find('.adjust-for-announcement');
+
       expect(adjustedElements.length).toBeGreaterThan(0);
       return adjustedElements;
     }

--- a/src/app/apps/components/connector/connector.component.spec.ts
+++ b/src/app/apps/components/connector/connector.component.spec.ts
@@ -66,6 +66,7 @@ describe('ConnectorComponent', () => {
       type: 'type.connector.facebook'
     });
     fixture.detectChanges();
+
     expect(hostComponent.component).toBeTruthy();
   });
 
@@ -80,6 +81,7 @@ describe('ConnectorComponent', () => {
 
     const compiled = fixture.debugElement.nativeElement as HTMLElement;
     const button = compiled.querySelector('button#connector-connect') as HTMLButtonElement;
+
     expect(button).toBeDefined();
     expect(button.getAttribute('hidden')).toBeNull();
     expect(button.innerText).toBe('Connect');
@@ -96,6 +98,7 @@ describe('ConnectorComponent', () => {
 
     const compiled = fixture.debugElement.nativeElement as HTMLElement;
     const button = compiled.querySelector('button#connector-connect') as HTMLButtonElement;
+
     expect(button).toBeDefined();
     expect(button.getAttribute('hidden')).toBeNull();
     expect(button.innerText).toBe('Sign In with FamilySearch');
@@ -114,9 +117,11 @@ describe('ConnectorComponent', () => {
     const compiled = fixture.debugElement.nativeElement as HTMLElement;
 
     const connectButton = compiled.querySelector('button#connector-connect') as HTMLButtonElement;
+
     expect(connectButton.getAttribute('hidden')).not.toBeNull();
 
     const importButton = compiled.querySelector('button#facebook-import') as HTMLButtonElement;
+
     expect(importButton.getAttribute('hidden')).toBeNull();
   });
 
@@ -133,15 +138,19 @@ describe('ConnectorComponent', () => {
     const compiled = fixture.debugElement.nativeElement as HTMLElement;
 
     const connectButton = compiled.querySelector('button#connector-connect') as HTMLButtonElement;
+
     expect(connectButton.getAttribute('hidden')).not.toBeNull();
 
     const importButton = compiled.querySelector('button#familysearch-tree-import') as HTMLButtonElement;
+
     expect(importButton.getAttribute('hidden')).toBeNull();
 
     const uploadButton = compiled.querySelector('button#familysearch-upload') as HTMLButtonElement;
+
     expect(uploadButton.getAttribute('hidden')).not.toBeNull();
 
     const downloadButton = compiled.querySelector('button#familysearch-download') as HTMLButtonElement;
+
     expect(downloadButton.getAttribute('hidden')).not.toBeNull();
   });
 
@@ -159,15 +168,19 @@ describe('ConnectorComponent', () => {
     const compiled = fixture.debugElement.nativeElement as HTMLElement;
 
     const connectButton = compiled.querySelector('button#connector-connect') as HTMLButtonElement;
+
     expect(connectButton.getAttribute('hidden')).not.toBeNull();
 
     const importButton = compiled.querySelector('button#familysearch-tree-import') as HTMLButtonElement;
+
     expect(importButton.getAttribute('hidden')).toBeNull();
 
     const uploadButton = compiled.querySelector('button#familysearch-upload') as HTMLButtonElement;
+
     expect(uploadButton.getAttribute('hidden')).toBeNull();
 
     const downloadButton = compiled.querySelector('button#familysearch-download') as HTMLButtonElement;
+
     expect(downloadButton.getAttribute('hidden')).toBeNull();
   });
 });

--- a/src/app/archive-settings/manage-metadata/manage-custom-metadata/manage-custom-metadata.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/manage-custom-metadata/manage-custom-metadata.component.spec.ts
@@ -66,27 +66,33 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
 
   it('should create', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
 
   it('should load custom metadata categories', async () => {
     const { find } = await shallow.render();
+
     expect(find('.category').length).toBe(3);
   });
 
   it('should be able to select a category', async () => {
     const { find, fixture } = await shallow.render();
+
     expect(find('.category.selected').length).toBe(0);
     find('.category')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('.category.selected').length).toBe(1);
   });
 
   it('should be able to load tags by metadata category', async () => {
     const { find, fixture } = await shallow.render();
+
     expect(find('.value').length).toBe(0);
     find('.category')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('.value').length).toBe(3);
   });
 
@@ -94,6 +100,7 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
     const { find, fixture } = await shallow.render();
     find('.category')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('.value').length).toBe(3);
     defaultTagList.push({
       tagId: 9,
@@ -103,6 +110,7 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
     find('pr-metadata-add-new-value').triggerEventHandler('tagsUpdate', {});
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(find('.value').length).toBe(4);
   });
 
@@ -110,6 +118,7 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
     const { instance } = await shallow.render();
     instance.addDeletedTag(new TagVO(defaultTagList[1]));
     await instance.refreshTagsInPlace();
+
     expect(instance.tagsList.length).toBe(4);
     expect(instance.tagsList.map((t) => t.tagId)).not.toContain(2);
   });
@@ -118,8 +127,10 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
     const { instance } = await shallow.render();
     instance.addDeletedCategory('a');
     await instance.refreshTagsInPlace();
+
     expect(instance.tagsList.length).toBe(2);
     instance.tagsList.forEach((tag) =>
+
       expect(tag.name.startsWith('a:')).toBeFalse()
     );
   });
@@ -134,6 +145,7 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
       type: 'type.tag.metadata.customField',
     });
     await instance.refreshTagsInPlace();
+
     expect(instance.tagsList.length).toBe(3);
   });
 
@@ -141,6 +153,7 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
     const { instance } = await shallow.render();
     instance.activeCategory = 'potato';
     instance.addDeletedCategory('potato');
+
     expect(instance.activeCategory).toBeNull();
   });
 
@@ -149,6 +162,7 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
     instance.activeCategory = 'c';
     defaultTagList.pop();
     await instance.refreshTagsInPlace();
+
     expect(instance.activeCategory).toBeNull();
   });
 
@@ -156,9 +170,11 @@ describe('ManageCustomMetadataComponent #custom-metadata', () => {
     const { instance } = await shallow.render();
     instance.activeCategory = 'c';
     instance.addDeletedTag(new TagVO(defaultTagList.slice(-1).pop()));
+
     expect(instance.activeCategory).toBeNull();
     instance.activeCategory = 'a';
     instance.addDeletedTag(new TagVO(defaultTagList[1]));
+
     expect(instance.activeCategory).toBe('a');
   });
 });

--- a/src/app/archive-settings/manage-metadata/subcomponents/category-add/add-new-category.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/category-add/add-new-category.component.spec.ts
@@ -60,6 +60,7 @@ describe('AddNewCategoryComponent', () => {
 
   it('should create', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
 
@@ -67,6 +68,7 @@ describe('AddNewCategoryComponent', () => {
     const { instance, outputs } = await shallow.render();
     firstValueName = 'potato';
     await instance.createNewCategory('vegetable');
+
     expect(createdTag.name).toBe('vegetable:potato');
     expect(outputs.tagsUpdate.emit).toHaveBeenCalled();
     expect(outputs.newCategory.emit).toHaveBeenCalledWith('vegetable');
@@ -76,6 +78,7 @@ describe('AddNewCategoryComponent', () => {
     const { instance } = await shallow.render();
     firstValueName = 'test';
     await expectAsync(instance.createNewCategory('a:b')).toBeRejected();
+
     expect(createdTag).toBeNull();
     expect(messageShown).toBeTrue();
   });
@@ -85,6 +88,7 @@ describe('AddNewCategoryComponent', () => {
     acceptPrompt = false;
     firstValueName = 'test';
     await instance.createNewCategory('test');
+
     expect(createdTag).toBeNull();
     expect(outputs.tagsUpdate.emit).not.toHaveBeenCalled();
   });
@@ -94,6 +98,7 @@ describe('AddNewCategoryComponent', () => {
     error = true;
     firstValueName = 'potato';
     await expectAsync(instance.createNewCategory('abc')).toBeRejected();
+
     expect(createdTag).toBeNull();
     expect(messageShown).toBeTrue();
     expect(outputs.tagsUpdate.emit).not.toHaveBeenCalled();

--- a/src/app/archive-settings/manage-metadata/subcomponents/category-edit/category-edit.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/category-edit/category-edit.component.spec.ts
@@ -96,12 +96,14 @@ describe('CategoryEditComponent', () => {
 
   it('should exist', async () => {
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
 
   it('should be able to delete a category', async () => {
     const { instance, outputs } = await defaultRender();
     await instance.delete();
+
     expect(deletedTags.length).toBe(2);
     deletedTags.forEach((tag) => expect(tag.name).toContain('test'));
     expect(outputs.refreshTags.emit).toHaveBeenCalled();
@@ -112,6 +114,7 @@ describe('CategoryEditComponent', () => {
     const { instance, outputs } = await defaultRender();
     error = true;
     await expectAsync(instance.delete()).toBeRejected();
+
     expect(messageShown).toBeTrue();
     expect(outputs.refreshTags.emit).not.toHaveBeenCalled();
     expect(outputs.deletedCategory.emit).not.toHaveBeenCalled();
@@ -120,11 +123,13 @@ describe('CategoryEditComponent', () => {
   it('should be able to save a category', async () => {
     const { instance, outputs } = await defaultRender();
     await instance.save('potato');
+
     expect(savedTags.length).toBe(2);
     savedTags.forEach((tag) => {
       expect(tag.name.startsWith('potato')).toBeTrue(); // Verify category name changed
       expect(tag.name.substring(6).includes('potato')).toBeFalse(); // Verify value name not changed
     });
+
     expect(outputs.refreshTags.emit).toHaveBeenCalled();
   });
 
@@ -132,6 +137,7 @@ describe('CategoryEditComponent', () => {
     const { instance, outputs } = await defaultRender();
     error = true;
     await expectAsync(instance.save('potato')).toBeRejected();
+
     expect(messageShown).toBeTrue();
     expect(outputs.refreshTags.emit).not.toHaveBeenCalled();
   });
@@ -140,6 +146,7 @@ describe('CategoryEditComponent', () => {
     rejectDelete = true;
     const { instance, outputs } = await defaultRender();
     await instance.delete();
+
     expect(deletedTags.length).toBe(0);
     expect(outputs.deletedCategory.emit).not.toHaveBeenCalled();
   });

--- a/src/app/archive-settings/manage-metadata/subcomponents/form-create/form-create.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/form-create/form-create.component.spec.ts
@@ -27,11 +27,13 @@ describe('FormCreateComponent', () => {
 
   it('should create', async () => {
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
 
   it('should be a text label at first', async () => {
     const { find } = await defaultRender();
+
     expect(find('.placeholder-text').length).toBe(1);
     expect(find('input').length).toBe(0);
   });
@@ -40,16 +42,19 @@ describe('FormCreateComponent', () => {
     const { find, fixture } = await defaultRender();
     find('.placeholder-text').triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('input').length).toBe(1);
   });
 
   it('should use specified placeholder text', async () => {
     const { find, fixture } = await defaultRender();
+
     expect(find('.placeholder-text').nativeElement.innerText).toBe(
       'Add New Test'
     );
     find('.placeholder-text').triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('input').nativeElement.placeholder).toBe('Add New Test');
   });
 
@@ -67,9 +72,11 @@ describe('FormCreateComponent', () => {
     find('form').triggerEventHandler('submit', {
       target: find('form').nativeElement,
     });
+
     expect(instance.waiting).toBe(true);
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(createdTag).toBe('abc');
     expect(instance.waiting).toBe(false);
     expect(find('.placeholder-text').length).toBe(1);
@@ -90,6 +97,7 @@ describe('FormCreateComponent', () => {
     });
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(find('input').length).toBe(1);
     setTimeout(() => {
       expect(instance.waiting).toBe(false);
@@ -101,6 +109,7 @@ describe('FormCreateComponent', () => {
     const { instance } = await defaultRender();
     instance.newTagName = 'potato';
     await instance.runSubmitCallback();
+
     expect(instance.newTagName).toBe('');
   });
 
@@ -122,6 +131,7 @@ describe('FormCreateComponent', () => {
     }
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(callbackCalls).toBe(1);
   });
 });

--- a/src/app/archive-settings/manage-metadata/subcomponents/form-edit/form-edit.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/form-edit/form-edit.component.spec.ts
@@ -49,44 +49,54 @@ describe('FormEditComponent', () => {
 
   it('should exist', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
 
   it('should print tag value', async () => {
     const { find } = await defaultRender();
+
     expect(find('.value-name').nativeElement.innerText).toBe('test');
   });
 
   it('should have a dropdown edit/delete menu', async () => {
     const { find, fixture } = await defaultRender();
+
     expect(find('.edit-delete-menu').length).toBe(0);
     expect(find('.edit-delete-trigger').length).toBe(1);
     find('.edit-delete-trigger')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('.edit-delete-menu').length).toBe(1);
   });
 
   it('should be call the delete function', async () => {
     const { find, fixture } = await defaultRender();
+
     expect(find('.delete').length).toBe(0);
     find('.edit-delete-trigger')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('.delete').length).toBe(1);
     find('.delete')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(deleted).toBeTrue();
   });
 
   it('should be able to open the value editor', async () => {
     const { instance, find, fixture } = await defaultRender('123');
+
     expect(find('.value-editor').length).toBe(0);
     expect(find('.edit').length).toBe(0);
     find('.edit-delete-trigger')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('.edit').length).toBe(1);
     find('.edit')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
+
     expect(find('.value-line').length).toBe(0);
     expect(find('.edit-delete-menu').length).toBe(0);
     expect(find('.value-editor').length).toBe(1);
@@ -94,6 +104,7 @@ describe('FormEditComponent', () => {
     const input = find('.value-editor input');
     input.nativeElement.value = 'Test';
     input.triggerEventHandler('input', { target: input.nativeElement });
+
     expect(instance.newValueName).toBe('Test');
     expect(input.nativeElement.placeholder).toBe('123');
   });
@@ -105,12 +116,14 @@ describe('FormEditComponent', () => {
     find('.edit')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
     const input = find('.value-editor input');
+
     expect(instance.newValueName).toBe('testValue');
     input.nativeElement.value = 'potato';
     input.triggerEventHandler('input', { target: input.nativeElement });
     find('form').triggerEventHandler('submit', {});
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(find('.value-editor').length).toBe(0);
     expect(updated).toBeTrue();
     expect(newTagName).toBe('potato');
@@ -125,6 +138,7 @@ describe('FormEditComponent', () => {
     find('.delete')[0].triggerEventHandler('click', {});
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(callbackCalls).toBe(1);
   });
 
@@ -141,6 +155,7 @@ describe('FormEditComponent', () => {
     find('form').triggerEventHandler('submit', {});
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(callbackCalls).toBe(1);
   });
 
@@ -150,6 +165,7 @@ describe('FormEditComponent', () => {
     fixture.detectChanges();
     subject.next(Infinity);
     fixture.detectChanges();
+
     expect(find('.edit-delete-menu').length).toBe(0);
   });
 
@@ -160,6 +176,7 @@ describe('FormEditComponent', () => {
     });
     const { find, fixture } = await defaultRender();
     find('.edit-delete-trigger')[0].triggerEventHandler('click', {});
+
     expect(emitted).toBeTrue();
   });
 
@@ -167,6 +184,7 @@ describe('FormEditComponent', () => {
     const { find, fixture } = await defaultRender();
     find('.value-line').triggerEventHandler('dblclick', {});
     fixture.detectChanges();
+
     expect(find('.value-editor input').length).toBe(1);
   });
 });

--- a/src/app/archive-settings/manage-metadata/subcomponents/value-add/add-new-value.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/value-add/add-new-value.component.spec.ts
@@ -51,13 +51,16 @@ describe('AddNewValueComponent', () => {
 
   it('should create', async () => {
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
 
   it('should be able to create a new tag', async () => {
     const { instance, outputs } = await defaultRender();
+
     expect(outputs.tagsUpdate.emit).not.toHaveBeenCalled();
     await instance.createNewTag('abc');
+
     expect(createdTag?.name).toBe('test:abc');
     expect(outputs.tagsUpdate.emit).toHaveBeenCalled();
   });
@@ -66,6 +69,7 @@ describe('AddNewValueComponent', () => {
     const { instance, outputs } = await defaultRender();
     error = true;
     await expectAsync(instance.createNewTag('abc')).toBeRejected();
+
     expect(createdTag).toBeNull();
     expect(messageShown).toBeTrue();
     expect(outputs.tagsUpdate.emit).not.toHaveBeenCalled();

--- a/src/app/archive-settings/manage-metadata/subcomponents/value-edit/value-edit.component.spec.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/value-edit/value-edit.component.spec.ts
@@ -77,12 +77,14 @@ describe('EditValueComponent', () => {
 
   it('should create', async () => {
     const { element } = await defaultRender();
+
     expect(element).toBeTruthy();
   });
 
   it('should be able to delete a tag', async () => {
     const { instance, outputs } = await defaultRender();
     await instance.delete();
+
     expect(deleted).toBeTrue();
     expect(outputs.refreshTags.emit).toHaveBeenCalled();
     expect(outputs.deletedTag.emit).toHaveBeenCalled();
@@ -91,6 +93,7 @@ describe('EditValueComponent', () => {
   it('should be able to edit a value', async () => {
     const { instance, outputs } = await defaultRender();
     await instance.save('potato');
+
     expect(updated).toBeTrue();
     expect(newTagName).toBe('abc:potato');
     expect(outputs.refreshTags.emit).toHaveBeenCalled();
@@ -100,6 +103,7 @@ describe('EditValueComponent', () => {
     const { instance, outputs } = await defaultRender();
     error = true;
     await expectAsync(instance.delete()).toBeRejected();
+
     expect(messageShown).toBeTrue();
     expect(outputs.refreshTags.emit).not.toHaveBeenCalled();
   });
@@ -108,6 +112,7 @@ describe('EditValueComponent', () => {
     const { instance, outputs } = await defaultRender();
     error = true;
     await expectAsync(instance.save('test')).toBeRejected();
+
     expect(messageShown).toBeTrue();
     expect(outputs.refreshTags.emit).not.toHaveBeenCalled();
   });
@@ -116,6 +121,7 @@ describe('EditValueComponent', () => {
     rejectDelete = true;
     const { instance, outputs } = await defaultRender();
     await instance.delete();
+
     expect(outputs.deletedTag.emit).not.toHaveBeenCalled();
   });
 });

--- a/src/app/auth/components/login/login.component.spec.ts
+++ b/src/app/auth/components/login/login.component.spec.ts
@@ -54,6 +54,7 @@ describe('LoginComponent', () => {
       email: '',
       password: TEST_DATA.user.password,
     });
+
     expect(component.loginForm.invalid).toBeTruthy();
     expect(component.loginForm.get('email').errors.required).toBeTruthy();
   });
@@ -64,6 +65,7 @@ describe('LoginComponent', () => {
       email: 'lasld;f;aslkj',
       password: TEST_DATA.user.password,
     });
+
     expect(component.loginForm.invalid).toBeTruthy();
     expect(component.loginForm.get('email').errors.email).toBeTruthy();
   });
@@ -74,6 +76,7 @@ describe('LoginComponent', () => {
       email: TEST_DATA.user.email,
       password: '',
     });
+
     expect(component.loginForm.invalid).toBeTruthy();
     expect(component.loginForm.get('password').errors.required).toBeTruthy();
   });
@@ -84,6 +87,7 @@ describe('LoginComponent', () => {
       email: TEST_DATA.user.email,
       password: 'short',
     });
+
     expect(component.loginForm.invalid).toBeTruthy();
     expect(component.loginForm.get('password').errors.minlength).toBeTruthy();
   });
@@ -94,6 +98,7 @@ describe('LoginComponent', () => {
       email: TEST_DATA.user.email,
       password: TEST_DATA.user.password,
     });
+
     expect(component.loginForm.valid).toBeTruthy();
   });
 });

--- a/src/app/auth/components/signup/signup.component.spec.ts
+++ b/src/app/auth/components/signup/signup.component.spec.ts
@@ -91,6 +91,7 @@ describe('SignupComponent', () => {
       password: TEST_DATA.user.password,
       confirm: TEST_DATA.user.password,
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('email').errors.required).toBeTruthy();
   });
@@ -100,6 +101,7 @@ describe('SignupComponent', () => {
     component.signupForm.patchValue({
       email: 'lasld;f;aslkj',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('email').errors.email).toBeTruthy();
   });
@@ -109,6 +111,7 @@ describe('SignupComponent', () => {
     component.signupForm.patchValue({
       name: '',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('name').errors.required).toBeTruthy();
   });
@@ -137,6 +140,7 @@ describe('SignupComponent', () => {
       password: 'ass',
       confirm: 'ass',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('password').errors.minlength).toBeTruthy();
   });
@@ -147,6 +151,7 @@ describe('SignupComponent', () => {
       password: 'longenough',
       confirm: 'longenougher',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('confirm').errors.mismatch).toBeTruthy();
   });
@@ -162,6 +167,7 @@ describe('SignupComponent', () => {
       password: TEST_DATA.user.password,
       confirm: TEST_DATA.user.password,
     });
+
     expect(component.signupForm.valid).toBeTruthy();
   });
 });

--- a/src/app/auth/components/verify/verify.component.spec.ts
+++ b/src/app/auth/components/verify/verify.component.spec.ts
@@ -70,6 +70,7 @@ describe('VerifyComponent', () => {
 
   it('should create', async () => {
     await init();
+
     expect(component).toBeTruthy();
   });
 
@@ -85,6 +86,7 @@ describe('VerifyComponent', () => {
 
   it('should require only email verification if only email unverified', async () => {
     await init();
+
     expect(component.verifyingEmail).toBeTruthy();
     expect(component.needsEmail).toBeTruthy();
     expect(component.needsPhone).toBeFalsy();
@@ -93,6 +95,7 @@ describe('VerifyComponent', () => {
   it('should require only phone verification if only phone unverified', async () => {
     const unverifiedPhoneData = require('@root/test/responses/auth.verify.unverifiedPhone.success.json');
     await init(unverifiedPhoneData);
+
     expect(component.verifyingPhone).toBeTruthy();
     expect(component.needsPhone).toBeTruthy();
     expect(component.needsEmail).toBeFalsy();
@@ -101,6 +104,7 @@ describe('VerifyComponent', () => {
   it('should require verification of both if both unverified, and verify email first', async () => {
     const unverifiedBothData = require('@root/test/responses/auth.verify.unverifiedBoth.success.json');
     await init(unverifiedBothData);
+
     expect(component.verifyingEmail).toBeTruthy();
     expect(component.needsPhone).toBeTruthy();
     expect(component.needsEmail).toBeTruthy();
@@ -188,6 +192,7 @@ describe('VerifyComponent', () => {
     // Testing environments might not have the site key enabled,
     // so force captchaEnabled to be true.
     component.captchaEnabled = true;
+
     expect(component.captchaPassed).toBeFalsy();
     expect(component.canSendCodes('phone')).toBeFalsy();
 

--- a/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
@@ -47,6 +47,7 @@ describe('AdvancedSettingsComponent', () => {
 
   it('initializes allowSFTPDeletion from the account service', async () => {
     const { instance } = await shallow.render();
+
     expect(instance.allowSFTPDeletion).toEqual(1);
   });
 

--- a/src/app/core/components/archive-payer/archive-payer.component.spec.ts
+++ b/src/app/core/components/archive-payer/archive-payer.component.spec.ts
@@ -46,6 +46,7 @@ describe('ArchivePayerComponent', () => {
     component.hasPayer = false;
     fixture.detectChanges();
     const divElement = fixture.nativeElement.querySelector('#no-payer');
+
     expect(divElement).toBeTruthy();
   });
 
@@ -60,6 +61,7 @@ describe('ArchivePayerComponent', () => {
 
     fixture.detectChanges();
     const divElement = fixture.nativeElement.querySelector('#with-payer');
+
     expect(divElement).toBeTruthy();
   });
 
@@ -68,6 +70,7 @@ describe('ArchivePayerComponent', () => {
 
     fixture.detectChanges();
     const divElement = fixture.nativeElement.querySelector('#with-payer');
+
     expect(divElement).toBeTruthy();
   });
 
@@ -85,6 +88,7 @@ describe('ArchivePayerComponent', () => {
 
     fixture.detectChanges();
     const div = fixture.nativeElement.querySelector('#is-not-payer');
+
     expect(div).toBeTruthy();
   });
 
@@ -99,6 +103,7 @@ describe('ArchivePayerComponent', () => {
 
     fixture.detectChanges();
     const div = fixture.nativeElement.querySelector('#is-payer');
+
     expect(div).toBeTruthy();
   });
 
@@ -116,6 +121,7 @@ describe('ArchivePayerComponent', () => {
     component.ngOnInit();
 
     fixture.detectChanges();
+
     expect(component.hasPayer).toEqual(true);
   });
 
@@ -130,6 +136,7 @@ describe('ArchivePayerComponent', () => {
 
     component.ngOnInit();
     fixture.detectChanges();
+
     expect(component.hasPayer).toEqual(false);
   });
 

--- a/src/app/core/components/archive-switcher/archive-switcher.component.spec.ts
+++ b/src/app/core/components/archive-switcher/archive-switcher.component.spec.ts
@@ -62,6 +62,7 @@ describe('ArchiveSwitcherComponent', () => {
     expect(component.archives.length).toEqual(archives.length);
 
     const element = fixture.debugElement.nativeElement as HTMLElement;
+
     expect(element.querySelectorAll('.archive-list pr-archive-small').length).toEqual(component.archives.length);
   });
 });

--- a/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
+++ b/src/app/core/components/confirm-gift-dialog/confirm-gift-dialog.component.spec.ts
@@ -166,6 +166,7 @@ describe('ConfirmGiftDialogComponent', () => {
     expect(showErrorSpy).toHaveBeenCalledWith(
       'Something went wrong! Please try again.'
     );
+
     expect(giftResultSpy).toHaveBeenCalledWith({
       isSuccessful: false,
       response: null,

--- a/src/app/core/components/gift-storage/gift-storage.component.spec.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.spec.ts
@@ -28,7 +28,8 @@ describe('GiftStorageComponent', () => {
   });
 
   it('should create', async () => {
-    const { instance } = await shallow.render(); // Render the component
+    const { instance } = await shallow.render();
+
     expect(instance).toBeTruthy();
   });
 

--- a/src/app/core/components/invitations-dialog/invitations-dialog.component.spec.ts
+++ b/src/app/core/components/invitations-dialog/invitations-dialog.component.spec.ts
@@ -34,6 +34,7 @@ describe('InvitationsDialog', () => {
 
   it('exists', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
 

--- a/src/app/core/components/left-menu/left-menu.component.spec.ts
+++ b/src/app/core/components/left-menu/left-menu.component.spec.ts
@@ -68,6 +68,7 @@ describe('LeftMenuComponent', () => {
     fixture.detectChanges();
 
     const prArchiveStoragePayerDebugElement = fixture.debugElement.query(By.directive(ArchiveStoragePayerComponent));
+
     expect(prArchiveStoragePayerDebugElement).toBeTruthy();
   }));
 
@@ -80,6 +81,7 @@ describe('LeftMenuComponent', () => {
     fixture.detectChanges();
 
     const prArchiveStoragePayerDebugElement = fixture.debugElement.query(By.directive(ArchiveStoragePayerComponent));
+
     expect(prArchiveStoragePayerDebugElement).toBeFalsy();
   });
 });

--- a/src/app/core/components/main/main.component.spec.ts
+++ b/src/app/core/components/main/main.component.spec.ts
@@ -105,12 +105,14 @@ describe('MainComponent', () => {
 
   it('should create', async () => {
     await init();
+
     expect(component).toBeTruthy();
   });
 
   it('should show a prompt when both email and phone are unverified', async () => {
     const data = require('@root/test/responses/auth.verify.unverifiedBoth.success.json');
     await init(data);
+
     expect(messageService.showMessage).toHaveBeenCalledTimes(1);
     expect(messageService.showMessage).toHaveBeenCalledWith(
       jasmine.stringMatching('email and phone'),
@@ -127,6 +129,7 @@ describe('MainComponent', () => {
   it('should show a prompt when only email is unverified', async () => {
     const data = require('@root/test/responses/auth.verify.unverifiedEmail.success.json');
     await init(data);
+
     expect(messageService.showMessage).toHaveBeenCalledTimes(1);
     expect(messageService.showMessage).toHaveBeenCalledWith(
       jasmine.stringMatching('email'),
@@ -137,6 +140,7 @@ describe('MainComponent', () => {
         sendEmail: true,
       }
     );
+
     expect(messageService.showMessage).not.toHaveBeenCalledWith(
       jasmine.stringMatching('email and phone'),
       jasmine.anything(),
@@ -148,6 +152,7 @@ describe('MainComponent', () => {
   it('should show a prompt when only phone is unverified', async () => {
     const data = require('@root/test/responses/auth.verify.unverifiedPhone.success.json');
     await init(data);
+
     expect(messageService.showMessage).toHaveBeenCalledTimes(1);
     expect(messageService.showMessage).toHaveBeenCalledWith(
       jasmine.stringMatching('phone'),
@@ -158,6 +163,7 @@ describe('MainComponent', () => {
         sendSms: true,
       }
     );
+
     expect(messageService.showMessage).not.toHaveBeenCalledWith(
       jasmine.stringMatching('email and phone'),
       jasmine.anything(),
@@ -169,6 +175,7 @@ describe('MainComponent', () => {
   it('should show a prompt when nothing is unverified', async () => {
     const data = require('@root/test/responses/auth.login.success.json');
     await init(data);
+
     expect(messageService.showMessage).toHaveBeenCalledTimes(0);
   });
 

--- a/src/app/core/components/manage-tags/manage-tags.component.spec.ts
+++ b/src/app/core/components/manage-tags/manage-tags.component.spec.ts
@@ -95,17 +95,20 @@ describe('ManageTagsComponent #manage-tags', () => {
 
   it('should exist', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
 
   it('should have a sorted list of tags', async () => {
     const { find, element } = await defaultRender();
+
     expect(find('.tag').length).toBe(2);
     expect(find('.tag')[0].nativeElement.textContent).toContain('Potato');
   });
 
   it('should have a delete button for each tag', async () => {
     const { find, outputs } = await defaultRender();
+
     expect(find('.delete').length).toBeGreaterThan(0);
     expect(outputs.refreshTags.emit).not.toHaveBeenCalled();
   });
@@ -115,6 +118,7 @@ describe('ManageTagsComponent #manage-tags', () => {
     find('.delete')[0].nativeElement.click();
     await fixture.whenStable();
     await fixture.detectChanges();
+
     expect(deleted).toBeTruthy();
     expect(deletedTag.name).toBe('Potato');
     expect(outputs.refreshTags.emit).toHaveBeenCalled();
@@ -135,6 +139,7 @@ describe('ManageTagsComponent #manage-tags', () => {
 
   it('should have edit buttons for each tag', async () => {
     const { find } = await defaultRender();
+
     expect(find('.edit').length).toBeGreaterThan(0);
   });
 
@@ -142,6 +147,7 @@ describe('ManageTagsComponent #manage-tags', () => {
     const { find, fixture } = await defaultRender();
     find('.edit')[0].nativeElement.click();
     await fixture.detectChanges();
+
     expect(find('.tag input').length).toBe(1);
     expect(find('.tag input').nativeElement.value).toBe('Potato');
   });
@@ -156,6 +162,7 @@ describe('ManageTagsComponent #manage-tags', () => {
     find('.tag input').nativeElement.form.dispatchEvent(new Event('submit'));
     await fixture.whenStable();
     await fixture.detectChanges();
+
     expect(find('.tag input').length).toBe(0);
     expect(renamed).toBeTruthy();
     expect(renamedTag.name).toBe('Starchy Tuber');
@@ -170,12 +177,14 @@ describe('ManageTagsComponent #manage-tags', () => {
     find('.tag input').nativeElement.dispatchEvent(new Event('change'));
     find('.cancel').nativeElement.click();
     await fixture.detectChanges();
+
     expect(find('.cancel').length).toBe(0);
     expect(find('.tag')[0].nativeElement.textContent).not.toContain('Do Not Show Value');
   });
 
   it('should have a null state', async () => {
     const { find } = await defaultRender([]);
+
     expect(find('.tag').length).toBe(0);
     expect(find('.tagList').length).toBe(0);
   });
@@ -186,6 +195,7 @@ describe('ManageTagsComponent #manage-tags', () => {
       find('input.filter').nativeElement.value = val;
       find('input.filter').nativeElement.dispatchEvent(new Event('change'));
       await fixture.detectChanges();
+
       expect(find('.tag').length).toBe(expectedCount);
     }
     it('Trimming input', async () => {
@@ -211,6 +221,7 @@ describe('ManageTagsComponent #manage-tags', () => {
       confirm = clickConfirm;
       find('.delete')[0].nativeElement.click();
       await fixture.whenStable();
+
       expect(deleted).toBe(clickConfirm);
     }
     it('should not delete when you cancel out', async () => {

--- a/src/app/core/components/public-settings/public-settings.component.spec.ts
+++ b/src/app/core/components/public-settings/public-settings.component.spec.ts
@@ -57,31 +57,37 @@ describe('PublicSettingsComponent', () => {
 
   it('should exist', async () => {
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
 
   describe('it should have the proper option checked by default', () => {
     it('on', async () => {
       const { element } = await defaultRender();
+
       expect(element.componentInstance.allowDownloadsToggle).toBeTruthy();
     });
     it('off', async () => {
       const { element } = await defaultRender({
         allowPublicDownload: false,
       } as ArchiveVO);
+
       expect(element.componentInstance.allowDownloadsToggle).toBeFalsy();
     });
   });
 
   it('should save the archive setting when changed', async () => {
     const { element } = await defaultRender();
+
     expect(updated).toBeFalse();
     element.componentInstance.allowDownloadsToggle = 0;
     await element.componentInstance.onAllowDownloadsChange();
+
     expect(updated).toBeTrue();
     expect(updatedDownload).toBeFalse();
     element.componentInstance.allowDownloadsToggle = 1;
     await element.componentInstance.onAllowDownloadsChange();
+
     expect(updatedDownload).toBeTrue();
   });
 
@@ -90,6 +96,7 @@ describe('PublicSettingsComponent', () => {
     throwError = true;
     element.componentInstance.allowDownloadsToggle = 0;
     await element.componentInstance.onAllowDownloadsChange();
+
     expect(updated).toBeFalse();
   });
 });

--- a/src/app/core/components/storage-dialog/storage-dialog.component.spec.ts
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.spec.ts
@@ -87,6 +87,7 @@ describe('StorageDialogComponent', () => {
 
   it('should exist', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
 
@@ -94,6 +95,7 @@ describe('StorageDialogComponent', () => {
     const { instance } = await shallow.render();
     const promoData: PromoVOData = { code: 'promo' };
     await instance.onPromoFormSubmit(promoData);
+
     expect(mockApiService.billing.calledRedeemPromoCode).toBeTruthy();
   });
 
@@ -101,6 +103,7 @@ describe('StorageDialogComponent', () => {
     const { instance } = await shallow.render();
     const promoData: PromoVOData = { code: 'promo' };
     await instance.onPromoFormSubmit(promoData);
+
     expect(mockAccountService.addedStorage).toBe(5000 * 1024 * 1024);
   });
 
@@ -113,6 +116,7 @@ describe('StorageDialogComponent', () => {
     instance.activeTab = 'promo';
     fixture.detectChanges();
     const button = find('.btn-primary');
+
     expect(button.nativeElement.disabled).toBeFalsy();
   });
 

--- a/src/app/core/components/upload-button/upload-button.component.spec.ts
+++ b/src/app/core/components/upload-button/upload-button.component.spec.ts
@@ -44,6 +44,7 @@ describe('UploadButtonComponent', () => {
 
   it('should be hidden when no current folder set', () => {
     const button = fixture.debugElement.nativeElement.querySelector('.btn');
+
     expect(button.hidden).toBeTruthy();
   });
 
@@ -53,6 +54,7 @@ describe('UploadButtonComponent', () => {
       accessRole: 'access.role.owner'
     }));
     await fixture.whenStable();
+
     expect(component.hidden).toBeFalsy();
     expect(component.disabled).toBeFalsy();
   });
@@ -63,6 +65,7 @@ describe('UploadButtonComponent', () => {
       type: 'type.folder.app'
     }));
     await fixture.whenStable();
+
     expect(component.hidden).toBeFalsy();
     expect(component.disabled).toBeTruthy();
   });
@@ -73,6 +76,7 @@ describe('UploadButtonComponent', () => {
       accessRole: 'access.role.viewer'
     }));
     await fixture.whenStable();
+
     expect(component.hidden).toBeFalsy();
     expect(component.disabled).toBeTruthy();
   });

--- a/src/app/core/guards/myfiles.guard.spec.ts
+++ b/src/app/core/guards/myfiles.guard.spec.ts
@@ -31,6 +31,7 @@ describe('MyfilesGuard', () => {
       dummyRoute,
       dummyRouterState('/app/myfiles')
     ) as UrlTree;
+
     expect(tree.toString()).toBe('/app/private');
   });
 
@@ -39,6 +40,7 @@ describe('MyfilesGuard', () => {
       dummyRoute,
       dummyRouterState('/app/myfiles/0001-000m/22')
     ) as UrlTree;
+
     expect(tree.toString()).toBe('/app/private/0001-000m/22');
   });
 });

--- a/src/app/core/services/upload/upload.service.spec.ts
+++ b/src/app/core/services/upload/upload.service.spec.ts
@@ -76,12 +76,14 @@ describe('UploadService', () => {
 
   it('should register upload session start time', () => {
     session.emit(UploadSessionStatus.Start);
+
     expect(service.getUploadStartTime()).not.toBeUndefined();
   });
 
   it('should output upload session elapsed time after upload is finished', () => {
     session.emit(UploadSessionStatus.Start);
     session.emit(UploadSessionStatus.Done);
+
     expect(service.getElapsedUploadTime()).toBeGreaterThan(-1);
   });
 

--- a/src/app/dialog/dialog.component.spec.ts
+++ b/src/app/dialog/dialog.component.spec.ts
@@ -13,6 +13,7 @@ describe('DialogComponent', () => {
 
   it('should create', async () => {
     const { instance } = await shallow.render();
+
     expect(instance).toBeTruthy();
   });
 
@@ -20,14 +21,17 @@ describe('DialogComponent', () => {
     const { instance } = await shallow.render();
     instance.show();
     tick();
+
     expect(instance.isVisible).toBeTrue();
     instance.hide();
+
     expect(instance.isVisible).toBeFalse();
   }));
 
   it('sets options correctly', async () => {
     const { instance } = await shallow.render();
     instance.setOptions({ width: '100px', borderRadius: '10px' });
+
     expect(instance.width).toEqual('100px');
     expect(instance.borderRadius).toEqual('10px');
   });
@@ -35,6 +39,7 @@ describe('DialogComponent', () => {
     const { instance, find } = await shallow.render();
     spyOn(instance, 'onMenuWrapperClick').and.callThrough();
     find('.menu-wrapper').triggerEventHandler('mousedown', {});
+
     expect(instance.onMenuWrapperClick).toHaveBeenCalled();
   });
 });

--- a/src/app/directive/components/directive-display/directive-display.component.spec.ts
+++ b/src/app/directive/components/directive-display/directive-display.component.spec.ts
@@ -39,12 +39,14 @@ describe('DirectiveDisplayComponent', () => {
 
   it('should create', async () => {
     const { find, instance } = await shallow.render();
+
     expect(instance).toBeTruthy();
     expect(find('.error').length).toBe(0);
   });
 
   it('should fill in current archive info', async () => {
     const { find } = await shallow.render();
+
     expect(
       find('.archive-steward-header')[0].nativeElement.innerText
     ).toContain('The Test Archive');
@@ -52,10 +54,12 @@ describe('DirectiveDisplayComponent', () => {
 
   it('should fetch directive info from API', async () => {
     const { find, instance } = await shallow.render();
+
     expect(instance.directive).not.toBeUndefined();
     expect(find('.archive-steward-note')[0].nativeElement.innerText).toContain(
       'Unit Testing!'
     );
+
     expect(find('.archive-steward-email')[0].nativeElement.innerText).toContain(
       'test@example.com'
     );
@@ -64,17 +68,20 @@ describe('DirectiveDisplayComponent', () => {
   it('should format null fields properly', async () => {
     MockDirectiveRepo.reset();
     const { find } = await shallow.render();
+
     expect(find('.not-assigned').length).toBeGreaterThan(0);
   });
 
   it('should format filled out fields properly', async () => {
     const { find } = await shallow.render();
+
     expect(find('.not-assigned').length).toBe(0);
   });
 
   it('should be able to handle API errors when fetching Directive', async () => {
     MockDirectiveRepo.failRequest = true;
     const { find } = await shallow.render();
+
     expect(find('.error').length).toBe(1);
     expect(find('.archive-steward-table').length).toBe(0);
     expect(find('button').nativeElement.disabled).toBeTruthy();
@@ -84,12 +91,14 @@ describe('DirectiveDisplayComponent', () => {
     MockDirectiveRepo.legacyContactName = null;
     MockDirectiveRepo.legacyContactEmail = null;
     const { find } = await shallow.render();
+
     expect(find('.no-plan-warning').length).toBe(1);
     expect(find('button').nativeElement.disabled).toBeTruthy();
   });
 
   it('should not show the "No Plan" warning if the user does have a legacy contact', async () => {
     const { find } = await shallow.render();
+
     expect(find('.no-plan-warning').length).toBe(0);
     expect(find('button').nativeElement.disabled).toBeFalsy();
   });
@@ -97,6 +106,7 @@ describe('DirectiveDisplayComponent', () => {
   it('should be able to handle API errors when fetching Legacy Contact', async () => {
     MockDirectiveRepo.failLegacyRequest = true;
     const { find } = await shallow.render();
+
     expect(find('.error').length).toBe(1);
     expect(find('.archive-steward-table').length).toBe(0);
     expect(find('button').nativeElement.disabled).toBeTruthy();
@@ -108,6 +118,7 @@ describe('DirectiveDisplayComponent', () => {
     const { find } = await shallow.render(
       '<pr-directive-display [checkLegacyContact]="false"></pr-directive-display>'
     );
+
     expect(find('.no-plan-warning').length).toBe(0);
     expect(find('button').nativeElement.disabled).toBeFalsy();
   });
@@ -116,12 +127,14 @@ describe('DirectiveDisplayComponent', () => {
     MockDirectiveRepo.mockStewardEmail = null;
     MockDirectiveRepo.mockNote = null;
     const { find } = await shallow.render();
+
     expect(find('button').nativeElement.innerText).toContain('Assign');
     expect(find('button').nativeElement.innerText).not.toContain('Edit');
   });
 
   it('should say "Edit" for existing directive', async () => {
     const { find } = await shallow.render();
+
     expect(find('button').nativeElement.innerText).toContain('Edit');
   });
 });

--- a/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
@@ -71,11 +71,13 @@ describe('DirectiveEditComponent', () => {
 
   it('should create', async () => {
     const { instance } = await shallow.render();
+
     expect(instance).not.toBeNull();
   });
 
   it('should be able to fill out the directive form', async () => {
     const { instance, find } = await shallow.render();
+
     expect(find('.archive-steward-email').length).toBe(1);
     expect(find('.archive-steward-note').length).toBe(1);
 
@@ -97,6 +99,7 @@ describe('DirectiveEditComponent', () => {
     expect(find('*[disabled], *[readonly]').length).toBe(3);
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(find('*[disabled], *[readonly]').length).toBe(0);
 
     expect(find('.account-not-found').length).toBe(0);
@@ -134,9 +137,11 @@ describe('DirectiveEditComponent', () => {
 
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     fixture.detectChanges();
+
     expect(find('*[disabled], *[readonly]').length).toBe(3);
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(find('*[disabled], *[readonly]').length).toBe(0);
     expect(MockDirectiveRepo.createdDirective).toBeNull();
     expect(MockDirectiveRepo.editedDirective).not.toBeNull();
@@ -150,6 +155,7 @@ describe('DirectiveEditComponent', () => {
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(MockDirectiveRepo.createdDirective).toBeNull();
     expect(find('.account-not-found').length).toBe(0);
     expect(MockMessageService.errorShown).toBeTrue();
@@ -170,6 +176,7 @@ describe('DirectiveEditComponent', () => {
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(MockDirectiveRepo.editedDirective).toBeNull();
     expect(find('.account-not-found').length).toBe(0);
     expect(MockMessageService.errorShown).toBeTrue();
@@ -186,6 +193,7 @@ describe('DirectiveEditComponent', () => {
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(instance.savedDirective.emit).toHaveBeenCalled();
     expect(savedDirective).not.toBeUndefined();
   });
@@ -209,6 +217,7 @@ describe('DirectiveEditComponent', () => {
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(instance.savedDirective.emit).toHaveBeenCalled();
     expect(savedDirective).not.toBeUndefined();
   });
@@ -216,22 +225,27 @@ describe('DirectiveEditComponent', () => {
     const { find, fixture } = await shallow.render();
     fillOutForm(find, '  ', 'Test Memo');
     fixture.detectChanges();
+
     expect(find('.save-btn').nativeElement.disabled).toBeTruthy();
     fillOutForm(find, 'email@example.com', '');
     fixture.detectChanges();
+
     expect(find('.save-btn').nativeElement.disabled).toBeFalsy();
     fillOutForm(find, 'email@example.com', 'memo');
     fixture.detectChanges();
+
     expect(find('.save-btn').nativeElement.disabled).toBeFalsy();
   });
   it('should show an error message if a user with the given email does not exist when creating a directive', async () => {
     MockDirectiveRepo.accountExists = false;
     const { find, fixture, outputs } = await shallow.render();
     fillOutForm(find, 'notfound@example.com', 'Test Memo');
+
     expect(find('.account-not-found').length).toBe(0);
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(MockDirectiveRepo.createdDirective).toBeNull();
     expect(outputs.savedDirective.emit).not.toHaveBeenCalled();
     expect(find('.account-not-found').length).toBe(1);
@@ -239,6 +253,7 @@ describe('DirectiveEditComponent', () => {
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(MockDirectiveRepo.createdDirective).not.toBeNull();
     expect(outputs.savedDirective.emit).toHaveBeenCalled();
     expect(find('.account-not-found').length).toBe(0);
@@ -253,10 +268,12 @@ describe('DirectiveEditComponent', () => {
       bind: { directive },
     });
     fillOutForm(find, 'notfound@example.com', 'Test Memo');
+
     expect(find('.account-not-found').length).toBe(0);
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(MockDirectiveRepo.editedDirective).toBeNull();
     expect(outputs.savedDirective.emit).not.toHaveBeenCalled();
     expect(find('.account-not-found').length).toBe(1);
@@ -264,6 +281,7 @@ describe('DirectiveEditComponent', () => {
     find('.save-btn').nativeElement.dispatchEvent(new Event('click'));
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(MockDirectiveRepo.editedDirective).not.toBeNull();
     expect(outputs.savedDirective.emit).toHaveBeenCalled();
     expect(find('.account-not-found').length).toBe(0);

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
@@ -33,35 +33,43 @@ describe('LegacyContactDisplayComponent', () => {
 
   it('should create', async () => {
     const { instance } = await shallow.render();
+
     expect(instance).toBeTruthy();
   });
   it('should list legacy contact information', async () => {
     MockDirectiveRepo.legacyContactName = 'Test User';
     MockDirectiveRepo.legacyContactEmail = 'test@example.com';
     const { find } = await shallow.render();
+
     expect(find('.legacy-contact-name').length).toBe(1);
     expect(find('.legacy-contact-name')[0].nativeElement.innerText).toContain(
       'Test User'
     );
+
     expect(find('.legacy-contact-email').length).toBe(1);
     expect(find('.legacy-contact-email')[0].nativeElement.innerText).toContain(
       'test@example.com'
     );
+
     expect(find('.not-assigned').length).toBe(0);
   });
   it('should show "not assigned" if no legacy contact', async () => {
     const { find } = await shallow.render();
+
     expect(find('.legacy-contact-name')[0].nativeElement.innerText).toContain(
       'not assigned'
     );
+
     expect(find('.legacy-contact-email')[0].nativeElement.innerText).toContain(
       'not assigned'
     );
+
     expect(find('.not-assigned').length).toBe(2);
   });
   it('should show an error message if there was an error fetching legacy contact', async () => {
     MockDirectiveRepo.throwError = true;
     const { find } = await shallow.render();
+
     expect(find('.legacy-contact-name').length).toBe(0);
     expect(find('.legacy-contact-email').length).toBe(0);
     expect(find('.error').length).toBe(1);
@@ -69,11 +77,13 @@ describe('LegacyContactDisplayComponent', () => {
   it('should emit an event when the edit button is pressed', async () => {
     const { find, fixture, outputs } = await shallow.render();
     find('button').nativeElement.dispatchEvent(new Event('click'));
+
     expect(outputs.beginEdit.emit).toHaveBeenCalled();
   });
   it('should emit an event when the legacy contact is fetched', async () => {
     const { fixture, outputs } = await shallow.render();
     await fixture.whenStable();
+
     expect(outputs.loadedLegacyContact.emit).toHaveBeenCalled();
   });
 });

--- a/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.spec.ts
+++ b/src/app/directive/components/legacy-contact-edit/legacy-contact-edit.component.spec.ts
@@ -55,11 +55,13 @@ describe('LegacyContactEditComponent', () => {
 
   it('should create', async () => {
     const { instance } = await shallow.render();
+
     expect(instance).toBeTruthy();
   });
 
   it('should be able to fill out legacy contact form', async () => {
     const { instance, find } = await shallow.render();
+
     expect(find('.legacy-contact-name').length).toBe(1);
     expect(find('.legacy-contact-email').length).toBe(1);
 
@@ -81,6 +83,7 @@ describe('LegacyContactEditComponent', () => {
     expect(find('*[disabled]').length).toBe(3);
     await fixture.whenStable();
     fixture.detectChanges();
+
     expect(find('*[disabled]').length).toBe(0);
 
     expect(MockDirectiveRepo.savedLegacyContact.email).toBe('save@example.com');
@@ -123,6 +126,7 @@ describe('LegacyContactEditComponent', () => {
     expect(MockDirectiveRepo.savedLegacyContact.name).toBe(
       'Existing Updated Contact'
     );
+
     expect(MockDirectiveRepo.createdLegacyContact).toBeFalse();
     expect(MockDirectiveRepo.updatedLegacyContact).toBeTrue();
   });
@@ -201,14 +205,17 @@ describe('LegacyContactEditComponent', () => {
 
     fillOutForm(find, '', 'Test No Submit');
     fixture.detectChanges();
+
     expect(find('.save-btn[disabled]').length).toBe(1);
 
     fillOutForm(find, 'no-submit@example.com', '');
     fixture.detectChanges();
+
     expect(find('.save-btn[disabled]').length).toBe(1);
 
     fillOutForm(find, 'submit@example.com', 'Submit Now Works');
     fixture.detectChanges();
+
     expect(find('.save-btn[disabled]').length).toBe(0);
   });
 });

--- a/src/app/embed/components/login-embed/login-embed.component.spec.ts
+++ b/src/app/embed/components/login-embed/login-embed.component.spec.ts
@@ -77,6 +77,7 @@ describe('LoginEmbedComponent', () => {
       email: '',
       password: TEST_DATA.user.password,
     });
+
     expect(component.loginForm.invalid).toBeTruthy();
     expect(component.loginForm.get('email').errors.required).toBeTruthy();
   });
@@ -86,6 +87,7 @@ describe('LoginEmbedComponent', () => {
     component.loginForm.patchValue({
       email: 'lasld;f;aslkj',
     });
+
     expect(component.loginForm.invalid).toBeTruthy();
     expect(component.loginForm.get('email').errors.email).toBeTruthy();
   });
@@ -107,6 +109,7 @@ describe('LoginEmbedComponent', () => {
     component.loginForm.patchValue({
       password: 'ass',
     });
+
     expect(component.loginForm.invalid).toBeTruthy();
     expect(component.loginForm.get('password').errors.minlength).toBeTruthy();
   });
@@ -117,6 +120,7 @@ describe('LoginEmbedComponent', () => {
       email: TEST_DATA.user.email,
       password: TEST_DATA.user.password,
     });
+
     expect(component.loginForm.valid).toBeTruthy();
   });
 });

--- a/src/app/embed/components/signup-embed/signup-embed.component.spec.ts
+++ b/src/app/embed/components/signup-embed/signup-embed.component.spec.ts
@@ -78,6 +78,7 @@ describe('SignupEmbedComponent', () => {
       confirm: TEST_DATA.user.password,
       agreed: true,
     });
+
     expect(component.signupForm.invalid).toBeFalsy();
   });
 
@@ -91,6 +92,7 @@ describe('SignupEmbedComponent', () => {
       confirm: TEST_DATA.user.password,
       agreed: true,
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('email').errors.required).toBeTruthy();
   });
@@ -100,6 +102,7 @@ describe('SignupEmbedComponent', () => {
     component.signupForm.patchValue({
       email: 'lasld;f;aslkj',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('email').errors.email).toBeTruthy();
   });
@@ -109,6 +112,7 @@ describe('SignupEmbedComponent', () => {
     component.signupForm.patchValue({
       name: '',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('name').errors.required).toBeTruthy();
   });
@@ -138,6 +142,7 @@ describe('SignupEmbedComponent', () => {
       password: 'ass',
       confirm: 'ass',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('password').errors.minlength).toBeTruthy();
   });
@@ -148,6 +153,7 @@ describe('SignupEmbedComponent', () => {
       password: 'longenough',
       confirm: 'longenougher',
     });
+
     expect(component.signupForm.invalid).toBeTruthy();
     expect(component.signupForm.get('confirm').errors.mismatch).toBeTruthy();
   });
@@ -163,6 +169,7 @@ describe('SignupEmbedComponent', () => {
       password: TEST_DATA.user.password,
       confirm: TEST_DATA.user.password,
     });
+
     expect(component.signupForm.valid).toBeTruthy();
   });
 });

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -80,6 +80,7 @@ describe('EditTagsComponent', () => {
 
   it('should create', async () => {
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
 
@@ -89,14 +90,17 @@ describe('EditTagsComponent', () => {
     expect(
       element.componentInstance.itemTags.find((tag) => tag.name === 'tagOne')
     ).toBeTruthy();
+
     expect(
       element.componentInstance.itemTags.find((tag) => tag.name === 'tagTwo')
     ).toBeTruthy();
+
     expect(
       element.componentInstance.itemTags.find(
         (tag) => tag.name === 'customField:customValueOne'
       )
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.itemTags.find(
         (tag) => tag.name === 'customField:customValueTwo'
@@ -108,16 +112,19 @@ describe('EditTagsComponent', () => {
         (tag) => tag.name === 'tagOne'
       )
     ).toBeTruthy();
+
     expect(
       element.componentInstance.matchingTags.find(
         (tag) => tag.name === 'tagTwo'
       )
     ).toBeTruthy();
+
     expect(
       element.componentInstance.matchingTags.find(
         (tag) => tag.name === 'customField:customValueOne'
       )
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.matchingTags.find(
         (tag) => tag.name === 'customField:customValueTwo'
@@ -131,14 +138,17 @@ describe('EditTagsComponent', () => {
     expect(
       element.componentInstance.itemTags.find((tag) => tag.name === 'tagOne')
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.itemTags.find((tag) => tag.name === 'tagTwo')
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.itemTags.find(
         (tag) => tag.name === 'customField:customValueOne'
       )
     ).toBeTruthy();
+
     expect(
       element.componentInstance.itemTags.find(
         (tag) => tag.name === 'customField:customValueTwo'
@@ -150,16 +160,19 @@ describe('EditTagsComponent', () => {
         (tag) => tag.name === 'tagOne'
       )
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.matchingTags.find(
         (tag) => tag.name === 'tagTwo'
       )
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.matchingTags.find(
         (tag) => tag.name === 'customField:customValueOne'
       )
     ).toBeTruthy();
+
     expect(
       element.componentInstance.matchingTags.find(
         (tag) => tag.name === 'customField:customValueTwo'
@@ -171,6 +184,7 @@ describe('EditTagsComponent', () => {
     const { element } = await defaultRender();
     const tagCreateSpy = spyOn(element.componentInstance.api.tag, 'create');
     await element.componentInstance.onInputEnter('key:value');
+
     expect(element.componentInstance.newTagInputError).toBeTruthy();
     expect(tagCreateSpy).not.toHaveBeenCalled();
   });
@@ -179,6 +193,7 @@ describe('EditTagsComponent', () => {
     const { element } = await defaultRender(defaultItem, 'customMetadata');
     const tagCreateSpy = spyOn(element.componentInstance.api.tag, 'create');
     await element.componentInstance.onInputEnter('keyword');
+
     expect(element.componentInstance.newTagInputError).toBeTruthy();
     expect(tagCreateSpy).not.toHaveBeenCalled();
   });
@@ -194,6 +209,7 @@ describe('EditTagsComponent', () => {
       'click',
       {}
     );
+
     expect(dialogOpenSpy.open).toHaveBeenCalled();
   });
 
@@ -211,6 +227,7 @@ describe('EditTagsComponent', () => {
     fixture.detectChanges();
 
     const focusedElement = document.activeElement as HTMLElement;
+
     expect(focusedElement).toBe(tags[1].nativeElement);
   });
 
@@ -228,6 +245,7 @@ describe('EditTagsComponent', () => {
     fixture.detectChanges();
 
     const focusedElement = document.activeElement as HTMLElement;
+
     expect(focusedElement).toBe(tags[0].nativeElement);
   });
 
@@ -247,6 +265,7 @@ describe('EditTagsComponent', () => {
     fixture.detectChanges();
 
     const focusedElement = document.activeElement as HTMLElement;
+
     expect(focusedElement).toEqual(input.nativeElement);
   });
 });

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
@@ -141,11 +141,13 @@ describe('FileViewerComponent', () => {
 
   it('should create', async () => {
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
 
   it('should have two tags components', async () => {
     const { findComponent } = await defaultRender();
+
     expect(findComponent(TagsComponent)).toHaveFound(2);
   });
 
@@ -155,14 +157,17 @@ describe('FileViewerComponent', () => {
     expect(
       element.componentInstance.keywords.find((tag) => tag.name === 'tagOne')
     ).toBeTruthy();
+
     expect(
       element.componentInstance.keywords.find((tag) => tag.name === 'tagTwo')
     ).toBeTruthy();
+
     expect(
       element.componentInstance.keywords.find(
         (tag) => tag.name === 'customField:customValueOne'
       )
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.keywords.find(
         (tag) => tag.name === 'customField:customValueTwo'
@@ -174,16 +179,19 @@ describe('FileViewerComponent', () => {
         (tag) => tag.name === 'tagOne'
       )
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.customMetadata.find(
         (tag) => tag.name === 'tagTwo'
       )
     ).not.toBeTruthy();
+
     expect(
       element.componentInstance.customMetadata.find(
         (tag) => tag.name === 'customField:customValueOne'
       )
     ).toBeTruthy();
+
     expect(
       element.componentInstance.customMetadata.find(
         (tag) => tag.name === 'customField:customValueTwo'
@@ -194,6 +202,7 @@ describe('FileViewerComponent', () => {
   it('should be able to load multiple record in a folder', async () => {
     setUpMultipleRecords(defaultItem, secondItem);
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
 
@@ -203,6 +212,7 @@ describe('FileViewerComponent', () => {
       { type: 'type.tag.metadata.customField', name: 'test:metadta' },
       { type: 'type.generic.placeholder', name: 'test' },
     ]);
+
     expect(instance.keywords.length).toBe(1);
     expect(instance.customMetadata.length).toBe(1);
   });
@@ -211,6 +221,7 @@ describe('FileViewerComponent', () => {
     const { inject, instance } = await defaultRender();
     const publicProfile = inject(PublicProfileService);
     publicProfile.archiveBs.next(new ArchiveVO({ allowPublicDownload: true }));
+
     expect(instance.allowDownloads).toBeTruthy();
   });
 
@@ -219,6 +230,7 @@ describe('FileViewerComponent', () => {
     const publicProfile = inject(PublicProfileService);
     publicProfile.archiveBs.next(new ArchiveVO({ allowPublicDownload: true }));
     publicProfile.archiveBs.next(null);
+
     expect(instance.allowDownloads).toBeFalsy();
   });
 
@@ -233,6 +245,7 @@ describe('FileViewerComponent', () => {
       setUpMultipleRecords(defaultItem, secondItem);
       const { instance } = await defaultRender();
       keyDown(instance, 'ArrowRight');
+
       expect(instance.currentIndex).toBe(1);
     });
 
@@ -240,6 +253,7 @@ describe('FileViewerComponent', () => {
       setUpMultipleRecords(secondItem, defaultItem);
       const { instance } = await defaultRender();
       keyDown(instance, 'ArrowLeft');
+
       expect(instance.currentIndex).toBe(0);
     });
 
@@ -247,6 +261,7 @@ describe('FileViewerComponent', () => {
       setUpMultipleRecords(secondItem, defaultItem);
       const { instance } = await defaultRender();
       keyDown(instance, 'ArrowRight');
+
       expect(instance.currentIndex).toBe(1);
     });
 
@@ -254,6 +269,7 @@ describe('FileViewerComponent', () => {
       setUpMultipleRecords(defaultItem, secondItem);
       const { instance } = await defaultRender();
       keyDown(instance, 'ArrowLeft');
+
       expect(instance.currentIndex).toBe(0);
     });
 
@@ -266,6 +282,7 @@ describe('FileViewerComponent', () => {
       const { instance } = await defaultRender();
       keyDown(instance, 'ArrowRight');
       keyDown(instance, 'ArrowRight');
+
       expect(instance.currentIndex).toBe(1);
     });
 
@@ -278,6 +295,7 @@ describe('FileViewerComponent', () => {
         const { fixture, instance } = await defaultRender();
         keyDown(instance, 'ArrowRight');
         await fixture.whenStable();
+
         expect(navigatedUrl).toContain('1234-1234');
       });
       it('should navigate after the record has been fetched if it is still fetching', async () => {
@@ -292,6 +310,7 @@ describe('FileViewerComponent', () => {
         keyDown(instance, 'ArrowRight');
         secondItemFetching.archiveNbr = '1234-1234';
         await fixture.whenStable();
+
         expect(navigatedUrl).toContain('1234-1234');
       });
     });
@@ -330,6 +349,7 @@ describe('FileViewerComponent', () => {
       phrase: string
     ) {
       const url = instance.getPdfUrl();
+
       expect(url).toBeTruthy();
       expect(
         instance.sanitizer.sanitize(SecurityContext.RESOURCE_URL, url)
@@ -349,12 +369,14 @@ describe('FileViewerComponent', () => {
 
     it('will have a falsy document URL if it is not a document', async () => {
       const { instance } = await defaultRender();
+
       expect(instance.getPdfUrl()).toBeFalsy();
     });
 
     it('will have a falsy document URL if the URL is falsy', async () => {
       setUpCurrentRecord('pdf', false);
       const { instance } = await defaultRender();
+
       expect(instance.getPdfUrl()).toBeFalsy();
     });
   });
@@ -367,12 +389,14 @@ describe('FileViewerComponent', () => {
     it('can close the file viewer', async () => {
       const { instance } = await defaultRender();
       instance.close();
+
       expect(navigatedUrl).toContain('.');
     });
 
     it('can finish editing', async () => {
       const { instance } = await defaultRender();
       await instance.onFinishEditing('displayName', 'Test');
+
       expect(savedProperty.name).toBe('displayName');
       expect(savedProperty.value).toBe('Test');
     });
@@ -382,6 +406,7 @@ describe('FileViewerComponent', () => {
       const { fixture, instance } = await defaultRender();
       instance.onLocationClick();
       await fixture.whenStable();
+
       expect(openedDialogs).toContain('location');
     });
 
@@ -390,6 +415,7 @@ describe('FileViewerComponent', () => {
       const { fixture, instance } = await defaultRender();
       instance.onLocationClick();
       await fixture.whenStable();
+
       expect(openedDialogs).not.toContain('location');
     });
 
@@ -398,6 +424,7 @@ describe('FileViewerComponent', () => {
       const { fixture, instance } = await defaultRender();
       instance.onTagsClick('keyword');
       await fixture.whenStable();
+
       expect(openedDialogs).toContain('tags');
     });
 
@@ -406,6 +433,7 @@ describe('FileViewerComponent', () => {
       const { fixture, instance } = await defaultRender();
       instance.onTagsClick('keyword');
       await fixture.whenStable();
+
       expect(openedDialogs).not.toContain('tags');
     });
 
@@ -413,6 +441,7 @@ describe('FileViewerComponent', () => {
       const { fixture, instance } = await defaultRender();
       instance.onDownloadClick();
       await fixture.whenStable();
+
       expect(downloaded).toBeTrue();
     });
   });

--- a/src/app/file-browser/components/publish/publish.component.spec.ts
+++ b/src/app/file-browser/components/publish/publish.component.spec.ts
@@ -53,6 +53,7 @@ describe('PublishComponent', () => {
 
   it('should create', async () => {
     const { instance } = await shallow.render();
+
     expect(instance).toBeTruthy();
   });
 

--- a/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.spec.ts
+++ b/src/app/file-browser/components/sharing-dialog/sharing-dialog.component.spec.ts
@@ -209,6 +209,7 @@ describe('SharingDialogComponent', () => {
     component.approveShare(component.pendingShares[0]);
 
     tick();
+
     expect(apiSpy).toHaveBeenCalled();
     expect(showMessageSpy).toHaveBeenCalled();
     expect(component.pendingShares.length).toBe(0);
@@ -231,6 +232,7 @@ describe('SharingDialogComponent', () => {
     component.onAccessChange(share);
 
     tick();
+
     expect(confirmSpy).toHaveBeenCalled();
     expect(component.shares.length).toBe(1);
     expect(component.shares[0].accessRole).toBe(shareViewer.accessRole);
@@ -250,6 +252,7 @@ describe('SharingDialogComponent', () => {
     component.onAccessChange(share);
 
     tick();
+
     expect(confirmSpy).toHaveBeenCalled();
     expect(component.shares.length).toBe(1);
     expect(component.shares[0].accessRole).toBe(shareViewer.accessRole);
@@ -287,6 +290,7 @@ describe('SharingDialogComponent - Shallow Rendering', () => {
     const { instance } = await shallow.render();
 
     await instance.generateShareLink();
+
     expect(instance.shareLink.shareUrl).toContain('example.com');
 
     instance.linkDefaultAccessRole = 'access.role.owner';
@@ -294,6 +298,7 @@ describe('SharingDialogComponent - Shallow Rendering', () => {
       'defaultAccessRole',
       'access.role.owner'
     );
+
     expect(instance.shareLink.defaultAccessRole).toBe('access.role.owner');
   });
 });

--- a/src/app/gallery/components/gallery-header/gallery-header.component.spec.ts
+++ b/src/app/gallery/components/gallery-header/gallery-header.component.spec.ts
@@ -37,10 +37,12 @@ describe('GalleryHeaderComponent', () => {
   });
   it('should render', async () => {
     const { element } = await defaultRender();
+
     expect(element).not.toBeNull();
   });
   it('should render back button when logged in', async () => {
     const { find, element, fixture } = await defaultRender();
+
     expect(find('.return-btn').length).toBeGreaterThan(0);
   });
 });

--- a/src/app/notifications/services/notification.service.spec.ts
+++ b/src/app/notifications/services/notification.service.spec.ts
@@ -88,6 +88,7 @@ describe('NotificationService', () => {
     loggedInSpy = spyOn(accountService, 'isLoggedIn').and.returnValue(false);
 
     service = TestBed.inject(NotificationService);
+
     expect(service).toBeTruthy();
   });
 
@@ -96,6 +97,7 @@ describe('NotificationService', () => {
     getNotificationsSpy = spyOn(apiService.notification, 'getNotifications');
 
     service = TestBed.inject(NotificationService);
+
     expect(service.notifications).toBeDefined();
     expect(service.notifications.length).toBe(0);
     expect(getNotificationsSpy).not.toHaveBeenCalled();
@@ -133,6 +135,7 @@ describe('NotificationService', () => {
     service = TestBed.inject(NotificationService);
 
     flushMicrotasks();
+
     expect(service.newNotificationCount).toBeGreaterThan(0);
     const countBeforeNew = service.newNotificationCount;
 
@@ -165,6 +168,7 @@ describe('NotificationService', () => {
     service = TestBed.inject(NotificationService);
 
     flushMicrotasks();
+
     expect(service.newNotificationCount).toBeGreaterThan(0);
     countBeforeMarkSeen = service.newNotificationCount;
 
@@ -197,6 +201,7 @@ describe('NotificationService', () => {
     service = TestBed.inject(NotificationService);
 
     flushMicrotasks();
+
     expect(service.newNotificationCount).toBeGreaterThan(0);
     countBeforeMarkSeen = service.newNotificationCount;
 

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
@@ -56,10 +56,12 @@ describe('CreateNewArchiveComponent #onboarding', () => {
   });
   it('should exist', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
   it('should emit a progress bar change event on mount', async () => {
     const { outputs } = await shallow.render();
+
     expect(outputs.progress.emit).toHaveBeenCalledWith(0);
   });
   it('should NOT show disabled-overlay when selectedValue is truthy', async () => {
@@ -72,6 +74,7 @@ describe('CreateNewArchiveComponent #onboarding', () => {
     fixture.detectChanges();
 
     const overlayDiv = find('.disabled-overlay');
+
     expect(overlayDiv.length).toBe(0);
   });
 
@@ -86,6 +89,7 @@ describe('CreateNewArchiveComponent #onboarding', () => {
     fixture.detectChanges();
 
     const button = find('.chart-path').nativeElement;
+
     expect(button.disabled).toBe(false);
   });
 
@@ -94,6 +98,7 @@ describe('CreateNewArchiveComponent #onboarding', () => {
 
     instance.selectedValue = '';
     const overlayDiv = find('.disabled-overlay');
+
     expect(overlayDiv.length).toBe(1);
   });
 

--- a/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
@@ -76,27 +76,34 @@ describe('OnboardingComponent #onboarding', () => {
   });
   it('should exist', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
   it('should load the create new archive screen as default', async () => {
     const { find, fixture } = await shallow.render();
     fixture.detectChanges();
+
     expect(find('pr-create-new-archive')).toHaveFoundOne();
   });
   it('can change screens', async () => {
     const { find, fixture } = await shallow.render();
+
     expect(find('pr-create-new-archive')).toHaveFoundOne();
     fixture.detectChanges();
+
     expect(find('pr-welcome-screen')).toHaveFound(0);
   });
   it('stores the newly created archive', async () => {
     const { element, find, fixture } = await shallow.render();
+
     expect(element.componentInstance.currentArchive).toBeUndefined();
     fixture.detectChanges();
 
     const child = find('pr-create-new-archive');
+
     expect(child).toHaveFoundOne();
     child.triggerEventHandler('createdArchive', new ArchiveVO({}));
+
     expect(element.componentInstance.currentArchive).not.toBeUndefined();
   });
   it('stores an accepted archive invitation', async () => {
@@ -124,6 +131,7 @@ describe('OnboardingComponent #onboarding', () => {
     if (instance.pendingArchives.length > 0) {
       expect(instance.screen).toBe(OnboardingScreen.pendingArchives);
     }
+
     expect(find('pr-welcome-screen')).toHaveFoundOne();
     find('pr-welcome-screen').triggerEventHandler(
       'selectInvitation',
@@ -131,16 +139,19 @@ describe('OnboardingComponent #onboarding', () => {
     );
     fixture.detectChanges();
     await fixture.whenStable();
+
     expect(
       element.componentInstance.selectedPendingArchive
     ).not.toBeUndefined();
   });
   it('can be tested with debugging component', async () => {
     const { element } = await shallow.render();
+
     expect(element.componentInstance.pendingArchives.length).toBe(0);
     element.componentInstance.setState({
       pendingArchives: [new ArchiveVO({})],
     });
+
     expect(element.componentInstance.pendingArchives.length).toBe(1);
   });
 

--- a/src/app/onboarding/components/welcome-screen/welcome-screen.component.spec.ts
+++ b/src/app/onboarding/components/welcome-screen/welcome-screen.component.spec.ts
@@ -21,6 +21,7 @@ describe('WelcomeScreenComponent #onboarding', () => {
   });
   it('should exist', async () => {
     const { find } = await defaultRender();
+
     expect(find('.welcome-screen')).toHaveFoundOne();
   });
   it('should display a list of pending archives if they are available', async () => {
@@ -30,6 +31,7 @@ describe('WelcomeScreenComponent #onboarding', () => {
       }),
     ];
     const { find } = await defaultRender(pendingArchives);
+
     expect(find('pr-archive-small')).toHaveFoundOne();
   });
   it('should pass up a selected archive', async () => {
@@ -40,6 +42,7 @@ describe('WelcomeScreenComponent #onboarding', () => {
     ];
     const { element, find, outputs } = await defaultRender(pendingArchives);
     element.componentInstance.selectPendingArchive(pendingArchives[0]);
+
     expect(outputs.selectInvitation.emit).toHaveBeenCalledWith(
       pendingArchives[0]
     );

--- a/src/app/pledge/components/new-pledge/new-pledge.component.spec.ts
+++ b/src/app/pledge/components/new-pledge/new-pledge.component.spec.ts
@@ -84,6 +84,7 @@ describe('NewPledgeComponent', () => {
 
   it('should exist', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
 

--- a/src/app/route-history/route-history.service.spec.ts
+++ b/src/app/route-history/route-history.service.spec.ts
@@ -45,6 +45,7 @@ describe('RouteHistoryService', () => {
   it('should provide the current route after navigation', async () => {
     expectRoutesToBeUndefined();
     await router.navigate(['/home']);
+
     expect(service.currentRoute).toEqual('/home');
     expect(service.previousRoute).toBeUndefined();
   });
@@ -53,6 +54,7 @@ describe('RouteHistoryService', () => {
     expectRoutesToBeUndefined();
     await router.navigate(['/home']);
     await router.navigate(['/profile']);
+
     expect(service.currentRoute).toEqual('/profile');
     expect(service.previousRoute).toEqual('/home');
   });

--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -108,6 +108,7 @@ describe('SearchService', () => {
         { name: '"Potato"', tagId: 1 },
       ]);
       const searchTokens = service.parseSearchTerm('tag:""Potato""');
+
       expect(searchTokens[1].length).toBe(1);
       expect(searchTokens[1][0].tagId).toBe(1);
     });
@@ -144,6 +145,7 @@ describe('SearchService', () => {
         { displayName: 'Do not match' },
       ]);
       const searchResults = search('Potato');
+
       expect(searchResults.length).toBe(1);
       expect(searchResults[0].displayName).toBe('Potato');
     });
@@ -155,6 +157,7 @@ describe('SearchService', () => {
             'VeryLongDisplayNameThatNeedsToUseFuzzySearchAndIgnoreLocationPortrait',
         },
       ]);
+
       expect(search('Portrait').length).toBe(1);
     });
 
@@ -163,6 +166,7 @@ describe('SearchService', () => {
         { displayName: 'Potato' },
         { displayName: 'Potato Two' },
       ]);
+
       expect(search('Potato', 1).length).toBe(1);
     });
 
@@ -191,6 +195,7 @@ describe('SearchService', () => {
     it('can search a populated tag service', () => {
       tags.setTags([{ name: 'Potato' }, { name: 'DoNotMatch' }]);
       const searchResults = search('Potato');
+
       expect(searchResults.length).toBe(1);
       expect(searchResults[0].name).toBe('Potato');
     });
@@ -199,11 +204,13 @@ describe('SearchService', () => {
       tags.setTags([
         { name: 'VeryLongTagNameThatProbablyWontEvenHappenInProduction' },
       ]);
+
       expect(search('Production').length).toBe(1);
     });
 
     it('should limit results if limit is provided', () => {
       tags.setTags([{ name: 'Potato' }, { name: 'Potato Two' }]);
+
       expect(search('Potato', 1).length).toBe(1);
     });
 
@@ -215,12 +222,14 @@ describe('SearchService', () => {
   it('can do a complete archive search', () => {
     const apiSpy = spyOn(api.search, 'itemsByNameObservable');
     service.getResultsInCurrentArchive('Test', []);
+
     expect(apiSpy).toHaveBeenCalled();
   });
 
   it('can do a public archive search', () => {
     const apiSpy = spyOn(api.search, 'itemsByNameInPublicArchiveObservable');
     service.getResultsInPublicArchive('Test', [], '1');
+
     expect(apiSpy).toHaveBeenCalled();
   });
 
@@ -229,6 +238,7 @@ describe('SearchService', () => {
     const searchTokens = service.parseSearchTerm(
       'tag:""A Multiword Tag"" "potato"'
     );
+
     expect(searchTokens[1].length).toBe(0);
   });
 

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.spec.ts
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.spec.ts
@@ -89,6 +89,7 @@ describe('CreateAccountDialogComponent', () => {
   ) {
     const element: HTMLElement = fixture.nativeElement;
     const button = element.querySelector(selector) as HTMLAnchorElement;
+
     expect(button).toBeTruthy();
     return button;
   }
@@ -100,6 +101,7 @@ describe('CreateAccountDialogComponent', () => {
   ) {
     expect(link.href).toContain(expectedPath);
     link.click();
+
     expect(dialogRefSpy).toHaveBeenCalled();
   }
 });

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.spec.ts
@@ -40,11 +40,13 @@ describe('BreadcrumbsComponent', () => {
 
   it('should create', async () => {
     await init();
+
     expect(component).toBeTruthy();
   });
 
   it('should update the current folder when dataService is updated', async () => {
     await init();
+
     expect(component.currentFolder).toBeFalsy();
     const testFolder = new FolderVO({
       pathAsText: ['test'],
@@ -52,8 +54,10 @@ describe('BreadcrumbsComponent', () => {
       pathAsFolder_linkId: [1]
     });
     dataService.setCurrentFolder(testFolder);
+
     expect(component.currentFolder).toEqual(testFolder);
     dataService.setCurrentFolder();
+
     expect(component.currentFolder).toBeFalsy();
   });
 
@@ -65,8 +69,10 @@ describe('BreadcrumbsComponent', () => {
       pathAsFolder_linkId: [1, 2, 3]
     });
     dataService.setCurrentFolder(testFolder);
+
     expect(component.breadcrumbs.length).toBe(testFolder.pathAsArchiveNbr.length);
     const expectedUrl = `/private/${testFolder.pathAsArchiveNbr[1]}/${testFolder.pathAsFolder_linkId[1]}`;
+
     expect(component.breadcrumbs[1].routerPath).toEqual(expectedUrl);
   });
 
@@ -78,6 +84,7 @@ describe('BreadcrumbsComponent', () => {
       pathAsFolder_linkId: [1, 2, 3]
     });
     TestBed.inject(DataService).setCurrentFolder(testFolder);
+
     expect(component.breadcrumbs[0].routerPath).toEqual('/private');
     expect(component.breadcrumbs[1].routerPath).toContain('/private');
   });
@@ -90,6 +97,7 @@ describe('BreadcrumbsComponent', () => {
       pathAsFolder_linkId: [1, 2, 3]
     });
     TestBed.inject(DataService).setCurrentFolder(testFolder);
+
     expect(component.breadcrumbs[0].routerPath).toEqual('/apps');
     expect(component.breadcrumbs[1].routerPath).toContain('/apps');
   });
@@ -102,6 +110,7 @@ describe('BreadcrumbsComponent', () => {
       pathAsFolder_linkId: [1, 2, 3]
     });
     TestBed.inject(DataService).setCurrentFolder(testFolder);
+
     expect(component.breadcrumbs[0].routerPath).toEqual('/shares');
     expect(component.breadcrumbs[0].text).toEqual('Shares');
     expect(component.breadcrumbs[1].routerPath).toContain('/shares/test2');

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
@@ -73,6 +73,7 @@ describe('InlineValueEditComponent', () => {
     );
     displayElement.triggerEventHandler('click', null);
     tick();
+
     expect(component.isEditing).toBeTruthy();
   }));
 
@@ -80,6 +81,7 @@ describe('InlineValueEditComponent', () => {
     component.displayValue = TEST_TEXT;
     component.startEdit();
     const inputElement = fixture.debugElement.query(By.css('input'));
+
     expect(document.activeElement).toBe(inputElement.nativeElement);
   });
 
@@ -104,6 +106,7 @@ describe('InlineValueEditComponent', () => {
     const saveSpy = spyOn(component.doneEditing, 'emit');
     component.displayValue = TEST_TEXT;
     component.startEdit();
+
     expect(component.isEditing).toBeTruthy();
 
     component.cancel();
@@ -120,6 +123,7 @@ describe('InlineValueEditComponent', () => {
 
     const inputElem = component.inputElementRef
       .nativeElement as HTMLInputElement;
+
     expect(document.activeElement).toBe(inputElem);
     inputElem.value = 'new value!';
 
@@ -144,6 +148,7 @@ describe('InlineValueEditComponent', () => {
 
     fixture.detectChanges();
     component.startEdit();
+
     expect(component.isEditing).toBeFalsy();
   });
 
@@ -215,6 +220,7 @@ describe('InlineValueEditComponent', () => {
     const offset = applyTimezoneOffset(nowUtc, record.TimezoneVO);
 
     component.startEdit();
+
     expect(component.ngbDate).toBeDefined();
     expect(component.ngbDate.day).toBe(momentFormatNum(offset, 'D'));
     expect(component.ngbTime).toBeDefined();
@@ -236,6 +242,7 @@ describe('InlineValueEditComponent', () => {
     const offset = moment.utc().local();
 
     component.startEdit();
+
     expect(component.ngbDate).toBeDefined();
     expect(component.ngbDate.day).toBe(momentFormatNum(offset, 'D'));
     expect(component.ngbTime).toBeDefined();
@@ -272,6 +279,7 @@ describe('InlineValueEditComponent', () => {
     component.datePicker.dateSelect.emit(newDate);
 
     const utcDt = getUtcMomentFromDTString(component.editValue as string);
+
     expect(Number(utcDt.format('D'))).toEqual(11);
     expect(Number(utcDt.format('M'))).toEqual(newDate.month);
     expect(Number(utcDt.format('H'))).toEqual(2);
@@ -297,6 +305,7 @@ describe('InlineValueEditComponent', () => {
     fixture.detectChanges();
 
     const timePicker = fixture.debugElement.query(By.css('ngb-timepicker'));
+
     expect(component.dateOnly).toBeFalse();
     expect(timePicker).toBeTruthy();
   });
@@ -323,6 +332,7 @@ describe('InlineValueEditComponent', () => {
     fixture.detectChanges();
 
     const timePicker = fixture.debugElement.query(By.css('ngb-timepicker'));
+
     expect(component.dateOnly).toBeTrue();
     expect(timePicker).toBeNull();
   });
@@ -382,6 +392,7 @@ describe('InlineValueEditComponent', () => {
     expect(component.editValue).not.toBe(component.displayValue);
 
     const utcDt = getUtcMomentFromDTString(component.editValue as string);
+
     expect(Number(utcDt.format('D'))).toEqual(13);
     expect(Number(utcDt.format('h'))).toEqual(3);
   });
@@ -398,6 +409,7 @@ describe('InlineValueEditComponent', () => {
     fixture.detectChanges();
 
     await fixture.whenStable();
+
     expect(nameContainer.classList).toContain('is-name-hovered');
   });
 });

--- a/src/app/shared/components/message/message.component.spec.ts
+++ b/src/app/shared/components/message/message.component.spec.ts
@@ -32,6 +32,7 @@ describe('MessageComponent', () => {
 
   it('should accept a navigation url', () => {
     component.display('test', null, testUrl);
+
     expect(component.navigateTo).toEqual(testUrl);
   });
 
@@ -41,6 +42,7 @@ describe('MessageComponent', () => {
     spyOn(component, 'dismiss');
 
     component.display('test');
+
     expect(component.navigateTo).toBeFalsy();
 
     component.onClick();

--- a/src/app/shared/components/new-archive-form/new-archive-form.component.spec.ts
+++ b/src/app/shared/components/new-archive-form/new-archive-form.component.spec.ts
@@ -44,12 +44,15 @@ describe('NewArchiveFormComponent #onboarding', () => {
   });
   it('should create', async () => {
     const { element } = await shallow.render();
+
     expect(element).not.toBeNull();
   });
   it('should not submit when form is invalid', async () => {
     const { find, fixture, outputs } = await shallow.render();
+
     expect(find('button').nativeElement.disabled).toBeFalsy();
     find('button').nativeElement.click();
+
     expect(outputs.success.emit).not.toHaveBeenCalled();
     expect(outputs.error.emit).not.toHaveBeenCalled();
   });
@@ -59,6 +62,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     fixture.detectChanges();
     find('button').nativeElement.click();
     fixture.detectChanges();
+
     expect(find('button').nativeElement.disabled).toBeTruthy();
   });
   it('should create a new archive on submit', async () => {
@@ -67,6 +71,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     fixture.detectChanges();
     find('button').nativeElement.click();
     fixture.detectChanges();
+
     expect(created).toBeTrue();
   });
   it('should output new archiveVO when submitted', async () => {
@@ -75,6 +80,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     fixture.detectChanges();
     find('button').nativeElement.click();
     await fixture.whenStable();
+
     expect(outputs.success.emit).toHaveBeenCalled();
     expect(createdArchive.fullName).toBe('Test User');
     expect(createdArchive.type).toBe('type.archive.person');
@@ -88,6 +94,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     fixture.detectChanges();
     find('button').nativeElement.click();
     await fixture.whenStable();
+
     expect(outputs.error.emit).toHaveBeenCalled();
     expect(outputs.success.emit).not.toHaveBeenCalled();
   });
@@ -95,9 +102,11 @@ describe('NewArchiveFormComponent #onboarding', () => {
     const { find, fixture } = await shallow.render('<pr-new-archive-form [showRelations]="true"></pr-new-archive-form>');
     fillOutForm(find);
     fixture.detectChanges();
+
     expect(find('select[name="relation"]')).toHaveFoundOne();
     find('input[type="radio"]')[1].nativeElement.click();
     fixture.detectChanges();
+
     expect(find('select[name="relation"]')).not.toHaveFoundOne();
   });
   it('should submit relationType to API if it is enabled', async () => {
@@ -108,6 +117,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     element.componentInstance.formData.relationType = 'relation.other';
     find('button').nativeElement.click();
     await fixture.whenStable();
+
     expect(createdArchive.relationType).toBe('relation.other');
   });
 });

--- a/src/app/shared/components/tags/tags.component.spec.ts
+++ b/src/app/shared/components/tags/tags.component.spec.ts
@@ -38,11 +38,13 @@ describe('TagsComponent', () => {
     const debugTypeElement = fixture.debugElement.query(
       By.css('.customMetadataField')
     );
+
     expect(debugTypeElement).toBeTruthy();
 
     const debugValueElement = fixture.debugElement.query(
       By.css('.customMetadataValue')
     );
+
     expect(debugValueElement).toBeTruthy();
   });
 
@@ -54,6 +56,7 @@ describe('TagsComponent', () => {
     component.ngOnChanges();
     fixture.detectChanges();
     const addTags = fixture.debugElement.query(By.css('.not-empty'));
+
     expect(addTags).toBeTruthy();
   });
 });

--- a/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
@@ -115,6 +115,7 @@ describe('ThumbnailComponent', () => {
     hostComponent.item.update(leanItem);
     hostComponent.item.dataStatus = leanItem.dataStatus;
     fixture.detectChanges();
+
     expect(component['currentThumbUrl']).toEqual(image200);
   });
 
@@ -126,6 +127,7 @@ describe('ThumbnailComponent', () => {
     hostComponent.item.update(fullItem);
     hostComponent.item.dataStatus = fullItem.dataStatus;
     fixture.detectChanges();
+
     expect(component['targetThumbWidth']).toEqual(200);
     expect(component['currentThumbUrl']).toEqual(image200);
   });
@@ -138,6 +140,7 @@ describe('ThumbnailComponent', () => {
     hostComponent.item.update(fullItem);
     hostComponent.item.dataStatus = fullItem.dataStatus;
     fixture.detectChanges();
+
     expect(component['targetThumbWidth']).toEqual(200);
     expect(component['currentThumbUrl']).toEqual(image200);
   });
@@ -150,6 +153,7 @@ describe('ThumbnailComponent', () => {
     hostComponent.item.update(fullItem);
     hostComponent.item.dataStatus = fullItem.dataStatus;
     fixture.detectChanges();
+
     expect(component['targetThumbWidth']).toEqual(200);
     expect(component['currentThumbUrl']).toEqual(image200);
   });
@@ -160,6 +164,7 @@ describe('ThumbnailComponent', () => {
     hostComponent.item.update(fullItem);
     hostComponent.item.dataStatus = fullItem.dataStatus;
     fixture.detectChanges();
+
     expect(component['targetThumbWidth']).toEqual(500);
     expect(component['currentThumbUrl']).toEqual(image500);
   });
@@ -170,11 +175,13 @@ describe('ThumbnailComponent', () => {
     hostComponent.item.update(fullItem);
     hostComponent.item.dataStatus = fullItem.dataStatus;
     fixture.detectChanges();
+
     expect(component['targetThumbWidth']).toEqual(500);
     expect(component['currentThumbUrl']).toEqual(image500);
 
     hostComponent.item = fullItem2;
     fixture.detectChanges();
+
     expect(component['targetThumbWidth']).toEqual(500);
     expect(component['currentThumbUrl']).toEqual(fullItem2.thumbURL500);
   });
@@ -186,6 +193,7 @@ describe('ThumbnailComponent', () => {
     hostComponent.item.type = 'type.record.archive';
     hostComponent.item.dataStatus = fullItem.dataStatus;
     fixture.detectChanges();
+
     expect(component['element'].querySelector('fa-icon')).not.toBeNull();
     expect(
       component['element'].querySelector('.pr-thumbnail-image:not([hidden])')

--- a/src/app/shared/pipes/get-alt-text.pipe.spec.ts
+++ b/src/app/shared/pipes/get-alt-text.pipe.spec.ts
@@ -17,6 +17,7 @@ describe('GetAltTextPipe', () => {
     value.altText = 'alt text';
     value.displayName = 'display name';
     const result = pipe.transform(value);
+
     expect(result).toEqual('alt text');
   });
 
@@ -24,6 +25,7 @@ describe('GetAltTextPipe', () => {
     const value = new RecordVO({});
     value.displayName = 'display name';
     const result = pipe.transform(value);
+
     expect(result).toEqual('display name');
   });
 });

--- a/src/app/shared/pipes/pr-constants.pipe.spec.ts
+++ b/src/app/shared/pipes/pr-constants.pipe.spec.ts
@@ -6,18 +6,21 @@ const prConstants = new PrConstantsService();
 describe('PrConstantsPipe', () => {
   it('create an instance', () => {
     const pipe = new PrConstantsPipe(prConstants);
+
     expect(pipe).toBeTruthy();
   });
 
   it('translates an existing string', () => {
     const pipe = new PrConstantsPipe(prConstants);
     const constantString = 'access.role.viewer';
+
     expect(pipe.transform(constantString)).toEqual('Viewer');
   });
 
   it('returns string unchanged if missing', () => {
     const pipe = new PrConstantsPipe(prConstants);
     const constantString = 'access.role.missing';
+
     expect(pipe.transform(constantString)).toEqual(constantString);
   });
 });

--- a/src/app/shared/pipes/pr-date.pipe.spec.ts
+++ b/src/app/shared/pipes/pr-date.pipe.spec.ts
@@ -5,6 +5,7 @@ import { PrDatePipe } from './pr-date.pipe';
 describe('PrDatePipe', () => {
   it('create an instance', () => {
     const pipe = new PrDatePipe();
+
     expect(pipe).toBeTruthy();
   });
 

--- a/src/app/shared/pipes/prepend-protocol.pipe.spec.ts
+++ b/src/app/shared/pipes/prepend-protocol.pipe.spec.ts
@@ -14,12 +14,14 @@ describe('PrependProtocolPipe', () => {
   it('prepends https:// to a url', () => {
     const url = 'www.example.com';
     const result = pipe.transform(url);
+
     expect(result).toBe('https://www.example.com');
   });
 
   it('does not prepend the protocol to an url that already has it', () => {
     const url = 'https://www.example.com';
     const result = pipe.transform(url);
+
     expect(result).toBe('https://www.example.com');
   });
 });

--- a/src/app/shared/pipes/public-link.pipe.spec.ts
+++ b/src/app/shared/pipes/public-link.pipe.spec.ts
@@ -20,6 +20,7 @@ describe('PublicLinkPipe', () => {
       archiveNbr: '0001-00gh',
     });
     const route = pipe.transform(folder);
+
     expect(route).toBeDefined();
     expect(route.endsWith('/p/archive/0001-0000/0001-00gh/100')).toBeTruthy();
   });
@@ -36,6 +37,7 @@ describe('PublicLinkPipe', () => {
       archiveNbr: '0001-00gp',
     });
     const route = pipe.transform(record);
+
     expect(route).toBeDefined();
     expect(
       route.endsWith('/p/archive/0001-0000/0001-meow/1234/record/0001-00gp')
@@ -49,6 +51,7 @@ describe('PublicLinkPipe', () => {
     });
 
     const url = new URL(pipe.transform(folder));
+
     expect(url.pathname).not.toContain('//');
   });
 });

--- a/src/app/shared/pipes/public-route.pipe.spec.ts
+++ b/src/app/shared/pipes/public-route.pipe.spec.ts
@@ -4,6 +4,7 @@ import { PublicRoutePipe } from './public-route.pipe';
 describe('PublicRoutePipe', () => {
   it('create an instance', () => {
     const pipe = new PublicRoutePipe();
+
     expect(pipe).toBeTruthy();
   });
 
@@ -14,6 +15,7 @@ describe('PublicRoutePipe', () => {
       archiveNbr: '0001-00gh'
     });
     const route = pipe.transform(folder);
+
     expect(route).toBeDefined();
     expect(route).toEqual(['/p', 'archive', '0001-0000', folder.archiveNbr, folder.folder_linkId ]);
   });
@@ -31,6 +33,7 @@ describe('PublicRoutePipe', () => {
       archiveNbr: '0001-00gp'
     });
     const route = pipe.transform(record);
+
     expect(route).toBeDefined();
     expect(route).toEqual(['/p', 'archive', '0001-0000', '0001-meow', '1234', 'record', record.archiveNbr ]);
   });

--- a/src/app/shared/services/account/tests/account.service.spec.ts
+++ b/src/app/shared/services/account/tests/account.service.spec.ts
@@ -123,6 +123,7 @@ describe('AccountService', () => {
 
   it('should be created', () => {
     const { instance } = shallow.createService();
+
     expect(instance).toBeTruthy();
   });
 
@@ -140,6 +141,7 @@ describe('AccountService', () => {
       '',
       true
     );
+
     expect(account.primaryEmail).toEqual('test@permanent.org');
   });
 
@@ -178,6 +180,7 @@ describe('AccountService', () => {
     instance.setAccount(account);
 
     await instance.verifyEmail('sampleToken');
+
     expect(instance.getAccount().emailStatus).toBe('status.auth.verified');
     expect(instance.getAccount().keepLoggedIn).toBeTrue();
     expect(trackerSpy).toHaveBeenCalled();
@@ -197,6 +200,7 @@ describe('AccountService', () => {
     instance.setAccount(account);
 
     await instance.verifyEmail('sampleToken');
+
     expect(instance.getAccount().phoneStatus).toBe('status.auth.verified');
     expect(instance.getAccount().keepLoggedIn).toBeTrue();
     expect(trackerSpy).toHaveBeenCalled();
@@ -213,6 +217,7 @@ describe('AccountService', () => {
       new File([], 'test.txt'),
     ]);
     await instance.deductAccountStorage(200);
+
     expect(instance.getAccount().spaceLeft).toEqual(99800);
   });
 

--- a/src/app/shared/services/api/account.repo.spec.ts
+++ b/src/app/shared/services/api/account.repo.spec.ts
@@ -49,9 +49,11 @@ describe('AccountRepo', () => {
         true
       )
       .subscribe((response) =>
+
         expect(response.primaryEmail).toEqual('test@permanent.org')
       );
     const req = httpMock.expectOne(`${environment.apiUrl}/account/post`);
+
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Request-Version')).toBe('2');
     req.flush(expected);

--- a/src/app/shared/services/api/account.repo.spec.ts
+++ b/src/app/shared/services/api/account.repo.spec.ts
@@ -48,10 +48,9 @@ describe('AccountRepo', () => {
         true,
         true
       )
-      .subscribe((response) =>
-
-        expect(response.primaryEmail).toEqual('test@permanent.org')
-      );
+      .subscribe((response) => {
+        expect(response.primaryEmail).toEqual('test@permanent.org');
+      });
     const req = httpMock.expectOne(`${environment.apiUrl}/account/post`);
 
     expect(req.request.method).toBe('POST');

--- a/src/app/shared/services/api/archive.repo.spec.ts
+++ b/src/app/shared/services/api/archive.repo.spec.ts
@@ -46,6 +46,7 @@ describe('ArchiveRepo', () => {
     repo.get([TEST_DATA.archive, TEST_DATA_2.archive])
     .then((response) => {
       const archives = response.getArchiveVOs();
+
       expect(archives.length).toBe(2);
 
       expect(archives[0].archiveId).toEqual(TEST_DATA.archive.archiveId);
@@ -65,6 +66,7 @@ describe('ArchiveRepo', () => {
     .then((response: ArchiveResponse) => {
       const archives = response.getArchiveVOs();
       const count = expected.Results[0].data.length;
+
       expect(archives.length).toBe(count);
     });
 

--- a/src/app/shared/services/api/auth.repo.spec.ts
+++ b/src/app/shared/services/api/auth.repo.spec.ts
@@ -115,6 +115,7 @@ describe('AuthRepo', () => {
           .get('/v2/health', {}, Object, { useStelaDomain: false })
           .toPromise();
         const req2 = httpMock.expectOne(`${environment.apiUrl}/v2/health`);
+
         expect(req2.request.headers.get('Authorization')).toBe(
           'Bearer test_token'
         );
@@ -150,6 +151,7 @@ describe('AuthRepo', () => {
     const req = httpMock.expectOne(
       `${environment.apiUrl}/account/changePassword`
     );
+
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.has('Request-Version')).toBeFalse();
     req.flush({
@@ -173,6 +175,7 @@ describe('AuthRepo', () => {
     const req = httpMock.expectOne(
       `${environment.apiUrl}/account/changePassword`
     );
+
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Request-Version')).toBe('2');
     req.flush({});

--- a/src/app/shared/services/api/base.repo.spec.ts
+++ b/src/app/shared/services/api/base.repo.spec.ts
@@ -15,6 +15,7 @@ describe('BaseRepo', () => {
 
   it('should be initialized with HttpService ', inject([HttpService], (http: HttpService) => {
     const authRepo = new BaseRepo(http);
+
     expect(authRepo.http).toEqual(jasmine.any(HttpService));
   }));
 });

--- a/src/app/shared/services/api/directive.repo.spec.ts
+++ b/src/app/shared/services/api/directive.repo.spec.ts
@@ -51,6 +51,7 @@ describe('DirectiveRepo', () => {
     });
 
     const req = httpMock.expectOne(apiUrl('/v2/directive/archive/1234'));
+
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.has('Authorization')).toBeTrue();
     req.flush([
@@ -91,6 +92,7 @@ describe('DirectiveRepo', () => {
     });
 
     const req = httpMock.expectOne(apiUrl('/v2/directive'));
+
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.has('Authorization')).toBeTrue();
     req.flush(new Directive(newDirectiveData));
@@ -110,6 +112,7 @@ describe('DirectiveRepo', () => {
     });
 
     const req = httpMock.expectOne(apiUrl('/v2/directive/test-id'));
+
     expect(req.request.method).toBe('PUT');
     expect(req.request.headers.has('Authorization')).toBeTrue();
     expect(req.request.body.directiveId).toBeUndefined();
@@ -132,6 +135,7 @@ describe('DirectiveRepo', () => {
     });
 
     const req = httpMock.expectOne(apiUrl('/v2/legacy-contact'));
+
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.has('Authorization')).toBeTrue();
     req.flush([
@@ -159,6 +163,7 @@ describe('DirectiveRepo', () => {
       });
 
     const req = httpMock.expectOne(apiUrl('/v2/legacy-contact'));
+
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.has('Authorization')).toBeTrue();
     expect(req.request.body.name).toBe('New User');
@@ -187,6 +192,7 @@ describe('DirectiveRepo', () => {
       });
 
     const req = httpMock.expectOne(apiUrl('/v2/legacy-contact/test-id'));
+
     expect(req.request.method).toBe('PUT');
     expect(req.request.headers.has('Authorization')).toBeTrue();
     expect(req.request.body.name).toBe('Updated User');

--- a/src/app/shared/services/data/data.service.spec.ts
+++ b/src/app/shared/services/data/data.service.spec.ts
@@ -43,6 +43,7 @@ describe('DataService', () => {
     [DataService],
     (service: DataService) => {
       service.setCurrentFolder(testFolder);
+
       expect(service.currentFolder).toEqual(testFolder);
     }
   ));
@@ -51,6 +52,7 @@ describe('DataService', () => {
     [DataService],
     (service: DataService) => {
       service.setCurrentFolder(null);
+
       expect(service.currentFolder).toBeNull();
       const subscription = service.currentFolderChange.subscribe(
         (newFolder: FolderVO) => {
@@ -67,10 +69,12 @@ describe('DataService', () => {
     (service: DataService) => {
       service.setCurrentFolder(testFolder);
       service.registerItem(testRecord);
+
       expect(service.getItemByFolderLinkId(testRecord.folder_linkId)).toBe(
         testRecord
       );
       service.unregisterItem(testRecord);
+
       expect(
         service.getItemByFolderLinkId(testRecord.folder_linkId)
       ).toBeUndefined();

--- a/src/app/shared/services/device/device.service.spec.ts
+++ b/src/app/shared/services/device/device.service.spec.ts
@@ -15,6 +15,7 @@ describe('DeviceService', () => {
 
   it('should be created', async () => {
     const { instance } = await shallow.createService();
+
     expect(instance).toBeTruthy();
   });
 
@@ -26,6 +27,7 @@ describe('DeviceService', () => {
     });
 
     const { instance } = await shallow.createService();
+
     expect(instance.isMobileWidth()).toBeTrue();
   });
 
@@ -36,6 +38,7 @@ describe('DeviceService', () => {
     });
 
     const { instance } = await shallow.createService();
+
     expect(instance.isMobile()).toBeTrue();
   });
 
@@ -46,6 +49,7 @@ describe('DeviceService', () => {
     });
 
     const { instance } = await shallow.createService();
+
     expect(instance.isIos()).toBeTrue();
   });
 
@@ -56,6 +60,7 @@ describe('DeviceService', () => {
     shallow = shallow.mock(CookieService, cookieService);
 
     const { instance } = await shallow.createService();
+
     expect(instance.didOptOut()).toBeTrue();
   });
 
@@ -67,6 +72,7 @@ describe('DeviceService', () => {
     });
 
     const { instance } = await shallow.createService();
+
     expect(instance.getViewMessageForEventTracking()).toEqual('Screen View');
   });
 });

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -79,6 +79,7 @@ describe('HttpV2Service', () => {
       });
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+
     expect(request.request.method).toEqual('POST');
     expect(request.request.headers.get('Request-Version')).toBe('2');
     expect(request.request.headers.has('Authorization')).toBeFalse();
@@ -89,6 +90,7 @@ describe('HttpV2Service', () => {
     service.post('/api/v2/health', {}, null, { csrf: true }).toPromise();
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+
     expect(request.request.body.csrf).toBeDefined();
     request.flush({ status: 'available' });
   });
@@ -99,6 +101,7 @@ describe('HttpV2Service', () => {
       .toPromise()
       .then((response) => {
         const resp = response[0];
+
         expect(resp instanceof HealthResponse).toBeTrue();
         expect(resp.status).toBe('available');
         expect(resp.constructorCalled).toBeTrue();
@@ -138,6 +141,7 @@ describe('HttpV2Service', () => {
     const request = httpTestingController.expectOne(
       apiUrl('/api/v2/health?test=potato')
     );
+
     expect(request.request.method).toBe('GET');
     expect(request.request.headers.get('Request-Version')).toBe('2');
     expect(request.request.body).toBeNull();
@@ -156,6 +160,7 @@ describe('HttpV2Service', () => {
     const request = httpTestingController.expectOne(
       apiUrl('/api/v2/health?id=32')
     );
+
     expect(request.request.method).toBe('DELETE');
     expect(request.request.headers.get('Request-Version')).toBe('2');
     expect(request.request.body).toBeNull();
@@ -172,6 +177,7 @@ describe('HttpV2Service', () => {
       });
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+
     expect(request.request.method).toBe('PUT');
     expect(request.request.headers.get('Request-Version')).toBe('2');
     expect(request.request.body).not.toBeNull();
@@ -182,6 +188,7 @@ describe('HttpV2Service', () => {
     service.get('/api/v2/health', {}).toPromise();
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+
     expect(request.request.method).toBe('GET');
     request.flush({});
   });
@@ -191,6 +198,7 @@ describe('HttpV2Service', () => {
     service.get('/api/v2/health').toPromise();
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+
     expect(request.request.headers.get('Authorization')).toBe(
       'Bearer auth_token'
     );
@@ -214,6 +222,7 @@ describe('HttpV2Service', () => {
     service.post('/api/v2/health', {}, HealthResponse).toPromise();
 
     const req = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+
     expect(req.request.body.csrf).toBeUndefined();
   });
 

--- a/src/app/shared/services/iframe/iframe.service.spec.ts
+++ b/src/app/shared/services/iframe/iframe.service.spec.ts
@@ -7,6 +7,7 @@ describe('IFrameService', () => {
 
   it('should be created', () => {
     const service: IFrameService = TestBed.get(IFrameService);
+
     expect(service).toBeTruthy();
   });
 });

--- a/src/app/shared/services/pr-constants/pr-constants.service.spec.ts
+++ b/src/app/shared/services/pr-constants/pr-constants.service.spec.ts
@@ -25,11 +25,13 @@ describe('PrConstantsService', () => {
 
   it('should translate a constants string', () => {
     const translateString = 'warning.auth.token_does_not_match';
+
     expect(service.translate(translateString)).toEqual(CONSTANTS.warning.auth.token_does_not_match);
   });
 
   it('should return the original string if not found', () => {
     const translateString = 'fake.translate.string';
+
     expect(service.translate(translateString)).toEqual(translateString);
   });
 });

--- a/src/app/shared/services/storage/storage.service.spec.ts
+++ b/src/app/shared/services/storage/storage.service.spec.ts
@@ -26,6 +26,7 @@ describe('StorageService', () => {
   it('should save a string value to SessionStorage', inject([StorageService], (service: StorageService) => {
     if (window.sessionStorage) {
       service.session.set(testKey, testValue);
+
       expect(window.sessionStorage.getItem(testKey)).toEqual(testValue);
     }
   }));
@@ -33,6 +34,7 @@ describe('StorageService', () => {
   it('should retrieve a string value from SessionStorage', inject([StorageService], (service: StorageService) => {
     if (window.sessionStorage) {
       window.sessionStorage.setItem(testKey, testValue);
+
       expect(service.session.get(testKey)).toEqual(testValue);
     }
   }));
@@ -40,6 +42,7 @@ describe('StorageService', () => {
   it('should save an object value to SessionStorage', inject([StorageService], (service: StorageService) => {
     if (window.sessionStorage) {
       service.session.set(testKey, testObject);
+
       expect(JSON.parse(window.sessionStorage.getItem(testKey))).toEqual(testObject);
     }
   }));
@@ -47,6 +50,7 @@ describe('StorageService', () => {
   it('should retrieve an object value from SessionStorage', inject([StorageService], (service: StorageService) => {
     if (window.sessionStorage) {
       window.sessionStorage.setItem(testKey, JSON.stringify(testObject));
+
       expect(service.session.get(testKey)).toEqual(testObject);
     }
   }));
@@ -60,9 +64,11 @@ describe('StorageService', () => {
   it('should handle storing a null-ish value to SessionStorage', inject([StorageService], (service: StorageService) => {
     if (window.sessionStorage) {
       service.session.set(testKey, null);
+
       expect(service.session.get(testKey)).toBeNull();
       service.session.delete(testKey);
       service.session.set(testKey, false);
+
       expect(service.session.get(testKey)).toBeFalsy();
     }
   }));
@@ -70,12 +76,14 @@ describe('StorageService', () => {
   it('should save a value to memory when SessionStorage not present', inject([StorageService], (service: StorageService) => {
     service.session.setStoreInMemory(true);
     service.session.set(testKey, testValue);
+
     expect(service.session.get(testKey)).toEqual(testValue);
   }));
 
   it('should save a string value to LocalStorage', inject([StorageService], (service: StorageService) => {
     if (window.localStorage) {
       service.local.set(testKey, testValue);
+
       expect(window.localStorage.getItem(testKey)).toEqual(testValue);
     }
   }));
@@ -83,6 +91,7 @@ describe('StorageService', () => {
   it('should retrieve a string value from LocalStorage', inject([StorageService], (service: StorageService) => {
     if (window.localStorage) {
       window.localStorage.setItem(testKey, testValue);
+
       expect(service.local.get(testKey)).toEqual(testValue);
     }
   }));
@@ -90,6 +99,7 @@ describe('StorageService', () => {
   it('should save an object value to SessionStorage', inject([StorageService], (service: StorageService) => {
     if (window.localStorage) {
       service.local.set(testKey, testObject);
+
       expect(JSON.parse(window.localStorage.getItem(testKey))).toEqual(testObject);
     }
   }));
@@ -97,6 +107,7 @@ describe('StorageService', () => {
   it('should retrieve an object value from SessionStorage', inject([StorageService], (service: StorageService) => {
     if (window.localStorage) {
       window.localStorage.setItem(testKey, JSON.stringify(testObject));
+
       expect(service.local.get(testKey)).toEqual(testObject);
     }
   }));
@@ -104,6 +115,7 @@ describe('StorageService', () => {
   it('should save a value to memory when LocalStorage not present', inject([StorageService], (service: StorageService) => {
     service.local.setStoreInMemory(true);
     service.local.set(testKey, testValue);
+
     expect(service.local.get(testKey)).toEqual(testValue);
   }));
 });

--- a/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
+++ b/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
@@ -28,6 +28,7 @@ describe('ThumbnailCache', () => {
   });
   it('should return an empty FolderThumbData object for uncached thumbnail', () => {
     const thumbs = cache.getThumbnail(folder);
+
     expect(thumbs.folderThumb200).toBeDefined();
     expect(thumbs.folderThumb500).toBeDefined();
     expect(thumbs.folderContentsType).toBe(FolderContentsType.BROKEN_THUMBNAILS);
@@ -35,18 +36,21 @@ describe('ThumbnailCache', () => {
   it('should be able to set and get thumbnail', () => {
     cache.saveThumbnail(folder, folderThumbData);
     const {folderThumb200, folderThumb500} = cache.getThumbnail(folder);
+
     expect(folderThumb200).toBe(folderThumbData.folderThumb200);
     expect(folderThumb500).toBe(folderThumbData.folderThumb500);
   });
   it('should be able to test if thumbnail is cached', () => {
     expect(cache.hasThumbnail(folder)).toBeFalse();
     cache.saveThumbnail(folder, folderThumbData);
+
     expect(cache.hasThumbnail(folder)).toBeTrue();
   });
   it('should use session storage to get this data', () => {
     cache.saveThumbnail(folder, folderThumbData);
     const cache2 = new ThumbnailCache(storage);
     const {folderThumb200, folderThumb500} = cache2.getThumbnail(folder);
+
     expect(folderThumb200).toBe(folderThumbData.folderThumb200);
     expect(folderThumb500).toBe(folderThumbData.folderThumb500);
   });
@@ -62,6 +66,7 @@ describe('ThumbnailCache', () => {
       folder.folder_linkId += 1;
       cache.saveThumbnail(folder, folderThumbData);
       const {folderThumb200, folderThumb500, folderContentsType} = cache.getThumbnail(folder);
+
       expect(folderThumb200).toBe('');
       expect(folderThumb500).toBe('');
       expect(folderContentsType).toBe(icon);
@@ -69,18 +74,21 @@ describe('ThumbnailCache', () => {
   });
   it('should be able to clear the cache for a specific folder', () => {
     cache.invalidateFolder(1234);
+
     expect(cache.hasThumbnail(folder)).toBeFalse();
   });
   describe('malformed session storage', () => {
     it('handles completely invalid session storage value', () => {
       storage.session.set('folderThumbnailCache', 'potato');
       cache = new ThumbnailCache(storage);
+
       expect(cache.hasThumbnail(folder)).toBeFalse();
     });
     it('handles linking another value instead of a string tuple', () => {
       storage.session.set('folderThumbnailCache', [[1234, 'potato']]);
       cache = new ThumbnailCache(storage);
       let thumbz = cache.getThumbnail(folder);
+
       expect(thumbz.folderThumb200).toBe('');
       expect(thumbz.folderThumb500).toBe('');
       expect(thumbz.folderContentsType).toBe(FolderContentsType.BROKEN_THUMBNAILS);
@@ -90,6 +98,7 @@ describe('ThumbnailCache', () => {
       storage.session.set('folderThumbnailCache', [[1234, [3.141, {}]]]);
       cache = new ThumbnailCache(storage);
       let thumbz = cache.getThumbnail(folder);
+
       expect(thumbz.folderThumb200).toBe('3.141');
       expect(thumbz.folderThumb500).toBe('[object Object]');
       expect(thumbz.folderContentsType).toBe(FolderContentsType.NORMAL);


### PR DESCRIPTION
This lint rule requires a newline before any `expect` statements, probably to separate the "arrange/act" parts of each test with the "assert" part. This one was automatically fixed with eslint.