### PR TITLE
PER-8783-support-txt-files

### DIFF
--- a/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
@@ -372,6 +372,12 @@ describe('FileViewerComponent', () => {
       expectSantizedUrlToContain(instance, 'original');
     });
 
+    it('will prefer the URL of the original if it is a TXT file', async () => {
+      setUpCurrentRecord('txt');
+      const { instance } = await defaultRender();
+      expectSantizedUrlToContain(instance, 'original');
+    });
+
     it('will have a falsy document URL if it is not a document', async () => {
       const { instance } = await defaultRender();
 

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
@@ -353,7 +353,7 @@ describe('FileViewerComponent', () => {
       instance: FileViewerComponent,
       phrase: string
     ) {
-      const url = instance.getPdfUrl();
+      const url = instance.getDocumentUrl();
 
       expect(url).toBeTruthy();
       expect(
@@ -375,14 +375,14 @@ describe('FileViewerComponent', () => {
     it('will have a falsy document URL if it is not a document', async () => {
       const { instance } = await defaultRender();
 
-      expect(instance.getPdfUrl()).toBeFalsy();
+      expect(instance.getDocumentUrl()).toBeFalsy();
     });
 
     it('will have a falsy document URL if the URL is falsy', async () => {
       setUpCurrentRecord('pdf', false);
       const { instance } = await defaultRender();
 
-      expect(instance.getPdfUrl()).toBeFalsy();
+      expect(instance.getDocumentUrl()).toBeFalsy();
     });
   });
 

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -187,10 +187,10 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   initRecord() {
     this.isAudio = this.currentRecord.type.includes('audio');
     this.isVideo = this.currentRecord.type.includes('video');
-    this.isDocument = this.currentRecord.FileVOs?.some((obj: ItemVO) =>
-      obj.type.includes('pdf')
+    this.isDocument = this.currentRecord.FileVOs?.some(
+      (obj: ItemVO) => obj.type.includes('pdf') || obj.type.includes('txt')
     );
-    this.documentUrl = this.getPdfUrl();
+    this.documentUrl = this.getDocumentUrl();
     this.setCurrentTags();
   }
 
@@ -202,7 +202,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
     this.fullscreen = value;
   }
 
-  getPdfUrl() {
+  getDocumentUrl() {
     if (!this.isDocument) {
       return false;
     }
@@ -216,7 +216,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
     let url;
 
-    if (original?.type.includes('pdf')) {
+    if (original?.type.includes('pdf') || original?.type.includes('txt')) {
       url = original?.fileURL;
     } else if (pdf) {
       url = pdf?.fileURL;


### PR DESCRIPTION
Display the .txt files in the file viewer using the same approach as the pdf, with the file Url from the FileVOs.

Steps to test:

1.Upload a .txt files
2.Wait for it to process
3.Open it in the viewer.
4.It should display the contents of the file instead of the previous icon