### PR TITLE
Fix failing MainComponent test

### DIFF
--- a/src/app/core/components/main/main.component.spec.ts
+++ b/src/app/core/components/main/main.component.spec.ts
@@ -45,6 +45,16 @@ describe('MainComponent', () => {
   let mockDragEvents: Subject<DragServiceEvent>;
 
   async function init(authResponseData = defaultAuthData) {
+    mockDragEvents = new Subject<DragServiceEvent>();
+    mockDragService = jasmine.createSpyObj('DragService', [
+      'getDestinationFromDropTarget',
+      'events',
+    ]);
+    mockDragService.events.and.returnValue(mockDragEvents.asObservable());
+    mockDragService.getDestinationFromDropTarget.and.returnValue(
+      new FolderVO({ type: 'type.folder.public' })
+    );
+
     const config = cloneDeep(Testing.BASE_TEST_CONFIG);
 
     config.imports.push(SharedModule);
@@ -82,16 +92,6 @@ describe('MainComponent', () => {
 
     promptService = TestBed.inject(PromptService);
     spyOn(promptService, 'confirm');
-
-    mockDragEvents = new Subject<DragServiceEvent>();
-    mockDragService = jasmine.createSpyObj('DragService', [
-      'getDestinationFromDropTarget',
-      'events',
-    ]);
-    mockDragService.events.and.returnValue(mockDragEvents.asObservable());
-    mockDragService.getDestinationFromDropTarget.and.returnValue(
-      new FolderVO({ type: 'type.folder.public' })
-    );
 
     fixture = TestBed.createComponent(MainComponent);
     component = fixture.componentInstance;


### PR DESCRIPTION
This test fails sometimes because the test module is provided with an undefined MockDragService. Initialize this mock before setting up providers so that this test passes regardless of which order tests are run in.

**Steps to test:**
1. Start the test runner with `npm run test`
2. Open the Karma debugger in your browser by navigating to http://localhost:9876/debug.html
3. Set the random seed to 83937 by adding `?seed=83937` at the end of the URL
4. On the current mainline branch, a test should fail in `MainComponent`
5. On this branch the test should pass.