### PR TITLE
Throw error on `jasmine/new-line-before-expect` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
       plugins: ['jasmine'],
       env: { jasmine: true },
       rules: {
+        'jasmine/new-line-before-expect': 'error',
         // We intend to enable these eventually:
         'jasmine/new-line-between-declarations': 'off',
         'jasmine/no-disabled-tests': 'off',

--- a/src/app/shared/services/account/tests/refreshAccount.spec.ts
+++ b/src/app/shared/services/account/tests/refreshAccount.spec.ts
@@ -144,6 +144,7 @@ describe('AccountService: refreshAccount', () => {
     });
 
     await instance.refreshAccount();
+
     expect(logOutSpy).not.toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
     expect(localStorageSpy).toHaveBeenCalled();
@@ -161,6 +162,7 @@ describe('AccountService: refreshAccount', () => {
 
     AuthRepoStub.loggedIn = false;
     await instance.refreshAccount();
+
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalled();
   });
@@ -180,6 +182,7 @@ describe('AccountService: refreshAccount', () => {
 
     AuthRepoStub.loggedIn = false;
     await instance.refreshAccount();
+
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
   });
@@ -199,6 +202,7 @@ describe('AccountService: refreshAccount', () => {
 
     AuthRepoStub.loggedIn = false;
     await instance.refreshAccount();
+
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
   });
@@ -215,6 +219,7 @@ describe('AccountService: refreshAccount', () => {
 
     AccountRepoStub.failRequest = true;
     await instance.refreshAccount();
+
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalled();
   });
@@ -234,6 +239,7 @@ describe('AccountService: refreshAccount', () => {
 
     AccountRepoStub.failRequest = true;
     await instance.refreshAccount();
+
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
   });
@@ -253,6 +259,7 @@ describe('AccountService: refreshAccount', () => {
 
     AccountRepoStub.failRequest = true;
     await instance.refreshAccount();
+
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Angular doesn't seem to have a way for eslint to be more strict when running lint checks. The `new-line-before-expect` rule recently added defaults to throwing warnings in eslint, which does not register as a lint failure in Github Actions. Change it to throw errors instead so that we start using this rule consistently. Also fix any pre-existing errors.

This should also fix any warning popups in the Github UI when doing code review.
