### PR TITLE
Create "scaffolding" for filesystem caching

### DIFF
--- a/src/app/filesystem/mocks/fake-filesystem-api.ts
+++ b/src/app/filesystem/mocks/fake-filesystem-api.ts
@@ -1,0 +1,34 @@
+import { FolderVO, RecordVO } from '@models';
+import { FilesystemApi } from '../types/filesystem-api';
+import {
+  FolderIdentifier,
+  RecordIdentifier,
+} from '../types/filesystem-identifier';
+import { ArchiveIdentifier } from '../types/archive-identifier';
+
+export class FakeFilesystemApi implements FilesystemApi {
+  private calledMethods: string[] = [];
+
+  public async navigate(folder: FolderIdentifier) {
+    this.logCall('navigate');
+    return new FolderVO({});
+  }
+
+  public async getRoot(archive: ArchiveIdentifier) {
+    this.logCall('getRoot');
+    return new FolderVO({});
+  }
+
+  public async getRecord(record: RecordIdentifier) {
+    this.logCall('recordGet');
+    return new RecordVO({});
+  }
+
+  public methodWasCalled(name: string): boolean {
+    return this.calledMethods.includes(name);
+  }
+
+  private logCall(name: string) {
+    this.calledMethods.push(name);
+  }
+}

--- a/src/app/filesystem/permanent-filesystem.spec.ts
+++ b/src/app/filesystem/permanent-filesystem.spec.ts
@@ -1,0 +1,37 @@
+import { PermanentFilesystem } from './permanent-filesystem';
+import { FakeFilesystemApi } from './mocks/fake-filesystem-api';
+
+describe('Permanent Filesystem (Folder Caching)', () => {
+  let fs: PermanentFilesystem;
+  let api: FakeFilesystemApi;
+
+  beforeEach(() => {
+    api = new FakeFilesystemApi();
+    fs = new PermanentFilesystem(api);
+  });
+
+  it('should exist', () => {
+    expect(fs).toBeTruthy();
+  });
+
+  it('should be able to fetch the filesystem root', async () => {
+    const root = await fs.getArchiveRoot({ archiveId: 0 });
+
+    expect(root).toBeTruthy();
+    expect(api.methodWasCalled('getRoot')).toBeTrue();
+  });
+
+  it('should be able to fetch an arbitrary folder', async () => {
+    const folder = await fs.getFolder({ folder_linkId: 0 });
+
+    expect(folder).toBeTruthy();
+    expect(api.methodWasCalled('navigate')).toBeTrue();
+  });
+
+  it('should be able to fetch an arbitrary record', async () => {
+    const record = await fs.getRecord({ recordId: 0 });
+
+    expect(record).toBeTruthy();
+    expect(api.methodWasCalled('recordGet')).toBeTrue();
+  });
+});

--- a/src/app/filesystem/permanent-filesystem.ts
+++ b/src/app/filesystem/permanent-filesystem.ts
@@ -1,0 +1,23 @@
+import { FolderVO, RecordVO } from '@models';
+import { FilesystemApi } from './types/filesystem-api';
+import { ArchiveIdentifier } from './types/archive-identifier';
+import {
+  FolderIdentifier,
+  RecordIdentifier,
+} from './types/filesystem-identifier';
+
+export class PermanentFilesystem {
+  constructor(private api: FilesystemApi) {}
+
+  public async getArchiveRoot(archive: ArchiveIdentifier): Promise<FolderVO> {
+    return await this.api.getRoot(archive);
+  }
+
+  public async getFolder(folder: FolderIdentifier): Promise<FolderVO> {
+    return await this.api.navigate(folder);
+  }
+
+  public async getRecord(record: RecordIdentifier): Promise<RecordVO> {
+    return await this.api.getRecord(record);
+  }
+}

--- a/src/app/filesystem/types/archive-identifier.ts
+++ b/src/app/filesystem/types/archive-identifier.ts
@@ -1,0 +1,1 @@
+export type ArchiveIdentifier = { archiveId: number } | { archiveNbr: string };

--- a/src/app/filesystem/types/filesystem-api.ts
+++ b/src/app/filesystem/types/filesystem-api.ts
@@ -1,0 +1,9 @@
+import { FolderVO, RecordVO } from '@models/index';
+import { ArchiveIdentifier } from './archive-identifier';
+import { FolderIdentifier, RecordIdentifier } from './filesystem-identifier';
+
+export interface FilesystemApi {
+  navigate: (folder: FolderIdentifier) => Promise<FolderVO>;
+  getRoot: (archive: ArchiveIdentifier) => Promise<FolderVO>;
+  getRecord: (record: RecordIdentifier) => Promise<RecordVO>;
+}

--- a/src/app/filesystem/types/filesystem-identifier.ts
+++ b/src/app/filesystem/types/filesystem-identifier.ts
@@ -1,0 +1,6 @@
+export type FilesystemItemIdentifier =
+  | { folder_linkId: number }
+  | { archiveNbr: string };
+
+export type FolderIdentifier = FilesystemItemIdentifier | { folderId: number };
+export type RecordIdentifier = FilesystemItemIdentifier | { recordId: number };


### PR DESCRIPTION
This class is intended to be a new central location for fetching parts of the Permanent filesystem from the API. Initially the class is set up just to wrap around an interface, with the idea that caching logic will be built around this code. Eventually when connected to the rest of the application, any sites that call the API methods will be replaced with calls to these methods instead.

Initially the ticket PER-9453 was just *<span title="A real &quot;draw the rest of the owl&quot; kind of ticket">"build a folder caching system"</span>* but we reduced in scope with the hope that the initial work would also serve as a bit of research into what other kinds of tickets the project needs. While the code in this PR is pretty basic, below are some points I'd like to bring up from my research:

## Questions/Discussion

The three methods included in the `PermanentFilesystem` class are based on the three main filesystem API calls used when loading a page and selecting a record. One question that has come up during the work on this ticket is: **What is the point of the `navigate` endpoints?** Looking at the back-end source code, it seems like these endpoints save some kind of information into session variables about the current folder. But as far as I can tell, this data isn't really used anywhere. Why can't we call an endpoint like `folder/getWithChildren` instead, which has a V2 version and the sftp-service uses exclusively? If the session variables on the `navigate` endpoints really are unused, I think there's really no reason to use them over standard `folder/get*` endpoints at this point.

From this, another question arises when it comes to fetching folders: **Do we even want to use the min/lean endpoints with this new system?** It seems like the original "lean/min" fetching system was a way to lazy load data in. When navigating into a folder, the front end initially calls `navigateMin` to load in the "min" versions of child items which really only include basic information like display names and IDs. It then does a call to `getLeanItems`, with the "lean" versions of items include more information (mostly info needed to display the items in the file list, but still not *all* the item metadata). Finally when you click on a record the web-app calls `record/get` to fetch the full item.

So the question is, why do we need to make all these calls? In theory, the lazy loading could be useful, but in practice I don't fully understand why we're doing this. From very informal testing, it seems like the `getLeanItems` call doesn't seem to be measurably slower than `navigateMin`. And even if the session blocking issue wasn't a problem (and it definitely is!), sending two API calls for no reason doesn't seem like it would speed up the application or help with lazy loading.

I'd like to discuss these questions because I think ideally the `PermanentFilesystem` class would only have to call one endpoint when fetching the child items of a folder for display in the UI. If we agree that `navigateMin` can be skipped, then I'd love for this to just always call `getLeanItems`, but also I think it's worth discussing whether or not we just want to call `getWithChildren` if it means we could speed up the app even more.