### PR TITLE
PER-9459 broken public search

### DIFF
--- a/src/app/shared/services/api/search.repo.spec.ts
+++ b/src/app/shared/services/api/search.repo.spec.ts
@@ -1,0 +1,48 @@
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { environment } from '@root/environments/environment';
+
+import { HttpService } from '@shared/services/http/http.service';
+import { HttpV2Service } from '../http-v2/http-v2.service';
+import { SearchRepo, SearchResponse } from './search.repo';
+
+describe('SearchRepo', () => {
+  let repo: SearchRepo;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [HttpService],
+    });
+
+    repo = new SearchRepo(
+      TestBed.inject(HttpService),
+      TestBed.inject(HttpV2Service)
+    );
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('returns the correct search results', () => {
+    const expected = require('@root/test/responses/search.get.publicFiles.success.json');
+    repo
+      .itemsByNameInPublicArchiveObservable('test', [], '1')
+      .toPromise()
+      .then((response: SearchResponse) => {
+        expect(JSON.stringify(response)).toEqual(JSON.stringify(expected[0]));
+      });
+
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/search/folderAndRecord?query=test&archiveId=1&publicOnly=true`
+    );
+    req.flush(expected);
+  });
+});

--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -1,5 +1,11 @@
 import { query } from '@angular/animations';
-import { ArchiveVO, RecordVO, FolderVO, ItemVO, TagVOData } from '@root/app/models';
+import {
+  ArchiveVO,
+  RecordVO,
+  FolderVO,
+  ItemVO,
+  TagVOData,
+} from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { flatten } from 'lodash';
 import { Observable } from 'rxjs';
@@ -45,10 +51,10 @@ export class SearchRepo extends BaseRepo {
   ): Observable<SearchResponse> {
     const data = {
       SearchVO: {
-      query,
-      TagVOs: tags,
-      numberOfResults: limit,
-      }
+        query,
+        TagVOs: tags,
+        numberOfResults: limit,
+      },
     };
 
     return this.http.sendRequest<SearchResponse>(
@@ -60,25 +66,22 @@ export class SearchRepo extends BaseRepo {
 
   public itemsByNameInPublicArchiveObservable(
     query: string,
-    tags: any[] = [],
+    tags: TagVOData[] = [],
     archiveId: string,
-    limit?: number,
+    limit?: number
   ) {
     const data = {
       query,
-      tags:'',
+      tags,
       archiveId,
-      publicOnly:true
+      publicOnly: true,
     };
 
-    return getFirst(this.httpV2.get<SearchResponse>(
-      '/search/folderAndRecord',
-      data,
-      null,
-      {
-        authToken:false
-      }
-    ));
+    return getFirst(
+      this.httpV2.get<SearchResponse>('/search/folderAndRecord', data, null, {
+        authToken: false,
+      })
+    );
   }
 }
 
@@ -101,7 +104,7 @@ export class SearchResponse extends BaseResponse {
     return flatten(archives);
   }
 
-  public getItemVOs(initChildren?: boolean): ItemVO[] {    
+  public getItemVOs(initChildren?: boolean): ItemVO[] {
     const data = this.getResultsData();
 
     if (!data.length) {
@@ -110,7 +113,7 @@ export class SearchResponse extends BaseResponse {
 
     const searchVO = data[0][0].SearchVO;
 
-    return searchVO.ChildItemVOs.map(i => {
+    return searchVO.ChildItemVOs.map((i) => {
       if (i.recordId) {
         return new RecordVO(i, initChildren);
       } else {

--- a/src/test/responses/search.get.publicFiles.success.json
+++ b/src/test/responses/search.get.publicFiles.success.json
@@ -1,0 +1,264 @@
+[
+  {
+     "query":"test",
+     "starting":null,
+     "numberOfResults":null,
+     "FolderVOs":[
+
+     ],
+     "RecordVOs":[
+
+     ],
+     "ChildItemVOs":[
+        {
+           "recordId":179,
+           "archiveId":null,
+           "archiveNbr":"0005-007o",
+           "publicDT":null,
+           "note":null,
+           "displayName":"test",
+           "downloadName":null,
+           "downloadNameOk":null,
+           "uploadFileName":null,
+           "uploadAccountId":null,
+           "uploadPayerAccountId":null,
+           "size":null,
+           "description":null,
+           "displayDT":null,
+           "displayEndDT":null,
+           "derivedDT":null,
+           "derivedEndDT":null,
+           "derivedCreatedDT":null,
+           "locnId":null,
+           "timeZoneId":null,
+           "view":null,
+           "viewProperty":null,
+           "imageRatio":null,
+           "metaToken":null,
+           "refArchiveNbr":null,
+           "type":"type.record.image",
+           "altText":null,
+           "thumbStatus":null,
+           "thumbURL200":null,
+           "thumbURL500":null,
+           "thumbURL1000":null,
+           "thumbURL2000":null,
+           "thumbDT":null,
+           "fileStatus":null,
+           "status":null,
+           "processedDT":null,
+           "FolderLinkVOs":[
+
+           ],
+           "folder_linkId":300,
+           "parentFolderId":null,
+           "position":null,
+           "accessRole":null,
+           "folderArchiveId":null,
+           "folder_linkType":"type.folder_link.public",
+           "pathAsFolder_linkId":null,
+           "pathAsText":null,
+           "parentFolder_linkId":24,
+           "ParentFolderVOs":null,
+           "parentArchiveNbr":"0005-0004",
+           "parentDisplayName":"Public",
+           "pathAsArchiveNbr":null,
+           "LocnVO":null,
+           "TimezoneVO":null,
+           "FileVOs":null,
+           "TagVOs":[
+
+           ],
+           "TextDataVOs":[
+
+           ],
+           "ArchiveVOs":[
+
+           ],
+           "saveAs":null,
+           "uploadUri":null,
+           "fileDurationInSecs":null,
+           "RecordExifVO":null,
+           "ShareVOs":[
+
+           ],
+           "AccessVO":null,
+           "searchScore":"1",
+           "archiveArchiveNbr":null,
+           "createdDT":null,
+           "updatedDT":null
+        },
+        {
+           "folderId":103,
+           "archiveNbr":"0005-006v",
+           "archiveId":null,
+           "displayName":"test-upload",
+           "downloadName":null,
+           "downloadNameOk":null,
+           "displayDT":null,
+           "displayEndDT":null,
+           "derivedDT":null,
+           "derivedEndDT":null,
+           "note":null,
+           "description":null,
+           "special":null,
+           "sort":null,
+           "locnId":null,
+           "timeZoneId":null,
+           "view":null,
+           "viewProperty":null,
+           "thumbArchiveNbr":null,
+           "imageRatio":null,
+           "type":"type.folder.public",
+           "thumbStatus":null,
+           "thumbURL200":null,
+           "thumbURL500":null,
+           "thumbURL1000":null,
+           "thumbURL2000":null,
+           "thumbDT":null,
+           "status":null,
+           "publicDT":null,
+           "parentFolderId":null,
+           "folder_linkType":"type.folder_link.public",
+           "FolderLinkVOs":[
+
+           ],
+           "accessRole":null,
+           "position":null,
+           "shareDT":null,
+           "pathAsFolder_linkId":null,
+           "pathAsText":[
+
+           ],
+           "folder_linkId":271,
+           "parentFolder_linkId":24,
+           "ParentFolderVOs":[
+
+           ],
+           "parentArchiveNbr":"0005-0004",
+           "parentDisplayName":"Public",
+           "pathAsArchiveNbr":[
+
+           ],
+           "ChildFolderVOs":[
+
+           ],
+           "RecordVOs":[
+
+           ],
+           "LocnVO":null,
+           "TimezoneVO":null,
+           "TagVOs":[
+
+           ],
+           "SharedArchiveVOs":[
+
+           ],
+           "FolderSizeVO":null,
+           "ChildItemVOs":[
+
+           ],
+           "ShareVOs":[
+
+           ],
+           "AccessVO":null,
+           "AccessVOs":null,
+           "archiveArchiveNbr":null,
+           "returnDataSize":null,
+           "posStart":null,
+           "posLimit":null,
+           "searchScore":"1",
+           "createdDT":null,
+           "updatedDT":null
+        },
+        {
+           "folderId":104,
+           "archiveNbr":"0005-006w",
+           "archiveId":null,
+           "displayName":"test-upload",
+           "downloadName":null,
+           "downloadNameOk":null,
+           "displayDT":null,
+           "displayEndDT":null,
+           "derivedDT":null,
+           "derivedEndDT":null,
+           "note":null,
+           "description":null,
+           "special":null,
+           "sort":null,
+           "locnId":null,
+           "timeZoneId":null,
+           "view":null,
+           "viewProperty":null,
+           "thumbArchiveNbr":null,
+           "imageRatio":null,
+           "type":"type.folder.public",
+           "thumbStatus":null,
+           "thumbURL200":null,
+           "thumbURL500":null,
+           "thumbURL1000":null,
+           "thumbURL2000":null,
+           "thumbDT":null,
+           "status":null,
+           "publicDT":null,
+           "parentFolderId":null,
+           "folder_linkType":"type.folder_link.public",
+           "FolderLinkVOs":[
+
+           ],
+           "accessRole":null,
+           "position":null,
+           "shareDT":null,
+           "pathAsFolder_linkId":null,
+           "pathAsText":[
+
+           ],
+           "folder_linkId":272,
+           "parentFolder_linkId":24,
+           "ParentFolderVOs":[
+
+           ],
+           "parentArchiveNbr":"0005-0004",
+           "parentDisplayName":"Public",
+           "pathAsArchiveNbr":[
+
+           ],
+           "ChildFolderVOs":[
+
+           ],
+           "RecordVOs":[
+
+           ],
+           "LocnVO":null,
+           "TimezoneVO":null,
+           "TagVOs":[
+
+           ],
+           "SharedArchiveVOs":[
+
+           ],
+           "FolderSizeVO":null,
+           "ChildItemVOs":[
+
+           ],
+           "ShareVOs":[
+
+           ],
+           "AccessVO":null,
+           "AccessVOs":null,
+           "archiveArchiveNbr":null,
+           "returnDataSize":null,
+           "posStart":null,
+           "posLimit":null,
+           "searchScore":"1",
+           "createdDT":null,
+           "updatedDT":null
+        }
+     ],
+     "TagVOs":[
+
+     ],
+     "createdDT":null,
+     "updatedDT":null
+  }
+]


### PR DESCRIPTION
Replaced the default value of the tags in the api call.

Steps to test:
1. Go to any public archive
2. Search for any file or folder
3. It should display the search results.