### PR TITLE
Enable `jasmine/no-disabled-tests` linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,9 +12,9 @@ module.exports = {
       env: { jasmine: true },
       rules: {
         'jasmine/new-line-before-expect': 'error',
+        'jasmine/no-disabled-tests': 'error',
         // We intend to enable these eventually:
         'jasmine/new-line-between-declarations': 'off',
-        'jasmine/no-disabled-tests': 'off',
         'jasmine/no-promise-without-done-fail': 'off',
         'jasmine/no-spec-dupes': 'off',
         'jasmine/no-unsafe-spy': 'off',

--- a/src/app/auth/components/logo/logo.component.spec.ts
+++ b/src/app/auth/components/logo/logo.component.spec.ts
@@ -2,15 +2,14 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { LogoComponent } from '@auth/components/logo/logo.component';
 
-xdescribe('LogoComponent', () => {
+describe('LogoComponent', () => {
   let component: LogoComponent;
   let fixture: ComponentFixture<LogoComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ LogoComponent ]
-    })
-    .compileComponents();
+      declarations: [LogoComponent],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/auth/components/mfa/mfa.component.spec.ts
+++ b/src/app/auth/components/mfa/mfa.component.spec.ts
@@ -6,28 +6,23 @@ import { CookieService } from 'ngx-cookie-service';
 
 import { MfaComponent } from '@auth/components/mfa/mfa.component';
 import { LogoComponent } from '@auth/components/logo/logo.component';
+import { MessageService } from '@shared/services/message/message.service';
 
-xdescribe('MfaComponent', () => {
+describe('MfaComponent', () => {
   let component: MfaComponent;
   let fixture: ComponentFixture<MfaComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        MfaComponent,
-        LogoComponent
-      ],
+      declarations: [MfaComponent, LogoComponent],
       imports: [
         FormsModule,
         ReactiveFormsModule,
         HttpClientTestingModule,
-        RouterTestingModule
+        RouterTestingModule,
       ],
-      providers: [
-        CookieService
-      ]
-    })
-    .compileComponents();
+      providers: [CookieService, MessageService],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/core/components/nav/nav.component.spec.ts
+++ b/src/app/core/components/nav/nav.component.spec.ts
@@ -1,11 +1,12 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
-import { cloneDeep  } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { NavComponent } from '@core/components/nav/nav.component';
 import { LeftMenuComponent } from '@core/components/left-menu/left-menu.component';
+import { RightMenuComponent } from '../right-menu/right-menu.component';
 
-xdescribe('NavComponent', () => {
+describe('NavComponent', () => {
   let component: NavComponent;
   let fixture: ComponentFixture<NavComponent>;
 
@@ -14,6 +15,7 @@ xdescribe('NavComponent', () => {
 
     config.declarations.push(NavComponent);
     config.declarations.push(LeftMenuComponent);
+    config.declarations.push(RightMenuComponent);
 
     TestBed.configureTestingModule(config).compileComponents();
   }));

--- a/src/app/shared/components/archive-picker/archive-picker.component.spec.ts
+++ b/src/app/shared/components/archive-picker/archive-picker.component.spec.ts
@@ -1,16 +1,27 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DIALOG_DATA, DialogRef } from '@root/app/dialog/dialog.service';
+import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
 import { ArchivePickerComponent } from './archive-picker.component';
 
-xdescribe('ArchivePickerComponent', () => {
+describe('ArchivePickerComponent', () => {
   let component: ArchivePickerComponent;
   let fixture: ComponentFixture<ArchivePickerComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ ArchivePickerComponent ]
-    })
-    .compileComponents();
+      declarations: [ArchivePickerComponent],
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: DialogRef, useValue: {} },
+        { provide: DIALOG_DATA, useValue: {} },
+        { provide: ApiService, useValue: {} },
+        { provide: AccountService, useValue: {} },
+        MessageService,
+      ],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
@@ -152,7 +152,7 @@ describe('InlineValueEditComponent', () => {
     expect(component.isEditing).toBeFalsy();
   });
 
-  xit('should set initial date and time based on local time with no timezone passed', () => {
+  it('should set initial date and time based on local time with no timezone passed', () => {
     const displayDT = formatDateISOString('2017-05-13T16:36:29.000000');
     component.displayValue = displayDT;
     component.type = 'date';
@@ -168,7 +168,7 @@ describe('InlineValueEditComponent', () => {
     expect(component.ngbTime.hour).toBe(momentFormatNum(local, 'H'));
   });
 
-  xit('should set initial date and time based on timezone', () => {
+  it('should set initial date and time based on timezone', () => {
     const voData: RecordVOData = {
       accessRole: 'access.role.owner',
       displayDT: '2017-05-13T16:36:29.000000',
@@ -198,7 +198,7 @@ describe('InlineValueEditComponent', () => {
     expect(component.ngbTime.hour).toBe(momentFormatNum(offset, 'H'));
   });
 
-  xit('should default to current date and time based on timezone', () => {
+  it('should default to current date and time based on timezone', () => {
     const voData: RecordVOData = {
       accessRole: 'access.role.owner',
       displayDT: null,
@@ -227,7 +227,7 @@ describe('InlineValueEditComponent', () => {
     expect(component.ngbTime.hour).toBe(momentFormatNum(offset, 'H'));
   });
 
-  xit('should default to current date and time in local timezone when missing timezone', () => {
+  it('should default to current date and time in local timezone when missing timezone', () => {
     const voData: RecordVOData = {
       displayDT: null,
       accessRole: 'access.role.owner',
@@ -354,15 +354,16 @@ describe('InlineValueEditComponent', () => {
     expect((component.editValue as string).length).toBe(10);
   });
 
-  xit('should update edit value when time is changed', () => {
+  it('should update edit value when time is changed', () => {
     const voData: RecordVOData = {
       accessRole: 'access.role.owner',
       displayDT: '2017-05-14T02:36:29.000000',
       TimezoneVO: {
         dstAbbrev: 'PDT',
         dstOffset: '-07:00',
-        stdAbbrev: 'PST',
-        stdOffset: '-08:00',
+        stdAbbrev: 'PDT',
+        stdOffset: '-07:00',
+        // Do not use DST so that this test passes all year long.
       },
     };
     const record = new RecordVO(voData);

--- a/src/app/shared/directives/bg-image-src.directive.spec.ts
+++ b/src/app/shared/directives/bg-image-src.directive.spec.ts
@@ -1,6 +1,0 @@
-import { BgImageSrcDirective } from '@shared/directives/bg-image-src.directive';
-
-xdescribe('BgImageSrcDirective', () => {
-  it('should create an instance', () => {
-  });
-});

--- a/src/app/shared/services/prompt/prompt.service.spec.ts
+++ b/src/app/shared/services/prompt/prompt.service.spec.ts
@@ -2,10 +2,10 @@ import { TestBed, inject } from '@angular/core/testing';
 
 import { PromptService } from '@shared/services/prompt/prompt.service';
 
-xdescribe('PromptService', () => {
+describe('PromptService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [PromptService]
+      providers: [PromptService],
     });
   });
 


### PR DESCRIPTION
A few tests throughout the codebase have been disabled. We shouldn't be committing skipped tests. Enable the no-disabled-tests linting rule to force us to either enable or delete disabled tests. This linting rule was chosen because it should (hopefully) not create any conflicts with currently open pull requests. Also because these skipped tests have been around forever!

<details>
<summary>(additional reason why we should enable this linting rule)</summary>

![It's free test coverage](https://github.com/PermanentOrg/web-app/assets/9145247/b0ad8d12-00d0-4062-83c0-420a43c87718)

</details>