### PR TITLE
PER-8502 Notify user when upload fails due to role permission

### DIFF
--- a/src/app/core/services/upload/upload.service.spec.ts
+++ b/src/app/core/services/upload/upload.service.spec.ts
@@ -102,4 +102,20 @@ describe('UploadService', () => {
 
     expect(emittedSessionStatus).toBe(UploadSessionStatus.FileNoBytesError);
   });
+
+  it('should handle NoAccessToUpload correctly', async () => {
+    uploadSessionMock.progress.subscribe((event) => {
+      emittedSessionStatus = event.sessionStatus;
+    });
+
+    const mockEvent: UploadProgressEvent = {
+      item: null,
+      sessionStatus: UploadSessionStatus.NoAccessToUpload,
+      statistics: { current: 0, total: 0, error: 0, completed: 0 },
+    };
+
+    uploadSessionMock.progress.emit(mockEvent);
+
+    expect(emittedSessionStatus).toBe(UploadSessionStatus.NoAccessToUpload);
+  });
 });

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -102,7 +102,8 @@ export class UploadService implements HasSubscriptions, OnDestroy {
               false,
               [],
               {},
-              '<a class="link" href="https://permanent.zohodesk.com/portal/en/kb/articles/roles-for-collaboration-and-sharing">Read More.</a>'
+              '"https://permanent.zohodesk.com/portal/en/kb/articles/roles-for-collaboration-and-sharing"',
+              'Read More'
             );
             break;
           case UploadSessionStatus.StorageError:

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -102,7 +102,7 @@ export class UploadService implements HasSubscriptions, OnDestroy {
               false,
               [],
               {},
-              '"https://permanent.zohodesk.com/portal/en/kb/articles/roles-for-collaboration-and-sharing"',
+              'https://permanent.zohodesk.com/portal/en/kb/articles/roles-for-collaboration-and-sharing',
               'Read More'
             );
             break;

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -95,6 +95,16 @@ export class UploadService implements HasSubscriptions, OnDestroy {
             );
             this.accountService.refreshAccountDebounced();
             break;
+
+          case UploadSessionStatus.NoAccessToUpload:
+            this.message.showError(
+              'You do not have permission to upload to this archive.',
+              false,
+              [],
+              {},
+              '<a class="link" href=https://permanent.zohodesk.com/portal/en/kb/articles/roles-for-collaboration-and-sharing>Read More.</a>'
+            );
+            break;
           case UploadSessionStatus.StorageError:
             this.message.showError(
               'You do not have enough storage available to upload these files.'

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -102,7 +102,7 @@ export class UploadService implements HasSubscriptions, OnDestroy {
               false,
               [],
               {},
-              '<a class="link" href=https://permanent.zohodesk.com/portal/en/kb/articles/roles-for-collaboration-and-sharing>Read More.</a>'
+              '<a class="link" href="https://permanent.zohodesk.com/portal/en/kb/articles/roles-for-collaboration-and-sharing">Read More.</a>'
             );
             break;
           case UploadSessionStatus.StorageError:

--- a/src/app/shared/components/message/message.component.html
+++ b/src/app/shared/components/message/message.component.html
@@ -6,11 +6,7 @@
     </div>
     <div (click)="onClick()" class="alert alert-primary" [ngClass]="style">
       {{ displayText }}
-      <span
-        class="link-body"
-        *ngIf="externalUrl"
-        [innerHtml]="externalUrl"
-      ></span>
+      <a *ngIf="externalMessage" [href]="externalUrl">{{ externalMessage }}</a>
     </div>
   </div>
 </div>

--- a/src/app/shared/components/message/message.component.html
+++ b/src/app/shared/components/message/message.component.html
@@ -1,10 +1,16 @@
+<!-- format  -->
 <div>
   <div class="alert-wrapper" [ngClass]="{ visible: visible, fade: useFade }">
     <div class="alert alert-primary icon-container" [ngClass]="style">
-        <i (click)="dismiss()" class="material-icons">close</i>
+      <i (click)="dismiss()" class="material-icons">close</i>
     </div>
     <div (click)="onClick()" class="alert alert-primary" [ngClass]="style">
       {{ displayText }}
+      <span
+        class="link-body"
+        *ngIf="externalUrl"
+        [innerHtml]="externalUrl"
+      ></span>
     </div>
   </div>
 </div>

--- a/src/app/shared/components/message/message.component.scss
+++ b/src/app/shared/components/message/message.component.scss
@@ -60,7 +60,3 @@ $transition-length: 0.33s;
     padding-right: 1px;
   }
 }
-
-.link {
-  color: black;
-}

--- a/src/app/shared/components/message/message.component.scss
+++ b/src/app/shared/components/message/message.component.scss
@@ -1,3 +1,4 @@
+/* @format */
 $transition-length: 0.33s;
 
 :host {
@@ -58,4 +59,8 @@ $transition-length: 0.33s;
   & > i {
     padding-right: 1px;
   }
+}
+
+.link {
+  color: black;
 }

--- a/src/app/shared/components/message/message.component.spec.ts
+++ b/src/app/shared/components/message/message.component.spec.ts
@@ -93,20 +93,15 @@ describe('MessageComponent', () => {
   });
 
   it('should display the external URL if it exists', () => {
-    component.externalUrl =
-      '<a class="test-link" href=https://www.example.com>Example</a>';
+    component.externalUrl = 'https://www.example.com';
+    component.externalMessage = 'test message';
     component.visible = true;
     fixture.detectChanges();
 
-    const externalLinkBody =
-      fixture.debugElement.nativeElement.querySelector('.link-body');
-
-    expect(externalLinkBody).toBeTruthy();
-
-    const externalLink =
-      fixture.debugElement.nativeElement.querySelector('.test-link');
+    const externalLink = fixture.debugElement.nativeElement.querySelector('a');
 
     expect(externalLink).toBeTruthy();
+
     expect(externalLink.href).toEqual('https://www.example.com/');
   });
 });

--- a/src/app/shared/components/message/message.component.spec.ts
+++ b/src/app/shared/components/message/message.component.spec.ts
@@ -91,4 +91,22 @@ describe('MessageComponent', () => {
 
     expect(component.dismiss).toHaveBeenCalledTimes(1);
   });
+
+  it('should display the external URL if it exists', () => {
+    component.externalUrl =
+      '<a class="test-link" href=https://www.example.com>Example</a>';
+    component.visible = true;
+    fixture.detectChanges();
+
+    const externalLinkBody =
+      fixture.debugElement.nativeElement.querySelector('.link-body');
+
+    expect(externalLinkBody).toBeTruthy();
+
+    const externalLink =
+      fixture.debugElement.nativeElement.querySelector('.test-link');
+
+    expect(externalLink).toBeTruthy();
+    expect(externalLink.href).toEqual('https://www.example.com/');
+  });
 });

--- a/src/app/shared/components/message/message.component.ts
+++ b/src/app/shared/components/message/message.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Component, OnInit } from '@angular/core';
 import { MessageService } from '@shared/services/message/message.service';
 import { Router } from '@angular/router';
@@ -8,12 +9,13 @@ interface Message {
   style: string;
   navigateTo?: string[];
   navigateParams?: any;
+  externalUrl?: string;
 }
 
 @Component({
   selector: 'pr-message',
   templateUrl: './message.component.html',
-  styleUrls: ['./message.component.scss']
+  styleUrls: ['./message.component.scss'],
 })
 export class MessageComponent implements OnInit {
   displayText: string;
@@ -23,6 +25,7 @@ export class MessageComponent implements OnInit {
   useFade = this.iFrame.isIFrame();
   style: string;
   queue: Message[] = [];
+  externalUrl: string;
 
   private displayTime = 9000;
 
@@ -34,25 +37,39 @@ export class MessageComponent implements OnInit {
     this.service.registerComponent(this);
   }
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
-  display(textToDisplay: string, style?: string, navigateTo?: string[], navigateParams = {}) {
+  display(
+    textToDisplay: string,
+    style?: string,
+    navigateTo?: string[],
+    navigateParams = {},
+    externalUrl?: string
+  ) {
     if (this.visible) {
-      this.queue.push({text: textToDisplay, style: style, navigateTo: navigateTo, navigateParams: navigateParams});
+      this.queue.push({
+        text: textToDisplay,
+        style: style,
+        navigateTo: navigateTo,
+        navigateParams: navigateParams,
+        externalUrl: externalUrl,
+      });
     } else {
       this.displayText = textToDisplay;
       this.navigateTo = navigateTo;
       this.navigateParams = navigateParams;
       this.style = style ? `alert-${style}` : null;
       this.visible = true;
+      this.externalUrl = externalUrl;
       setTimeout(this.dismiss.bind(this), this.displayTime);
     }
   }
 
   onClick() {
     if (this.navigateTo) {
-      this.router.navigate(this.navigateTo, { queryParams: this.navigateParams});
+      this.router.navigate(this.navigateTo, {
+        queryParams: this.navigateParams,
+      });
     }
 
     this.dismiss();
@@ -62,9 +79,18 @@ export class MessageComponent implements OnInit {
     this.visible = false;
     if (this.queue.length) {
       const message = this.queue.shift();
-      setTimeout(() => this.display(message.text, message.style, message.navigateTo), 500);
+      setTimeout(
+        () =>
+          this.display(
+            message.text,
+            message.style,
+            message.navigateTo,
+            message.navigateParams,
+            message.externalUrl
+          ),
+        500
+      );
     }
     return false;
   }
-
 }

--- a/src/app/shared/components/message/message.component.ts
+++ b/src/app/shared/components/message/message.component.ts
@@ -10,6 +10,7 @@ interface Message {
   navigateTo?: string[];
   navigateParams?: any;
   externalUrl?: string;
+  externalMessage?: string;
 }
 
 @Component({
@@ -26,6 +27,7 @@ export class MessageComponent implements OnInit {
   style: string;
   queue: Message[] = [];
   externalUrl: string;
+  externalMessage: string;
 
   private displayTime = 9000;
 
@@ -44,7 +46,8 @@ export class MessageComponent implements OnInit {
     style?: string,
     navigateTo?: string[],
     navigateParams = {},
-    externalUrl?: string
+    externalUrl?: string,
+    externalMessage?: string
   ) {
     if (this.visible) {
       this.queue.push({
@@ -53,6 +56,7 @@ export class MessageComponent implements OnInit {
         navigateTo: navigateTo,
         navigateParams: navigateParams,
         externalUrl: externalUrl,
+        externalMessage: externalMessage,
       });
     } else {
       this.displayText = textToDisplay;
@@ -61,6 +65,7 @@ export class MessageComponent implements OnInit {
       this.style = style ? `alert-${style}` : null;
       this.visible = true;
       this.externalUrl = externalUrl;
+      this.externalMessage = externalMessage;
       setTimeout(this.dismiss.bind(this), this.displayTime);
     }
   }
@@ -86,7 +91,8 @@ export class MessageComponent implements OnInit {
             message.style,
             message.navigateTo,
             message.navigateParams,
-            message.externalUrl
+            message.externalUrl,
+            message.externalMessage
           ),
         500
       );

--- a/src/app/shared/services/message/message.service.ts
+++ b/src/app/shared/services/message/message.service.ts
@@ -23,7 +23,8 @@ export class MessageService {
     translate?: boolean,
     navigateTo?: string[],
     navigateParams?: any,
-    externalUrl?: string
+    externalUrl?: string,
+    externalMessage?: string
   ) {
     if (!this.component) {
       throw new Error('MessageService - Missing component');
@@ -35,7 +36,8 @@ export class MessageService {
         style,
         navigateTo,
         navigateParams,
-        externalUrl
+        externalUrl,
+        externalMessage
       );
     } else {
       this.component.display(
@@ -43,7 +45,8 @@ export class MessageService {
         style,
         navigateTo,
         navigateParams,
-        externalUrl
+        externalUrl,
+        externalMessage
       );
     }
   }
@@ -53,7 +56,8 @@ export class MessageService {
     translate?: boolean,
     navigateTo?: string[],
     navigateParams?: any,
-    externalUrl?: string
+    externalUrl?: string,
+    externalMessage?: string
   ) {
     return this.showMessage(
       message,
@@ -61,7 +65,8 @@ export class MessageService {
       translate,
       navigateTo,
       navigateParams,
-      externalUrl
+      externalUrl,
+      externalMessage
     );
   }
 }

--- a/src/app/shared/services/message/message.service.ts
+++ b/src/app/shared/services/message/message.service.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { Injectable } from '@angular/core';
 import { MessageComponent } from '@shared/components/message/message.component';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
@@ -6,7 +7,7 @@ import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.s
 export class MessageService {
   private component: MessageComponent;
 
-  constructor(private constants: PrConstantsService) { }
+  constructor(private constants: PrConstantsService) {}
 
   registerComponent(toRegister: MessageComponent) {
     if (this.component) {
@@ -18,24 +19,49 @@ export class MessageService {
 
   public showMessage(
     message: string,
-    style ?: 'success' | 'info' | 'warning' | 'danger',
-    translate ?: boolean,
-    navigateTo ?: string[],
-    navigateParams ?: any
+    style?: 'success' | 'info' | 'warning' | 'danger',
+    translate?: boolean,
+    navigateTo?: string[],
+    navigateParams?: any,
+    externalUrl?: string
   ) {
     if (!this.component) {
       throw new Error('MessageService - Missing component');
     }
 
     if (!translate) {
-      this.component.display(message, style, navigateTo, navigateParams);
+      this.component.display(
+        message,
+        style,
+        navigateTo,
+        navigateParams,
+        externalUrl
+      );
     } else {
-      this.component.display(this.constants.translate(message), style, navigateTo, navigateParams);
+      this.component.display(
+        this.constants.translate(message),
+        style,
+        navigateTo,
+        navigateParams,
+        externalUrl
+      );
     }
-
   }
 
-  public showError(message: string, translate ?: boolean, navigateTo ?: string[]) {
-    return this.showMessage(message, 'danger', translate, navigateTo);
+  public showError(
+    message: string,
+    translate?: boolean,
+    navigateTo?: string[],
+    navigateParams?: any,
+    externalUrl?: string
+  ) {
+    return this.showMessage(
+      message,
+      'danger',
+      translate,
+      navigateTo,
+      navigateParams,
+      externalUrl
+    );
   }
 }


### PR DESCRIPTION
- Add a new message type to the message service to handle the permission error
- Made it possible to pass a html string to the message service, which can be used as an external link (ex:'Read More in case of error')

Steps to test:
1. Navigate to any archive where your role is viewer
2. Try uploading a file by drag and drop
3. It should display the following error message: You do not have permission to upload to this archive. [Read more.](https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing)