### PR TITLE
Fix broken folder picker

### DIFF
--- a/src/app/core/services/folder-picker/folder-picker.service.spec.ts
+++ b/src/app/core/services/folder-picker/folder-picker.service.spec.ts
@@ -1,15 +1,100 @@
-import { TestBed, inject } from '@angular/core/testing';
-
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import {
+  FolderPickerComponent,
+  FolderPickerOperations,
+} from '@core/components/folder-picker/folder-picker.component';
+import { FolderVO } from '@models/index';
 import { FolderPickerService } from './folder-picker.service';
 
+class FakeComponent {
+  public async show(
+    startingFolder: FolderVO,
+    operation: FolderPickerOperations,
+    savePromise?: Promise<any>,
+    filterFolderLinkIds: number[] = null,
+    allowRecords = false
+  ) {
+    return {
+      startingFolder,
+      operation,
+      savePromise,
+      filterFolderLinkIds,
+      allowRecords,
+    };
+  }
+}
+
 describe('FolderPickerService', () => {
+  let service: FolderPickerService;
+  let component: FakeComponent;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [FolderPickerService]
+      providers: [FolderPickerService],
     });
+    service = TestBed.inject(FolderPickerService);
+    component = new FakeComponent();
+    service.registerComponent(component as FolderPickerComponent);
   });
 
-  it('should be created', inject([FolderPickerService], (service: FolderPickerService) => {
+  it('should be created', () => {
     expect(service).toBeTruthy();
-  }));
+  });
+
+  it('should throw an error when choosing a folder if the component is not registered', () => {
+    service.unregisterComponent();
+
+    expect(() =>
+      service.chooseFolder(new FolderVO({}), FolderPickerOperations.Move)
+    ).toThrow();
+  });
+
+  it('should throw an error when choosing a record if the component is not registered', () => {
+    service.unregisterComponent();
+
+    expect(() => service.chooseRecord(new FolderVO({}))).toThrow();
+  });
+
+  it('cannot register a FolderPickerComponent twice', () => {
+    expect(() =>
+      service.registerComponent(component as FolderPickerComponent)
+    ).toThrow();
+  });
+
+  it('can unregister a FolderPickerComponent', () => {
+    service.unregisterComponent();
+
+    expect(() =>
+      service.registerComponent(component as FolderPickerComponent)
+    ).not.toThrow();
+  });
+
+  it('should call the correct component method when choosing a folder', async () => {
+    const params = {
+      startingFolder: new FolderVO({ folderId: 1 }),
+      operation: FolderPickerOperations.Copy,
+      savePromise: undefined,
+      filterFolderLinkIds: null,
+      allowRecords: false,
+    };
+    const result = await service.chooseFolder(
+      params.startingFolder,
+      params.operation
+    );
+
+    expect(result).toEqual(params);
+  });
+
+  it('should call the correct component method when choosing a record', async () => {
+    const params = {
+      startingFolder: new FolderVO({ folderId: 1 }),
+      operation: FolderPickerOperations.ChooseRecord,
+      savePromise: null,
+      filterFolderLinkIds: null,
+      allowRecords: true,
+    };
+    const result = (await service.chooseRecord(params.startingFolder)) as any;
+
+    expect(result).toEqual(params);
+  });
 });

--- a/src/app/core/services/folder-picker/folder-picker.service.ts
+++ b/src/app/core/services/folder-picker/folder-picker.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { FolderPickerComponent, FolderPickerOperations } from '@core/components/folder-picker/folder-picker.component';
 import { FolderVO, RecordVO } from '@root/app/models';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class FolderPickerService {
   private component: FolderPickerComponent;
 

--- a/src/app/core/services/folder-picker/folder-picker.service.ts
+++ b/src/app/core/services/folder-picker/folder-picker.service.ts
@@ -1,16 +1,22 @@
+/* @format */
 import { Injectable } from '@angular/core';
-import { FolderPickerComponent, FolderPickerOperations } from '@core/components/folder-picker/folder-picker.component';
+import {
+  FolderPickerComponent,
+  FolderPickerOperations,
+} from '@core/components/folder-picker/folder-picker.component';
 import { FolderVO, RecordVO } from '@root/app/models';
 
 @Injectable()
 export class FolderPickerService {
   private component: FolderPickerComponent;
 
-  constructor() { }
+  constructor() {}
 
   registerComponent(toRegister: FolderPickerComponent) {
     if (this.component) {
-      throw new Error('FolderPickerService - Folder picker component already registered');
+      throw new Error(
+        'FolderPickerService - Folder picker component already registered'
+      );
     }
 
     this.component = toRegister;
@@ -30,16 +36,25 @@ export class FolderPickerService {
       throw new Error('FolderPickerService - Folder picker component missing');
     }
 
-    return this.component.show(startingFolder, operation, savePromise, filterFolderLinkIds);
+    return this.component.show(
+      startingFolder,
+      operation,
+      savePromise,
+      filterFolderLinkIds
+    );
   }
 
-  chooseRecord(
-    startingFolder: FolderVO,
-  ): Promise<RecordVO> {
+  chooseRecord(startingFolder: FolderVO): Promise<RecordVO> {
     if (!this.component) {
       throw new Error('FolderPickerService - Folder picker component missing');
     }
 
-    return this.component.show(startingFolder, FolderPickerOperations.ChooseRecord, null, null, true);
+    return this.component.show(
+      startingFolder,
+      FolderPickerOperations.ChooseRecord,
+      null,
+      null,
+      true
+    );
   }
 }

--- a/src/app/shared/services/profile/profile.service.spec.ts
+++ b/src/app/shared/services/profile/profile.service.spec.ts
@@ -1,7 +1,7 @@
 /* @format */
+import { NgModule } from '@angular/core';
 import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
 import { ArchiveVO, FolderVO } from '@models/index';
-import { SharedModule } from '@shared/shared.module';
 import { Shallow } from 'shallow-render';
 import { ProfileItemVOData } from '@models/profile-item-vo';
 import { RecordVO } from '../../../models/record-vo';
@@ -46,12 +46,20 @@ const mockFolderPickerService = {
   },
 };
 
+@NgModule({
+  declarations: [ProfileService], // components your module owns.
+  imports: [], // other modules your module needs.
+  providers: [ProfileService], // providers available to your module.
+  bootstrap: [], // bootstrap this root component.
+})
+class DummyModule {}
+
 describe('ProfileService', () => {
   let shallow: Shallow<ProfileService>;
   let messageShown = false;
 
   beforeEach(() => {
-    shallow = new Shallow(ProfileService, SharedModule)
+    shallow = new Shallow(ProfileService, DummyModule)
       .mock(MessageService, {
         showError: () => {
           messageShown = true;

--- a/src/app/shared/services/profile/profile.service.ts
+++ b/src/app/shared/services/profile/profile.service.ts
@@ -96,7 +96,7 @@ export function orderItemsInDictionary(
   }
 }
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ProfileService {
   private profileItemDictionary: ProfileItemVODictionary = {};
 


### PR DESCRIPTION
This bug was caused by some Dependency Injection hijinks. See the commit message for more details.

While I was here I also wrote tests for the FolderPickerService.

**Stepz to Test:**
1. Go to the Profile section of the app
2. Try to change your banner/profile picture
3. Verify the file picker shows up