### PR TITLE
Enable jasmine/new-line-between-declarations linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,8 +13,8 @@ module.exports = {
       rules: {
         'jasmine/new-line-before-expect': 'error',
         'jasmine/no-disabled-tests': 'error',
+        'jasmine/new-line-between-declarations': 'error',
         // We intend to enable these eventually:
-        'jasmine/new-line-between-declarations': 'off',
         'jasmine/no-promise-without-done-fail': 'off',
         'jasmine/no-spec-dupes': 'off',
         'jasmine/no-unsafe-spy': 'off',

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.spec.ts
@@ -38,25 +38,30 @@ describe('AndroidAppNotifyComponent', () => {
     prompted = false;
     shallow = new Shallow(AndroidAppNotifyComponent, AnnouncementModule);
   });
+
   afterEach(() => {
     localStorage.clear();
   });
+
   it('should exist', async () => {
     const { element } = await shallow.render();
 
     expect(element).not.toBeNull();
   });
+
   it('should be invisible before `beforeinstallprompt` event', async () => {
     const { find } = await shallow.render();
 
     expect(find('div').length).toBe(0);
   });
+
   it('should appear when the `beforeinstallprompt` fires', async () => {
     const { find, fixture } = await shallow.render();
     await waitForPromptEvent(fixture);
 
     expect(find('div').length).toBeGreaterThan(0);
   });
+
   it('has a clickable button that shows the prompt', async () => {
     const { find, fixture } = await shallow.render();
     await waitForPromptEvent(fixture);
@@ -64,6 +69,7 @@ describe('AndroidAppNotifyComponent', () => {
 
     expect(prompted).toBeTruthy();
   });
+
   it('should dismiss itself after the App Install Banner appears', async () => {
     const { find, fixture } = await shallow.render();
     await waitForPromptEvent(fixture);
@@ -74,6 +80,7 @@ describe('AndroidAppNotifyComponent', () => {
 
     expect(find('div').length).toBe(0);
   });
+
   it('should be dismissable from a close button', async () => {
     const { find, fixture } = await shallow.render();
     await waitForPromptEvent(fixture);
@@ -88,6 +95,7 @@ describe('AndroidAppNotifyComponent', () => {
 
     expect(dismissed).toBeTruthy();
   });
+
   it('should not show up if previously dismissed', async () => {
     localStorage.setItem(AndroidAppNotifyComponent.storageKey, 'true');
     const { find, fixture } = await shallow.render();

--- a/src/app/announcement/components/announcement/announcement.component.spec.ts
+++ b/src/app/announcement/components/announcement/announcement.component.spec.ts
@@ -44,33 +44,40 @@ describe('AnnouncementComponent', () => {
   beforeEach(() => {
     shallow = new Shallow(AnnouncementComponent, AnnouncementModule);
   });
+
   afterEach(() => {
     window.localStorage.clear();
   });
+
   it('should exist', async () => {
     expect(shallow).not.toBeNull();
   });
+
   it('should take in test data', async () => {
     const { element } = await defaultRender([currentTestEvent]);
 
     expect(element).not.toBeNull();
   });
+
   it('should display the message', async () => {
     const { find, element } = await defaultRender([currentTestEvent]);
 
     expect(find('.announcement').length).toBeGreaterThan(0);
     expect(element.nativeElement.innerText).toContain('Test Event!!!');
   });
+
   it('should hide itself if event is in the future', async () => {
     const { find } = await defaultRender([futureTestEvent]);
 
     expect(find('.announcement').length).toBe(0);
   });
+
   it('should hide itself if the event is already over', async () => {
     const { find } = await defaultRender([pastTestEvent]);
 
     expect(find('.announcement').length).toBe(0);
   });
+
   it('should support multiple event definitions', async () => {
     const { find, element } = await defaultRender([
       pastTestEvent,
@@ -81,6 +88,7 @@ describe('AnnouncementComponent', () => {
     expect(find('.announcement').length).toBe(1);
     expect(element.nativeElement.innerText).toContain('Test Event!!!');
   });
+
   it('should be dismissable', async () => {
     const { find, fixture, element } = await defaultRender([currentTestEvent]);
 
@@ -90,6 +98,7 @@ describe('AnnouncementComponent', () => {
 
     expect(find('.announcement').length).toBe(0);
   });
+
   it('should set dismissed setting in localStorage', async () => {
     const { find, fixture, instance } = await defaultRender([currentTestEvent]);
 
@@ -101,6 +110,7 @@ describe('AnnouncementComponent', () => {
       currentTestEvent.start.toString()
     );
   });
+
   it('should recall dismissed setting from localStorage', async () => {
     window.localStorage.setItem(
       'announcementDismissed',
@@ -110,22 +120,26 @@ describe('AnnouncementComponent', () => {
 
     expect(find('.announcement').length).toBe(0);
   });
+
   it('should still be able to show a new announcement after dismissing a previous one', async () => {
     window.localStorage.setItem('announcementDismissed', 'pastevent');
     const { find } = await defaultRender([currentTestEvent]);
 
     expect(find('.announcement').length).toBe(1);
   });
+
   it('should be able to handle an empty data array', async () => {
     const { find } = await defaultRender([]);
 
     expect(find('.announcement').length).toBe(0);
   });
+
   it('should be able to handle the null case', async () => {
     const { find } = await defaultRender();
 
     expect(find('.announcement').length).toBe(0);
   });
+
   describe('Layout Adjustment', () => {
     async function renderWithAdjustables() {
       return await shallow.render(
@@ -152,6 +166,7 @@ describe('AnnouncementComponent', () => {
         expect(element.nativeElement.style.paddingTop).not.toBeUndefined();
       });
     });
+
     it('should readjust the page layout when it disappears', async () => {
       const { find, fixture } = await renderWithAdjustables();
       find('.dismiss-button').nativeElement.click();

--- a/src/app/archive-settings/manage-metadata/pipes/metadata-value.pipe.spec.ts
+++ b/src/app/archive-settings/manage-metadata/pipes/metadata-value.pipe.spec.ts
@@ -5,19 +5,24 @@ describe('MetadataValuePipe', () => {
   beforeEach(() => {
     pipe = new MetadataValuePipe();
   });
+
   it('can create an instance', () => {
     expect(pipe).toBeTruthy();
   });
+
   it('gets custom metadata value', () => {
     expect(pipe.transform('a:1')).toBe('1');
   });
+
   describe('weird cases', () => {
     it('no : separator', () => {
       expect(pipe.transform('potato')).toBe('potato');
     });
+
     it('multiple : separators', () => {
       expect(pipe.transform('a:b:c')).toBe('b:c');
     });
+
     it('empty string', () => {
       expect(pipe.transform('')).toBe('');
     });

--- a/src/app/component-library/components/form-input/form-input.component.spec.ts
+++ b/src/app/component-library/components/form-input/form-input.component.spec.ts
@@ -122,6 +122,7 @@ describe('FormInputComponent', () => {
 
     expect(instance.rightAlign).toBeTrue();
   });
+
   it('should bind the placeholder attribute to the input element', async () => {
     const mockControl = new UntypedFormControl('');
     const placeholderValue = 'Enter text here';

--- a/src/app/core/components/gift-storage/gift-storage.component.spec.ts
+++ b/src/app/core/components/gift-storage/gift-storage.component.spec.ts
@@ -159,6 +159,7 @@ describe('GiftStorageComponent', () => {
       message: '',
     });
   });
+
   it('updates account details upon successful gift operation', async () => {
     const { instance } = await shallow.render();
 
@@ -180,6 +181,7 @@ describe('GiftStorageComponent', () => {
     expect(mockAccountService.setAccount).toHaveBeenCalled();
     expect(instance.availableSpace).toBe('50.00');
   });
+
   it('parses the email string correctly', async () => {
     const { instance } = await shallow.render();
 

--- a/src/app/core/components/manage-tags/manage-tags.component.spec.ts
+++ b/src/app/core/components/manage-tags/manage-tags.component.spec.ts
@@ -201,15 +201,19 @@ describe('ManageTagsComponent #manage-tags', () => {
     it('Trimming input', async () => {
       testValue('  p ', 1);
     });
+
     it('Case-insensitivity', async () => {
       testValue('tOm', 1);
     });
+
     it('Searches anywhere in word', async () => {
       testValue('To', 2);
     });
+
     it('Completely invalid match', async () => {
       testValue('zzz', 0);
     });
+
     it('Null case', async () => {
       testValue('', 2);
     });
@@ -227,6 +231,7 @@ describe('ManageTagsComponent #manage-tags', () => {
     it('should not delete when you cancel out', async () => {
       testConfirm(false);
     });
+
     it('should delete when you click confirm', async () => {
       testConfirm(true);
     });

--- a/src/app/core/components/public-settings/public-settings.component.spec.ts
+++ b/src/app/core/components/public-settings/public-settings.component.spec.ts
@@ -67,6 +67,7 @@ describe('PublicSettingsComponent', () => {
 
       expect(element.componentInstance.allowDownloadsToggle).toBeTruthy();
     });
+
     it('off', async () => {
       const { element } = await defaultRender({
         allowPublicDownload: false,

--- a/src/app/dialog/dialog.component.spec.ts
+++ b/src/app/dialog/dialog.component.spec.ts
@@ -35,6 +35,7 @@ describe('DialogComponent', () => {
     expect(instance.width).toEqual('100px');
     expect(instance.borderRadius).toEqual('10px');
   });
+
   it('closes dialog on menu wrapper click', async () => {
     const { instance, find } = await shallow.render();
     spyOn(instance, 'onMenuWrapperClick').and.callThrough();

--- a/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
+++ b/src/app/directive/components/directive-edit/directive-edit.component.spec.ts
@@ -173,6 +173,7 @@ describe('DirectiveEditComponent', () => {
     expect(find('.account-not-found').length).toBe(0);
     expect(MockMessageService.errorShown).toBeTrue();
   });
+
   it('should handle API errors on editing', async () => {
     MockDirectiveRepo.failRequest = true;
     const directive = await createDirective(
@@ -194,6 +195,7 @@ describe('DirectiveEditComponent', () => {
     expect(find('.account-not-found').length).toBe(0);
     expect(MockMessageService.errorShown).toBeTrue();
   });
+
   it('should emit an output when a directive is created', async () => {
     const { find, fixture, instance } = await shallow.render();
     let savedDirective: DirectiveData;
@@ -210,6 +212,7 @@ describe('DirectiveEditComponent', () => {
     expect(instance.savedDirective.emit).toHaveBeenCalled();
     expect(savedDirective).not.toBeUndefined();
   });
+
   it('should emit an output when a directive is edited', async () => {
     const directive = await createDirective(
       'existing@example.com',
@@ -234,6 +237,7 @@ describe('DirectiveEditComponent', () => {
     expect(instance.savedDirective.emit).toHaveBeenCalled();
     expect(savedDirective).not.toBeUndefined();
   });
+
   it('should not allow submitting a form until email is filled out', async () => {
     const { find, fixture } = await shallow.render();
     fillOutForm(find, '  ', 'Test Memo');
@@ -249,6 +253,7 @@ describe('DirectiveEditComponent', () => {
 
     expect(find('.save-btn').nativeElement.disabled).toBeFalsy();
   });
+
   it('should show an error message if a user with the given email does not exist when creating a directive', async () => {
     MockDirectiveRepo.accountExists = false;
     const { find, fixture, outputs } = await shallow.render();
@@ -271,6 +276,7 @@ describe('DirectiveEditComponent', () => {
     expect(outputs.savedDirective.emit).toHaveBeenCalled();
     expect(find('.account-not-found').length).toBe(0);
   });
+
   it('should show an error message if a user with the given email does not exist when editing', async () => {
     MockDirectiveRepo.accountExists = false;
     const directive = await createDirective(

--- a/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
+++ b/src/app/directive/components/legacy-contact-display/legacy-contact-display.component.spec.ts
@@ -36,6 +36,7 @@ describe('LegacyContactDisplayComponent', () => {
 
     expect(instance).toBeTruthy();
   });
+
   it('should list legacy contact information', async () => {
     MockDirectiveRepo.legacyContactName = 'Test User';
     MockDirectiveRepo.legacyContactEmail = 'test@example.com';
@@ -53,6 +54,7 @@ describe('LegacyContactDisplayComponent', () => {
 
     expect(find('.not-assigned').length).toBe(0);
   });
+
   it('should show "not assigned" if no legacy contact', async () => {
     const { find } = await shallow.render();
 
@@ -66,6 +68,7 @@ describe('LegacyContactDisplayComponent', () => {
 
     expect(find('.not-assigned').length).toBe(2);
   });
+
   it('should show an error message if there was an error fetching legacy contact', async () => {
     MockDirectiveRepo.throwError = true;
     const { find } = await shallow.render();
@@ -74,12 +77,14 @@ describe('LegacyContactDisplayComponent', () => {
     expect(find('.legacy-contact-email').length).toBe(0);
     expect(find('.error').length).toBe(1);
   });
+
   it('should emit an event when the edit button is pressed', async () => {
     const { find, fixture, outputs } = await shallow.render();
     find('button').nativeElement.dispatchEvent(new Event('click'));
 
     expect(outputs.beginEdit.emit).toHaveBeenCalled();
   });
+
   it('should emit an event when the legacy contact is fetched', async () => {
     const { fixture, outputs } = await shallow.render();
     await fixture.whenStable();

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
@@ -303,6 +303,7 @@ describe('FileViewerComponent', () => {
 
         expect(navigatedUrl).toContain('1234-1234');
       });
+
       it('should navigate after the record has been fetched if it is still fetching', async () => {
         const secondItemFetching = Object.assign({}, secondItem, {
           isFetching: true,

--- a/src/app/filesystem/folder-cache.spec.ts
+++ b/src/app/filesystem/folder-cache.spec.ts
@@ -6,20 +6,24 @@ describe('FolderCache', () => {
   beforeEach(() => {
     cache = new FolderCache();
   });
+
   it('should exist', () => {
     expect(cache).toBeTruthy();
   });
+
   it('should return null if a folder is not cached', () => {
     cache.saveFolder(new FolderVO({ folder_linkId: 10000 }));
 
     expect(cache.getFolder({ folder_linkId: 1 })).toBeNull();
   });
+
   it('should be able to save to the cache', () => {
     const folder = new FolderVO({ folder_linkId: 1 });
     cache.saveFolder(folder);
 
     expect(cache.getFolder({ folder_linkId: 1 })).toEqual(folder);
   });
+
   it('should be able to update an existing cache value', () => {
     const folder = new FolderVO({ folder_linkId: 1 });
     cache.saveFolder(folder);

--- a/src/app/gallery/components/gallery-header/gallery-header.component.spec.ts
+++ b/src/app/gallery/components/gallery-header/gallery-header.component.spec.ts
@@ -35,11 +35,13 @@ describe('GalleryHeaderComponent', () => {
       accountMock
     );
   });
+
   it('should render', async () => {
     const { element } = await defaultRender();
 
     expect(element).not.toBeNull();
   });
+
   it('should render back button when logged in', async () => {
     const { find, element, fixture } = await defaultRender();
 

--- a/src/app/gallery/pipes/archive-type-name.pipe.spec.ts
+++ b/src/app/gallery/pipes/archive-type-name.pipe.spec.ts
@@ -8,6 +8,7 @@ describe('ArchiveTypeNamePipe', () => {
 
     expect(pipe).toBeTruthy();
   });
+
   it('transforms archive types to their proper names', () => {
     const pipe = new ArchiveTypeNamePipe();
 

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
@@ -69,16 +69,19 @@ describe('CreateNewArchiveComponent #onboarding', () => {
       .mock(AccountService, mockAccountService)
       .mock(AnalyticsService, mockAnalyticsService);
   });
+
   it('should exist', async () => {
     const { element } = await shallow.render();
 
     expect(element).not.toBeNull();
   });
+
   it('should emit a progress bar change event on mount', async () => {
     const { outputs } = await shallow.render();
 
     expect(outputs.progress.emit).toHaveBeenCalledWith(0);
   });
+
   it('should NOT show disabled-overlay when selectedValue is truthy', async () => {
     const { find, instance, fixture } = await shallow.render();
     instance.screen = 'create';

--- a/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
@@ -86,17 +86,20 @@ describe('OnboardingComponent #onboarding', () => {
       .mock(AnalyticsService, mockAnalyticsService)
       .replaceModule(RouterModule, RouterTestingModule);
   });
+
   it('should exist', async () => {
     const { element } = await shallow.render();
 
     expect(element).not.toBeNull();
   });
+
   it('should load the create new archive screen as default', async () => {
     const { find, fixture } = await shallow.render();
     fixture.detectChanges();
 
     expect(find('pr-create-new-archive')).toHaveFoundOne();
   });
+
   it('can change screens', async () => {
     const { find, fixture } = await shallow.render();
 
@@ -105,6 +108,7 @@ describe('OnboardingComponent #onboarding', () => {
 
     expect(find('pr-welcome-screen')).toHaveFound(0);
   });
+
   it('stores the newly created archive', async () => {
     const { element, find, fixture } = await shallow.render();
 
@@ -118,6 +122,7 @@ describe('OnboardingComponent #onboarding', () => {
 
     expect(element.componentInstance.currentArchive).not.toBeUndefined();
   });
+
   it('stores an accepted archive invitation', async () => {
     const mockPendingArchive = new ArchiveVO({ status: 'someStatus-pending' });
 
@@ -157,6 +162,7 @@ describe('OnboardingComponent #onboarding', () => {
       element.componentInstance.selectedPendingArchive
     ).not.toBeUndefined();
   });
+
   it('can be tested with debugging component', async () => {
     const { element } = await shallow.render();
 

--- a/src/app/onboarding/components/welcome-screen/welcome-screen.component.spec.ts
+++ b/src/app/onboarding/components/welcome-screen/welcome-screen.component.spec.ts
@@ -19,11 +19,13 @@ describe('WelcomeScreenComponent #onboarding', () => {
   beforeEach(() => {
     shallow = new Shallow(WelcomeScreenComponent, OnboardingModule);
   });
+
   it('should exist', async () => {
     const { find } = await defaultRender();
 
     expect(find('.welcome-screen')).toHaveFoundOne();
   });
+
   it('should display a list of pending archives if they are available', async () => {
     const pendingArchives: ArchiveVO[] = [
       new ArchiveVO({
@@ -34,6 +36,7 @@ describe('WelcomeScreenComponent #onboarding', () => {
 
     expect(find('pr-archive-small')).toHaveFoundOne();
   });
+
   it('should pass up a selected archive', async () => {
     const pendingArchives: ArchiveVO[] = [
       new ArchiveVO({

--- a/src/app/shared/components/new-archive-form/new-archive-form.component.spec.ts
+++ b/src/app/shared/components/new-archive-form/new-archive-form.component.spec.ts
@@ -42,11 +42,13 @@ describe('NewArchiveFormComponent #onboarding', () => {
     //@ts-ignore
     shallow = new Shallow(NewArchiveFormComponent, SharedModule).mock(ApiService, mockApiService);
   });
+
   it('should create', async () => {
     const { element } = await shallow.render();
 
     expect(element).not.toBeNull();
   });
+
   it('should not submit when form is invalid', async () => {
     const { find, fixture, outputs } = await shallow.render();
 
@@ -56,6 +58,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     expect(outputs.success.emit).not.toHaveBeenCalled();
     expect(outputs.error.emit).not.toHaveBeenCalled();
   });
+
   it('should disable button when form is waiting', async () => {
     const { find, fixture } = await shallow.render();
     fillOutForm(find);
@@ -65,6 +68,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
 
     expect(find('button').nativeElement.disabled).toBeTruthy();
   });
+
   it('should create a new archive on submit', async () => {
     const { find, fixture } = await shallow.render();
     fillOutForm(find);
@@ -74,6 +78,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
 
     expect(created).toBeTrue();
   });
+
   it('should output new archiveVO when submitted', async () => {
     const { find, fixture, outputs } = await shallow.render();
     fillOutForm(find);
@@ -87,6 +92,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     expect(createdArchive.relationType).toBeNull();
     expect(outputs.error.emit).not.toHaveBeenCalled();
   });
+
   it('should output errors if they occur', async () => {
     throwError = true;
     const { find, fixture, outputs } = await shallow.render();
@@ -98,6 +104,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
     expect(outputs.error.emit).toHaveBeenCalled();
     expect(outputs.success.emit).not.toHaveBeenCalled();
   });
+
   it('should have an input that enables relations', async () => {
     const { find, fixture } = await shallow.render('<pr-new-archive-form [showRelations]="true"></pr-new-archive-form>');
     fillOutForm(find);
@@ -109,6 +116,7 @@ describe('NewArchiveFormComponent #onboarding', () => {
 
     expect(find('select[name="relation"]')).not.toHaveFoundOne();
   });
+
   it('should submit relationType to API if it is enabled', async () => {
     const { element, find, fixture } = await shallow.render('<pr-new-archive-form [showRelations]="true"></pr-new-archive-form>');
     fillOutForm(find);

--- a/src/app/shared/pipes/access-role.pipe.spec.ts
+++ b/src/app/shared/pipes/access-role.pipe.spec.ts
@@ -7,6 +7,7 @@ describe('GetAltTextPipe', () => {
   beforeEach(() => {
     pipe = new AccessRolePipe();
   });
+
   it('create an instance', () => {
     expect(pipe).toBeTruthy();
   });

--- a/src/app/shared/pipes/get-alt-text.pipe.spec.ts
+++ b/src/app/shared/pipes/get-alt-text.pipe.spec.ts
@@ -8,6 +8,7 @@ describe('GetAltTextPipe', () => {
   beforeEach(() => {
     pipe = new GetAltTextPipe();
   });
+
   it('create an instance', () => {
     expect(pipe).toBeTruthy();
   });

--- a/src/app/shared/services/account/tests/refreshAccount.spec.ts
+++ b/src/app/shared/services/account/tests/refreshAccount.spec.ts
@@ -149,6 +149,7 @@ describe('AccountService: refreshAccount', () => {
     expect(router.navigate).not.toHaveBeenCalled();
     expect(localStorageSpy).toHaveBeenCalled();
   });
+
   it('should redirect the user to the login page if their session expires', async () => {
     const { instance, inject } = shallow.createService();
     const router = inject(Router);
@@ -166,6 +167,7 @@ describe('AccountService: refreshAccount', () => {
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalled();
   });
+
   it('should not redirect the user to login page if their session expires on a public archive', async () => {
     const { instance, inject } = shallow.createService();
     const router = inject(Router);
@@ -186,6 +188,7 @@ describe('AccountService: refreshAccount', () => {
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
   });
+
   it('should not redirect the user to login page if their session expires in the public gallery', async () => {
     const { instance, inject } = shallow.createService();
     const router = inject(Router);
@@ -206,6 +209,7 @@ describe('AccountService: refreshAccount', () => {
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
   });
+
   it('should redirect the user if the account/get call fails', async () => {
     const { instance, inject } = shallow.createService();
     const router = inject(Router);
@@ -223,6 +227,7 @@ describe('AccountService: refreshAccount', () => {
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalled();
   });
+
   it('should not redirect the user if the account/get call fails on the public archive', async () => {
     const { instance, inject } = shallow.createService();
     const router = inject(Router);
@@ -243,6 +248,7 @@ describe('AccountService: refreshAccount', () => {
     expect(logOutSpy).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
   });
+
   it('should not redirect the user if the account/get call fails on the public gallery', async () => {
     const { instance, inject } = shallow.createService();
     const router = inject(Router);

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -250,6 +250,7 @@ describe('HttpV2Service', () => {
       }
     );
   });
+
   it('can have its stela domain configured', () => {
     MockSecretService.stelaDomain = 'https://api.local.permanent.org/api/';
 

--- a/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
+++ b/src/app/shared/utilities/thumbnail-cache/thumbnail-cache.spec.ts
@@ -23,9 +23,11 @@ describe('ThumbnailCache', () => {
       folderContentsType: FolderContentsType.NORMAL,
     };
   });
+
   it('should exist', () => {
     expect(cache).not.toBeNull();
   });
+
   it('should return an empty FolderThumbData object for uncached thumbnail', () => {
     const thumbs = cache.getThumbnail(folder);
 
@@ -33,6 +35,7 @@ describe('ThumbnailCache', () => {
     expect(thumbs.folderThumb500).toBeDefined();
     expect(thumbs.folderContentsType).toBe(FolderContentsType.BROKEN_THUMBNAILS);
   });
+
   it('should be able to set and get thumbnail', () => {
     cache.saveThumbnail(folder, folderThumbData);
     const {folderThumb200, folderThumb500} = cache.getThumbnail(folder);
@@ -40,12 +43,14 @@ describe('ThumbnailCache', () => {
     expect(folderThumb200).toBe(folderThumbData.folderThumb200);
     expect(folderThumb500).toBe(folderThumbData.folderThumb500);
   });
+
   it('should be able to test if thumbnail is cached', () => {
     expect(cache.hasThumbnail(folder)).toBeFalse();
     cache.saveThumbnail(folder, folderThumbData);
 
     expect(cache.hasThumbnail(folder)).toBeTrue();
   });
+
   it('should use session storage to get this data', () => {
     cache.saveThumbnail(folder, folderThumbData);
     const cache2 = new ThumbnailCache(storage);
@@ -54,6 +59,7 @@ describe('ThumbnailCache', () => {
     expect(folderThumb200).toBe(folderThumbData.folderThumb200);
     expect(folderThumb500).toBe(folderThumbData.folderThumb500);
   });
+
   it('should store icon data instead if neccessary', () => {
     const iconTypes = [
       FolderContentsType.BROKEN_THUMBNAILS,
@@ -72,11 +78,13 @@ describe('ThumbnailCache', () => {
       expect(folderContentsType).toBe(icon);
     }
   });
+
   it('should be able to clear the cache for a specific folder', () => {
     cache.invalidateFolder(1234);
 
     expect(cache.hasThumbnail(folder)).toBeFalse();
   });
+
   describe('malformed session storage', () => {
     it('handles completely invalid session storage value', () => {
       storage.session.set('folderThumbnailCache', 'potato');
@@ -84,6 +92,7 @@ describe('ThumbnailCache', () => {
 
       expect(cache.hasThumbnail(folder)).toBeFalse();
     });
+
     it('handles linking another value instead of a string tuple', () => {
       storage.session.set('folderThumbnailCache', [[1234, 'potato']]);
       cache = new ThumbnailCache(storage);
@@ -94,6 +103,7 @@ describe('ThumbnailCache', () => {
       expect(thumbz.folderContentsType).toBe(FolderContentsType.BROKEN_THUMBNAILS);
       expect(storage.session.get('folderThumbnailCache').length).toBe(0);
     });
+
     it('handles properly casting other values to string if a tuple is provided', () => {
       storage.session.set('folderThumbnailCache', [[1234, [3.141, {}]]]);
       cache = new ThumbnailCache(storage);

--- a/src/app/views/components/timeline-view/timeline-util.spec.ts
+++ b/src/app/views/components/timeline-view/timeline-util.spec.ts
@@ -8,10 +8,12 @@ describe('Timeline Utilities', () => {
       expect(Util.dateTypeToNumber(Math.PI)).toBe(Math.PI);
       expect(Util.dateTypeToNumber(NaN)).toBeNaN();
     });
+
     it('will convert dates to number values', () => {
       expect(Util.dateTypeToNumber(new Date(0))).toBe(0);
       expect(Util.dateTypeToNumber(new Date(123456789))).toBe(123456789);
     });
+
     it('will convert strings to number values', () => {
       expect(Util.dateTypeToNumber('0')).toBe(0);
       expect(Util.dateTypeToNumber(Math.PI.toString())).toBe(Math.PI);


### PR DESCRIPTION
Enable a linting rule that enforces new lines between test blocks.