### PR TITLE
PER-8783-support-txt-files

### DIFF
--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -33,7 +33,9 @@
           (disableSwipe)="toggleSwipe($event)"
           (isFullScreen)="toggleFullscreen($event)"
           [item]="currentRecord"
-          *ngIf="showThumbnail && !isDocument && !isVideo && !isAudio"
+          *ngIf="
+            showThumbnail && !isDocument && !isTxtFile && !isVideo && !isAudio
+          "
           [hideResizableImage]="false"
         ></pr-thumbnail>
         <pr-video [item]="currentRecord" *ngIf="isVideo"></pr-video>
@@ -41,7 +43,7 @@
         <iframe
           [title]="currentRecord | getAltText"
           [src]="documentUrl"
-          *ngIf="isDocument && documentUrl"
+          *ngIf="isDocument  && documentUrl"
         ></iframe>
       </div>
     </div>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -33,9 +33,7 @@
           (disableSwipe)="toggleSwipe($event)"
           (isFullScreen)="toggleFullscreen($event)"
           [item]="currentRecord"
-          *ngIf="
-            showThumbnail && !isDocument && !isTxtFile && !isVideo && !isAudio
-          "
+          *ngIf="showThumbnail && !isDocument && !isVideo && !isAudio"
           [hideResizableImage]="false"
         ></pr-thumbnail>
         <pr-video [item]="currentRecord" *ngIf="isVideo"></pr-video>
@@ -43,7 +41,7 @@
         <iframe
           [title]="currentRecord | getAltText"
           [src]="documentUrl"
-          *ngIf="isDocument  && documentUrl"
+          *ngIf="isDocument && documentUrl"
         ></iframe>
       </div>
     </div>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
@@ -353,7 +353,7 @@ describe('FileViewerComponent', () => {
       instance: FileViewerComponent,
       phrase: string
     ) {
-      const url = instance.getPdfUrl();
+      const url = instance.getDocumentUrl();
 
       expect(url).toBeTruthy();
       expect(
@@ -372,17 +372,23 @@ describe('FileViewerComponent', () => {
       expectSantizedUrlToContain(instance, 'original');
     });
 
+    it('will prefer the URL of the original if it is a TXT file', async () => {
+      setUpCurrentRecord('txt');
+      const { instance } = await defaultRender();
+      expectSantizedUrlToContain(instance, 'original');
+    });
+
     it('will have a falsy document URL if it is not a document', async () => {
       const { instance } = await defaultRender();
 
-      expect(instance.getPdfUrl()).toBeFalsy();
+      expect(instance.getDocumentUrl()).toBeFalsy();
     });
 
     it('will have a falsy document URL if the URL is falsy', async () => {
       setUpCurrentRecord('pdf', false);
       const { instance } = await defaultRender();
 
-      expect(instance.getPdfUrl()).toBeFalsy();
+      expect(instance.getDocumentUrl()).toBeFalsy();
     });
   });
 

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -1,3 +1,4 @@
+import { some } from 'lodash';
 /* @format */
 import {
   Component,
@@ -7,6 +8,9 @@ import {
   Inject,
   HostListener,
   Optional,
+  ViewChild,
+  AfterViewInit,
+  Renderer2,
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -40,6 +44,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   public isVideo = false;
   public isAudio = false;
   public isDocument = false;
+  public isTxtFile = false;
   public showThumbnail = true;
   public isPublicArchive: boolean = false;
   public allowDownloads: boolean = false;
@@ -67,6 +72,8 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   public editingDate: boolean = false;
   private bodyScrollTop: number;
   private tagSubscription: Subscription;
+
+  @ViewChild('documentFrame') public documentFrame;
 
   constructor(
     private router: Router,
@@ -187,10 +194,10 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   initRecord() {
     this.isAudio = this.currentRecord.type.includes('audio');
     this.isVideo = this.currentRecord.type.includes('video');
-    this.isDocument = this.currentRecord.FileVOs?.some((obj: ItemVO) =>
-      obj.type.includes('pdf')
+    this.isDocument = this.currentRecord.FileVOs?.some(
+      (obj: ItemVO) => obj.type.includes('pdf') || obj.type.includes('txt')
     );
-    this.documentUrl = this.getPdfUrl();
+    this.documentUrl = this.getDocumentUrl();
     this.setCurrentTags();
   }
 
@@ -202,7 +209,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
     this.fullscreen = value;
   }
 
-  getPdfUrl() {
+  getDocumentUrl() {
     if (!this.isDocument) {
       return false;
     }
@@ -216,7 +223,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
     let url;
 
-    if (original?.type.includes('pdf')) {
+    if (original?.type.includes('pdf') || original?.type.includes('txt')) {
       url = original?.fileURL;
     } else if (pdf) {
       url = pdf?.fileURL;


### PR DESCRIPTION
Display the .txt files in the file viewer using the same approach as the pdf, with the file Url from the FileVOs.

Steps to test:
1. Upload a .txt files
2. Wait for it to process
3. Open it in the viewer.
4. It should display the contents of the file instead of the previous icon