### PR TITLE
Enable `storybook/prefer-pascal-case` linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -173,6 +173,7 @@ module.exports = {
         'import/no-default-export': 'off',
         'import/no-extraneous-dependencies': 'off',
         '@angular-eslint/component-selector': 'off',
+        'storybook/prefer-pascal-case': 'error',
       },
     },
   ],

--- a/src/app/component-library/components/button/button.stories.ts
+++ b/src/app/component-library/components/button/button.stories.ts
@@ -66,44 +66,44 @@ const meta: Meta<ButtonComponent> = {
 export default meta;
 type ButtonStory = StoryObj<ButtonComponent>;
 
-export const primaryMedium: ButtonStory = {
+export const PrimaryMedium: ButtonStory = {
   args: { variant: 'primary', text: 'Primary' },
 };
 
-export const secondaryMedium: ButtonStory = {
+export const SecondaryMedium: ButtonStory = {
   args: { variant: 'secondary', text: 'Secondary' },
 };
 
-export const primaryLarge: ButtonStory = {
+export const PrimaryLarge: ButtonStory = {
   args: { variant: 'primary', text: 'Primary', height: 'large' },
 };
 
-export const secondaryLarge: ButtonStory = {
+export const SecondaryLarge: ButtonStory = {
   args: { variant: 'secondary', text: 'Secondary', height: 'large' },
 };
 
-export const primaryFill: ButtonStory = {
+export const PrimaryFill: ButtonStory = {
   args: { variant: 'primary', text: 'Primary', size: 'fill' },
 };
 
-export const secondaryFill: ButtonStory = {
+export const SecondaryFill: ButtonStory = {
   args: { variant: 'secondary', text: 'Secondary', size: 'fill' },
 };
 
-export const darkModePrimary: ButtonStory = {
+export const DarkModePrimary: ButtonStory = {
   args: { variant: 'primary', text: 'Primary', mode: 'dark' },
   parameters: {
     backgrounds,
   },
 };
 
-export const darkModeSecondary: ButtonStory = {
+export const DarkModeSecondary: ButtonStory = {
   args: { variant: 'secondary', text: 'Secondary', mode: 'dark' },
   parameters: {
     backgrounds,
   },
 };
 
-export const tertiaryButton: ButtonStory = {
+export const TertiaryButton: ButtonStory = {
   args: { variant: 'tertiary', text: 'Tertiary' },
 };

--- a/src/app/component-library/components/form-input/form-input.stories.ts
+++ b/src/app/component-library/components/form-input/form-input.stories.ts
@@ -74,15 +74,15 @@ const meta: Meta<FormInputComponent> = {
 export default meta;
 type FormInputStory = StoryObj<FormInputComponent>;
 
-export const light: FormInputStory = {
+export const Light: FormInputStory = {
   args: { type: 'text', placeholder: 'Text', variant: 'light' },
 };
 
-export const lightDarkBackground: FormInputStory = {
+export const LightDarkBackground: FormInputStory = {
   args: { type: 'text', placeholder: 'Text', variant: 'light' },
   parameters: { backgrounds },
 };
 
-export const dark = {
+export const Dark = {
   args: { type: 'text', placeholder: 'Text', variant: 'dark' },
 };


### PR DESCRIPTION
This linting rule is enabled to warn by default, but warnings are pretty much useless for our CI pipeline. Set this to throw an error when violated, and then update existing violations of this linting rule.