### PR TITLE
PEr-8276 inform user about upload destination

### DIFF
--- a/src/app/core/components/upload-progress/upload-progress.component.html
+++ b/src/app/core/components/upload-progress/upload-progress.component.html
@@ -21,11 +21,7 @@
   >
     <div class="current-file">
       Uploading {{ currentItem.file.name }} to
-      {{
-        isUploadingFolder
-          ? folderTargetName + '/' + currentItem.parentFolder.displayName
-          : currentItem.parentFolder.displayName
-      }}
+      {{ folderTargetName }}
     </div>
     <div class="file-count">
       <strong>{{ fileCount.current }}</strong> of

--- a/src/app/core/components/upload-progress/upload-progress.component.html
+++ b/src/app/core/components/upload-progress/upload-progress.component.html
@@ -21,7 +21,11 @@
   >
     <div class="current-file">
       Uploading {{ currentItem.file.name }} to
-      {{ currentItem.parentFolder.displayName }}
+      {{
+        isUploadingFolder
+          ? folderTargetName + '/' + currentItem.parentFolder.displayName
+          : currentItem.parentFolder.displayName
+      }}
     </div>
     <div class="file-count">
       <strong>{{ fileCount.current }}</strong> of

--- a/src/app/core/components/upload-progress/upload-progress.component.html
+++ b/src/app/core/components/upload-progress/upload-progress.component.html
@@ -1,10 +1,9 @@
 <!-- @format -->
 <div
-  class="upload-wrapper"
+  class="upload-wrapper target-folder"
   [ngClass]="{
     visible: visible,
-    fade: useFade,
-    'target-folder': isUploadingInNestedFolder
+    fade: useFade
   }"
 >
   <div
@@ -20,10 +19,7 @@
     class="upload"
     *ngIf="status === UploadSessionStatus.InProgress && currentItem"
   >
-    <div *ngIf="!isUploadingInNestedFolder" class="current-file">
-      {{ currentItem.file.name }}
-    </div>
-    <div *ngIf="isUploadingInNestedFolder" class="current-file">
+    <div class="current-file">
       Uploading {{ currentItem.file.name }} to
       {{ currentItem.parentFolder.displayName }}
     </div>

--- a/src/app/core/components/upload-progress/upload-progress.component.html
+++ b/src/app/core/components/upload-progress/upload-progress.component.html
@@ -1,5 +1,12 @@
 <!-- @format -->
-<div class="upload-wrapper" [ngClass]="{ visible: visible, fade: useFade }">
+<div
+  class="upload-wrapper"
+  [ngClass]="{
+    visible: visible,
+    fade: useFade,
+    'target-folder': isUploadingInNestedFolder
+  }"
+>
   <div
     class="upload-progress"
     [ngStyle]="{ transform: getProgressTransform() }"
@@ -13,7 +20,13 @@
     class="upload"
     *ngIf="status === UploadSessionStatus.InProgress && currentItem"
   >
-    <div class="current-file">{{ currentItem.file.name }}</div>
+    <div *ngIf="!isUploadingInNestedFolder" class="current-file">
+      {{ currentItem.file.name }}
+    </div>
+    <div *ngIf="isUploadingInNestedFolder" class="current-file">
+      Uploading {{ currentItem.file.name }} to
+      {{ currentItem.parentFolder.displayName }}
+    </div>
     <div class="file-count">
       <strong>{{ fileCount.current }}</strong> of
       <strong>{{ fileCount.total }}</strong>

--- a/src/app/core/components/upload-progress/upload-progress.component.scss
+++ b/src/app/core/components/upload-progress/upload-progress.component.scss
@@ -120,5 +120,11 @@ $easing: $tweaked-ease;
     &.visible {
       opacity: 1;
     }
+
+    &.target-folder {
+      width: fit-content;
+      padding: 1.5rem 5rem;
+      transform: translate(-40%, -100%);
+    }
   }
 }

--- a/src/app/core/components/upload-progress/upload-progress.component.spec.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.spec.ts
@@ -1,0 +1,99 @@
+/* @format */
+import { UploadService } from '@core/services/upload/upload.service';
+import { CoreModule } from '@core/core.module';
+import { EventEmitter } from '@angular/core';
+import { Shallow } from 'shallow-render';
+import {
+  UploadProgressEvent,
+  UploadSessionStatus,
+} from '@core/services/upload/upload.session';
+import { UploadProgressComponent } from './upload-progress.component';
+import { UploadItem } from '@core/services/upload/uploadItem';
+import { FolderVO } from '@models/index';
+
+class MockUploadSession {
+  public progress = new EventEmitter<UploadProgressEvent>();
+}
+
+const mockUploadService = {
+  registerComponent: () => {},
+  uploadSession: new MockUploadSession(),
+};
+
+describe('UploadProgressComponent', () => {
+  let shallow: Shallow<UploadProgressComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(UploadProgressComponent, CoreModule).mock(
+      UploadService,
+      mockUploadService
+    );
+  });
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+    expect(instance).toBeTruthy();
+  });
+
+  it('should become visible when show() is called', async () => {
+    const { instance } = await shallow.render();
+    instance.show();
+    expect(instance.visible).toBe(true);
+  });
+
+  it('should display the correct file name and count', async () => {
+    const { find, instance, fixture } = await shallow.render();
+
+    const mockContent = new Uint8Array(10000);
+    const progressEvent = {
+      item: new UploadItem(
+        new File([mockContent], 'testfile.txt'),
+        new FolderVO({
+          displayName: 'testfolder',
+          pathAsArchiveNbr: ['1'],
+        })
+      ),
+      statistics: { current: 1, total: 5, completed: 0, error: 0 },
+      sessionStatus: UploadSessionStatus.InProgress,
+    };
+
+    mockUploadService.uploadSession.progress.emit(progressEvent);
+
+    fixture.detectChanges();
+
+    expect(find('.current-file').nativeElement.textContent).toContain(
+      'testfile.txt'
+    );
+    const fileCountElements = find('.file-count strong');
+    expect(fileCountElements[0].nativeElement.textContent).toEqual('1');
+    expect(fileCountElements[1].nativeElement.textContent).toEqual('5');
+  });
+
+  it('should display the correct file name and the folder when dragging the file into a folder', async () => {
+    const { find, instance, fixture } = await shallow.render();
+
+    const mockContent = new Uint8Array(10000);
+    const progressEvent = {
+      item: new UploadItem(
+        new File([mockContent], 'testfile.txt'),
+        new FolderVO({
+          displayName: 'testfolder',
+          pathAsArchiveNbr: [],
+        })
+      ),
+      statistics: { current: 1, total: 5, completed: 0, error: 0 },
+      sessionStatus: UploadSessionStatus.InProgress,
+    };
+
+    mockUploadService.uploadSession.progress.emit(progressEvent);
+
+    fixture.detectChanges();
+
+    expect(find('.current-file').nativeElement.textContent.trim()).toBe(
+      `Uploading ${progressEvent.item.file.name} to ${progressEvent.item.parentFolder.displayName}`
+    );
+    const fileCountElements = find('.file-count strong');
+    expect(fileCountElements[0].nativeElement.textContent).toEqual('1');
+    expect(fileCountElements[1].nativeElement.textContent).toEqual('5');
+  });
+});

--- a/src/app/core/components/upload-progress/upload-progress.component.spec.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.spec.ts
@@ -43,37 +43,6 @@ describe('UploadProgressComponent', () => {
     expect(instance.visible).toBe(true);
   });
 
-  it('should display the correct file name and count', async () => {
-    const { find, instance, fixture } = await shallow.render();
-
-    const mockContent = new Uint8Array(10000);
-    const progressEvent = {
-      item: new UploadItem(
-        new File([mockContent], 'testfile.txt'),
-        new FolderVO({
-          displayName: 'testfolder',
-          pathAsArchiveNbr: ['1'],
-        })
-      ),
-      statistics: { current: 1, total: 5, completed: 0, error: 0 },
-      sessionStatus: UploadSessionStatus.InProgress,
-    };
-
-    mockUploadService.uploadSession.progress.emit(progressEvent);
-
-    fixture.detectChanges();
-
-    expect(find('.current-file').nativeElement.textContent).toContain(
-      'testfile.txt'
-    );
-
-    const fileCountElements = find('.file-count strong');
-
-    expect(fileCountElements[0].nativeElement.textContent).toEqual('1');
-
-    expect(fileCountElements[1].nativeElement.textContent).toEqual('5');
-  });
-
   it('should display the correct file name and the folder when dragging the file into a folder', async () => {
     const { find, instance, fixture } = await shallow.render();
 

--- a/src/app/core/components/upload-progress/upload-progress.component.spec.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.spec.ts
@@ -7,9 +7,9 @@ import {
   UploadProgressEvent,
   UploadSessionStatus,
 } from '@core/services/upload/upload.session';
-import { UploadProgressComponent } from './upload-progress.component';
 import { UploadItem } from '@core/services/upload/uploadItem';
 import { FolderVO } from '@models/index';
+import { UploadProgressComponent } from './upload-progress.component';
 
 class MockUploadSession {
   public progress = new EventEmitter<UploadProgressEvent>();
@@ -32,12 +32,14 @@ describe('UploadProgressComponent', () => {
 
   it('should create', async () => {
     const { instance } = await shallow.render();
+
     expect(instance).toBeTruthy();
   });
 
   it('should become visible when show() is called', async () => {
     const { instance } = await shallow.render();
     instance.show();
+
     expect(instance.visible).toBe(true);
   });
 
@@ -64,8 +66,11 @@ describe('UploadProgressComponent', () => {
     expect(find('.current-file').nativeElement.textContent).toContain(
       'testfile.txt'
     );
+
     const fileCountElements = find('.file-count strong');
+
     expect(fileCountElements[0].nativeElement.textContent).toEqual('1');
+
     expect(fileCountElements[1].nativeElement.textContent).toEqual('5');
   });
 
@@ -92,8 +97,11 @@ describe('UploadProgressComponent', () => {
     expect(find('.current-file').nativeElement.textContent.trim()).toBe(
       `Uploading ${progressEvent.item.file.name} to ${progressEvent.item.parentFolder.displayName}`
     );
+
     const fileCountElements = find('.file-count strong');
+
     expect(fileCountElements[0].nativeElement.textContent).toEqual('1');
+
     expect(fileCountElements[1].nativeElement.textContent).toEqual('5');
   });
 });

--- a/src/app/core/components/upload-progress/upload-progress.component.spec.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.spec.ts
@@ -18,6 +18,12 @@ class MockUploadSession {
 const mockUploadService = {
   registerComponent: () => {},
   uploadSession: new MockUploadSession(),
+  getTargetFolderId: () => {
+    return 10;
+  },
+  getTargetFolderName: () => {
+    return 'testfolder';
+  },
 };
 
 describe('UploadProgressComponent', () => {
@@ -53,6 +59,7 @@ describe('UploadProgressComponent', () => {
         new FolderVO({
           displayName: 'testfolder',
           pathAsArchiveNbr: [],
+          folderId: 10,
         })
       ),
       statistics: { current: 1, total: 5, completed: 0, error: 0 },
@@ -65,6 +72,38 @@ describe('UploadProgressComponent', () => {
 
     expect(find('.current-file').nativeElement.textContent.trim()).toBe(
       `Uploading ${progressEvent.item.file.name} to ${progressEvent.item.parentFolder.displayName}`
+    );
+
+    const fileCountElements = find('.file-count strong');
+
+    expect(fileCountElements[0].nativeElement.textContent).toEqual('1');
+
+    expect(fileCountElements[1].nativeElement.textContent).toEqual('5');
+  });
+
+  it('should display the correct file name, the target folder and the current folder when dragging a file  nested into a folder over a folder', async () => {
+    const { find, instance, fixture } = await shallow.render();
+
+    const mockContent = new Uint8Array(10000);
+    const progressEvent = {
+      item: new UploadItem(
+        new File([mockContent], 'testfile.txt'),
+        new FolderVO({
+          displayName: 'testfolder1',
+          pathAsArchiveNbr: [],
+          folderId: 9,
+        })
+      ),
+      statistics: { current: 1, total: 5, completed: 0, error: 0 },
+      sessionStatus: UploadSessionStatus.InProgress,
+    };
+
+    mockUploadService.uploadSession.progress.emit(progressEvent);
+
+    fixture.detectChanges();
+
+    expect(find('.current-file').nativeElement.textContent.trim()).toBe(
+      `Uploading ${progressEvent.item.file.name} to testfolder/${progressEvent.item.parentFolder.displayName}`
     );
 
     const fileCountElements = find('.file-count strong');

--- a/src/app/core/components/upload-progress/upload-progress.component.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.ts
@@ -85,6 +85,19 @@ export class UploadProgressComponent {
     this.isUploadingFolder =
       this.upload.getTargetFolderId() !==
       progressEvent.item?.parentFolder.folderId;
-    this.folderTargetName = this.upload.getTargetFolderName();
+    if (this.isUploadingFolder) {
+      this.folderTargetName = `${this.upload.getTargetFolderName()}/${
+        progressEvent.item?.parentFolder.displayName
+      }`;
+    } else {
+      if (
+        progressEvent.item?.parentFolder.displayName === 'My Files' &&
+        progressEvent.item?.parentFolder.pathAsArchiveNbr.length === 1
+      ) {
+        this.folderTargetName = 'Private';
+      } else {
+        this.folderTargetName = progressEvent.item?.parentFolder.displayName;
+      }
+    }
   }
 }

--- a/src/app/core/components/upload-progress/upload-progress.component.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.ts
@@ -29,6 +29,9 @@ export class UploadProgressComponent {
   public currentItem: UploadItem;
   public fileCount: any;
 
+  public isUploadingFolder = false;
+  public folderTargetName = '';
+
   constructor(private upload: UploadService) {
     this.upload.registerComponent(this);
 
@@ -40,13 +43,16 @@ export class UploadProgressComponent {
             this.upload.showProgress();
             break;
           case UploadSessionStatus.Done:
-            this.upload.dismissProgress();
-            break;
           case UploadSessionStatus.DefaultError:
-            this.upload.dismissProgress();
-            break;
           case UploadSessionStatus.StorageError:
             this.upload.dismissProgress();
+            if (this.isUploadingFolder) {
+              this.isUploadingFolder = false;
+              this.folderTargetName = '';
+            }
+            break;
+          case UploadSessionStatus.InProgress:
+            this.displayFolderUploadDestination(progressEvent);
             break;
         }
 
@@ -73,5 +79,12 @@ export class UploadProgressComponent {
     } else {
       return 'scaleX(0)';
     }
+  }
+
+  displayFolderUploadDestination(progressEvent: UploadProgressEvent) {
+    this.isUploadingFolder =
+      this.upload.getTargetFolderId() !==
+      progressEvent.item?.parentFolder.folderId;
+    this.folderTargetName = this.upload.getTargetFolderName();
   }
 }

--- a/src/app/core/components/upload-progress/upload-progress.component.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.ts
@@ -28,7 +28,6 @@ export class UploadProgressComponent {
 
   public currentItem: UploadItem;
   public fileCount: any;
-  public isUploadingInNestedFolder: boolean = false;
 
   constructor(private upload: UploadService) {
     this.upload.registerComponent(this);
@@ -53,9 +52,6 @@ export class UploadProgressComponent {
 
         if (progressEvent.item) {
           this.currentItem = progressEvent.item;
-          this.isUploadingInNestedFolder = this.uploadCheckInsideNestedFolder(
-            this.currentItem
-          );
         }
 
         this.fileCount = progressEvent.statistics;
@@ -77,9 +73,5 @@ export class UploadProgressComponent {
     } else {
       return 'scaleX(0)';
     }
-  }
-
-  uploadCheckInsideNestedFolder(item: UploadItem): boolean {
-    return item.parentFolder.pathAsArchiveNbr.length === 0;
   }
 }

--- a/src/app/core/components/upload-progress/upload-progress.component.ts
+++ b/src/app/core/components/upload-progress/upload-progress.component.ts
@@ -28,6 +28,7 @@ export class UploadProgressComponent {
 
   public currentItem: UploadItem;
   public fileCount: any;
+  public isUploadingInNestedFolder: boolean = false;
 
   constructor(private upload: UploadService) {
     this.upload.registerComponent(this);
@@ -52,6 +53,9 @@ export class UploadProgressComponent {
 
         if (progressEvent.item) {
           this.currentItem = progressEvent.item;
+          this.isUploadingInNestedFolder = this.uploadCheckInsideNestedFolder(
+            this.currentItem
+          );
         }
 
         this.fileCount = progressEvent.statistics;
@@ -73,5 +77,9 @@ export class UploadProgressComponent {
     } else {
       return 'scaleX(0)';
     }
+  }
+
+  uploadCheckInsideNestedFolder(item: UploadItem): boolean {
+    return item.parentFolder.pathAsArchiveNbr.length === 0;
   }
 }

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -48,6 +48,8 @@ export class UploadService implements HasSubscriptions, OnDestroy {
   protected uploadStart: Date;
 
   private debug = debug('service:upload');
+  private targetFolderName = '';
+  private targetFolderId: number;
 
   constructor(
     private api: ApiService,
@@ -241,6 +243,10 @@ export class UploadService implements HasSubscriptions, OnDestroy {
       }
     }
 
+    const parentFolder = pathsByDepth.get(0)[0].folder;
+
+    this.setTargetFolderNameAndId(parentFolder);
+
     this.uploadSession.startFolders();
 
     // group folder creation at each depth
@@ -306,6 +312,34 @@ export class UploadService implements HasSubscriptions, OnDestroy {
         }
       }
     }
+  }
+
+  private setTargetFolderName(folder: FolderVO): void {
+    if (
+      folder.displayName === 'My Files' &&
+      folder.pathAsArchiveNbr.length === 1
+    ) {
+      this.targetFolderName = 'Private';
+    } else {
+      this.targetFolderName = folder.displayName;
+    }
+  }
+
+  private setTargetFolderId(folderId: number): void {
+    this.targetFolderId = folderId;
+  }
+
+  private setTargetFolderNameAndId(folder: FolderVO) {
+    this.setTargetFolderName(folder);
+    this.setTargetFolderId(folder.folderId);
+  }
+
+  public getTargetFolderName(): string {
+    return this.targetFolderName;
+  }
+
+  public getTargetFolderId(): number {
+    return this.targetFolderId;
   }
 
   showProgress() {


### PR DESCRIPTION
Display a different message when dragging a file onto a folder.

I have noticed that when dragging a file onto a folder, not the root, the `parentFolder`'s `pathAsArchiveNbr` value is always an empty array, so when the array is empty, I am displaying a different message.

Steps to test:
1Drag a file onto an uploaded folder.
2. The message should be "Uploading 'file' to 'folder'" instead of just the file's name
