### PR TITLE
Remove setTimeout from InlineValueEdit test

### DIFF
--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.spec.ts
@@ -136,11 +136,10 @@ describe('InlineValueEditComponent', () => {
     cancelButton.dispatchEvent(new Event('mousedown'));
 
     fixture.detectChanges();
+    await fixture.whenStable();
 
-    setTimeout(() => {
-      expect(onBlurSpy).toHaveBeenCalledTimes(1);
-      expect(doneEditingSpy).not.toHaveBeenCalled();
-    });
+    expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    expect(doneEditingSpy).not.toHaveBeenCalled();
   });
 
   it('should not allow editing if canEdit is false', async () => {


### PR DESCRIPTION
This may be the cause of some intermittent test failures, as all random test failures observed from this suite happen outside of a test, which would only happen when asyncronous code is still running after tests are marked complete.

Since the test is already marked as async, we can just await before making assertions rather than using setTimeout.

I can't reliably recreate the test failure, so I can't prove that this actually fixes things, but my theory is that some random async race conditions are causing these issues and so using `await` (alternatively we could have passed `done` into the setTimeout, but I think this is a better way of doing things in a test that's already async). At the very least, if random test failures persist in this test, it will be more easily debuggable since the test failure is not in a `setTimeout` anymore (though I do think this fixes the failure).