### PR TITLE
PER-9438-search-results-in-subfolders

### DIFF
--- a/src/app/public/components/public-search-results/public-search-results.component.spec.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.spec.ts
@@ -1,8 +1,8 @@
 /* @format */
-import { HttpClient, HttpHandler } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { FolderVO } from '@root/app/models';
 import { SearchService } from '@search/services/search.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DataService } from '../../../shared/services/data/data.service';
@@ -11,25 +11,24 @@ import { PublicSearchResultsComponent } from './public-search-results.component'
 describe('PublicSearchResultsComponent', () => {
   let component: PublicSearchResultsComponent;
   let fixture: ComponentFixture<PublicSearchResultsComponent>;
+  let mockRouter: Router;
+  let mockSearchService: SearchService;
+  let mockActivatedRoute = {
+    parent: {},
+  } as any;
 
   beforeEach(async () => {
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockSearchService = jasmine.createSpyObj('SearchService', [
+      'getResultsInPublicArchive',
+    ]);
+
     await TestBed.configureTestingModule({
       declarations: [PublicSearchResultsComponent],
       providers: [
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              paramMap: {
-                get(): string {
-                  return '123';
-                },
-              },
-            },
-          },
-        },
-        Router,
-        SearchService,
+        { provide: Router, useValue: mockRouter },
+        { provide: SearchService, useValue: mockSearchService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
         Location,
         DataService,
       ],
@@ -43,5 +42,38 @@ describe('PublicSearchResultsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate correctly on search result click for folders', () => {
+    const mockItem = new FolderVO({
+      type: 'type.folder.public',
+      archiveNbr: '123',
+      folder_linkId: 456,
+    });
+    component.onSearchResultClick(mockItem);
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(
+      [mockItem.archiveNbr, mockItem.folder_linkId],
+      { relativeTo: {} as any }
+    );
+  });
+
+  it('should navigate correctly on search result click for records', () => {
+    const mockItem = new FolderVO({
+      parentArchiveNbr: '456',
+      archiveNbr: '123',
+      parentFolder_linkId: 456,
+    });
+    component.onSearchResultClick(mockItem);
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(
+      [
+        mockItem.parentArchiveNbr,
+        mockItem.parentFolder_linkId,
+        'record',
+        mockItem.archiveNbr,
+      ],
+      { relativeTo: {} as any }
+    );
   });
 });

--- a/src/app/public/components/public-search-results/public-search-results.component.spec.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.spec.ts
@@ -1,7 +1,6 @@
 /* @format */
 import { ActivatedRoute, Router } from '@angular/router';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { FolderVO } from '@root/app/models';
 import { SearchService } from '@search/services/search.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';

--- a/src/app/public/components/public-search-results/public-search-results.component.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.ts
@@ -67,7 +67,12 @@ export class PublicSearchResultsComponent implements OnInit, OnDestroy {
       });
     } else {
       this.router.navigate(
-        [item.parentArchiveNbr, item.parentFolder_linkId, 'record', item.archiveNbr],
+        [
+          item.parentArchiveNbr,
+          item.parentFolder_linkId,
+          'record',
+          item.archiveNbr,
+        ],
         {
           relativeTo: this.route.parent,
         }

--- a/src/app/public/components/public-search-results/public-search-results.component.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.ts
@@ -14,7 +14,6 @@ import { SearchService } from '../../../search/services/search.service';
 export class PublicSearchResultsComponent implements OnInit, OnDestroy {
   public searchResults = [];
   public waiting = false;
-  public query = '';
 
   public types = {
     'type.folder.private': 'Folder',
@@ -40,7 +39,6 @@ export class PublicSearchResultsComponent implements OnInit, OnDestroy {
     if (this.route.params) {
       this.paramsSubscription = this.route.params.subscribe((params) => {
         this.archivePath = ['/p/archive', params.publicArchiveNbr];
-        this.query = params.query;
         this.searchSubscription = this.searchService
           .getResultsInPublicArchive(params.query, [], params.archiveId)
           .subscribe((response) => {
@@ -68,9 +66,12 @@ export class PublicSearchResultsComponent implements OnInit, OnDestroy {
         relativeTo: this.route.parent,
       });
     } else {
-      this.router.navigate(['record', item.archiveNbr], {
-        relativeTo: this.route.parent,
-      });
+      this.router.navigate(
+        [item.parentArchiveNbr, item.parentFolder_linkId, 'record', item.archiveNbr],
+        {
+          relativeTo: this.route.parent,
+        }
+      );
     }
   }
 }

--- a/src/app/public/components/public-search-results/public-search-results.component.ts
+++ b/src/app/public/components/public-search-results/public-search-results.component.ts
@@ -14,6 +14,7 @@ import { SearchService } from '../../../search/services/search.service';
 export class PublicSearchResultsComponent implements OnInit, OnDestroy {
   public searchResults = [];
   public waiting = false;
+  public query = '';
 
   public types = {
     'type.folder.private': 'Folder',
@@ -39,6 +40,7 @@ export class PublicSearchResultsComponent implements OnInit, OnDestroy {
     if (this.route.params) {
       this.paramsSubscription = this.route.params.subscribe((params) => {
         this.archivePath = ['/p/archive', params.publicArchiveNbr];
+        this.query = params.query;
         this.searchSubscription = this.searchService
           .getResultsInPublicArchive(params.query, [], params.archiveId)
           .subscribe((response) => {


### PR DESCRIPTION
Added the archive number of the parent folder and the link id when navigating in the search results into a nested record, thus forcing the data service to change the current folder.

Steps to test: 
1. Publish a folder with any record inside of it.
2. Go to the public archive and search for the nested record
3. It should open the record in the file viewer.