### PR TITLE
PER-9482: left side archive info not matching the file list items displayed

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -207,7 +207,7 @@ export class AccountService {
           const newArchive = response.getArchiveVO();
           const newAccount = response.getAccountVO();
           const account = this.getStorage('account');
-          newAccount.keepLoggedIn = account.keepLoggedIn;
+          newAccount.keepLoggedIn = account?.keepLoggedIn;
           this.account.update(newAccount);
           this.archive.update(newArchive);
           this.setStorage(newAccount.keepLoggedIn, ARCHIVE_KEY, this.archive);
@@ -646,7 +646,7 @@ export class AccountService {
     }
   }
 
-  private getStorage(key) {
+  public getStorage(key) {
     return this.storage.local.get(key) || this.storage.session.get(key);
   }
 

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -206,9 +206,11 @@ export class AccountService {
         if (loggedIn) {
           const newArchive = response.getArchiveVO();
           const newAccount = response.getAccountVO();
+          const account = this.getStorage('account');
+          newAccount.keepLoggedIn = account.keepLoggedIn;
           this.account.update(newAccount);
           this.archive.update(newArchive);
-          this.setStorage(this.account.keepLoggedIn, ARCHIVE_KEY, this.archive);
+          this.setStorage(newAccount.keepLoggedIn, ARCHIVE_KEY, this.archive);
         } else {
           throw loggedIn;
         }

--- a/src/app/shared/services/account/tests/refreshAccount.spec.ts
+++ b/src/app/shared/services/account/tests/refreshAccount.spec.ts
@@ -127,6 +127,9 @@ describe('AccountService: refreshAccount', () => {
     let localStorageSpy;
     if (services.storage) {
       localStorageSpy = spyOn(services.storage.local, 'set').and.callThrough();
+      spyOn(services.instance, 'getStorage').and.returnValue(
+        new AccountVO({ keepLoggedIn: true })
+      );
     }
 
     return { logOutSpy, localStorageSpy };


### PR DESCRIPTION
Get the account saved in the storage then use the keepLoggedIn flag from the storage account instead of the account service variable, because the variable was refreshing on each refresh, making keepLoggedIn null