### PR TITLE
Refactor RecordVO and add some coverage

### DIFF
--- a/src/app/core/resolves/record-resolve.service.spec.ts
+++ b/src/app/core/resolves/record-resolve.service.spec.ts
@@ -1,20 +1,126 @@
-import { TestBed, inject } from '@angular/core/testing';
+/* @format */
+import { TestBed } from '@angular/core/testing';
 import * as Testing from '@root/test/testbedConfig';
-import { cloneDeep  } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { RecordResolveService } from '@core/resolves/record-resolve.service';
 import { DataService } from '@shared/services/data/data.service';
+import { RecordVO } from '@models/index';
+import { DataStatus } from '@models/data-status.enum';
+import { ActivatedRoute } from '@angular/router';
+import { ApiService } from '@shared/services/api/api.service';
+import { RecordResponse } from '@shared/services/api/record.repo';
+import { MessageService } from '@shared/services/message/message.service';
 
 describe('RecordResolveService', () => {
+  let service: RecordResolveService;
+  let data: DataService;
+  let route: ActivatedRoute;
+  let api: ApiService;
+  let message: MessageService;
+
   beforeEach(() => {
     const config = cloneDeep(Testing.BASE_TEST_CONFIG);
     const providers = config.providers;
     providers.push(RecordResolveService);
     providers.push(DataService);
+    providers.push({
+      provide: ActivatedRoute,
+      useValue: {
+        snapshot: {
+          params: { recArchiveNbr: '1234-abcd' },
+        },
+      },
+    });
+    providers.push(MessageService);
+    providers.push(ApiService);
     TestBed.configureTestingModule(config);
+    service = TestBed.inject(RecordResolveService);
+    data = TestBed.inject(DataService);
+    route = TestBed.inject(ActivatedRoute);
+    api = TestBed.inject(ApiService);
+    message = TestBed.inject(MessageService);
   });
 
-  it('should be created', inject([RecordResolveService], (service: RecordResolveService) => {
+  it('should be created', () => {
     expect(service).toBeTruthy();
-  }));
+  });
+
+  it('should return a record that is fully cached by dataservice', async () => {
+    const record = new RecordVO(
+      { displayName: 'Test Record', archiveNbr: '1234-abcd' },
+      { dataStatus: DataStatus.Full }
+    );
+    const spy = spyOn(data, 'getItemByArchiveNbr').and.returnValue(record);
+    const fetchSpy = spyOn(data, 'fetchFullItems');
+    const result = await service.resolve(route.snapshot, null);
+
+    expect(result).toEqual(record);
+    expect(spy).toHaveBeenCalledWith('1234-abcd');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should fetch a lean record that is cached by dataservice', async () => {
+    const record = new RecordVO(
+      { displayName: 'Test Record', archiveNbr: '1234-abcd' },
+      { dataStatus: DataStatus.Lean }
+    );
+    const spy = spyOn(data, 'getItemByArchiveNbr').and.returnValue(record);
+    spyOn(data, 'fetchFullItems').and.callFake(async () => {
+      record.displayName = 'Fetched Record';
+      record.dataStatus = DataStatus.Full;
+      return true;
+    });
+    const result = await service.resolve(route.snapshot, null);
+
+    expect(result.displayName).toBe('Fetched Record');
+    expect(result.dataStatus).toBe(DataStatus.Full);
+    expect(spy).toHaveBeenCalledWith('1234-abcd');
+  });
+
+  it('should call record/get if a record is not cached', async () => {
+    spyOn(data, 'getItemByArchiveNbr').and.returnValue(undefined);
+    const apiSpy = spyOn(api.record, 'get').and.resolveTo(
+      new RecordResponse({
+        isSuccessful: true,
+        Results: [
+          {
+            data: [
+              {
+                RecordVO: {
+                  displayName: 'Test Record',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    );
+    const result = await service.resolve(route.snapshot, null);
+
+    expect(result.displayName).toBe('Test Record');
+    expect(apiSpy).toHaveBeenCalled();
+  });
+
+  it('should display an error message if an error is thrown', async () => {
+    spyOn(data, 'getItemByArchiveNbr').and.returnValue(undefined);
+    const apiSpy = spyOn(api.record, 'get').and.rejectWith(
+      new RecordResponse({
+        isSuccessful: false,
+        Results: [
+          {
+            message: ['Test Error'],
+          },
+        ],
+      })
+    );
+    let displayedErrorMessage: string;
+    spyOn(message, 'showError').and.callFake((message: string) => {
+      displayedErrorMessage = message;
+    });
+
+    await expectAsync(service.resolve(route.snapshot, null)).toBeRejected();
+
+    expect(displayedErrorMessage).toBe('Test Error');
+  });
 });

--- a/src/app/core/resolves/record-resolve.service.spec.ts
+++ b/src/app/core/resolves/record-resolve.service.spec.ts
@@ -10,7 +10,10 @@ import { DataStatus } from '@models/data-status.enum';
 import { ActivatedRoute } from '@angular/router';
 import { ApiService } from '@shared/services/api/api.service';
 import { RecordResponse } from '@shared/services/api/record.repo';
-import { MessageService } from '@shared/services/message/message.service';
+import {
+  MessageDisplayOptions,
+  MessageService,
+} from '@shared/services/message/message.service';
 
 describe('RecordResolveService', () => {
   let service: RecordResolveService;
@@ -104,7 +107,7 @@ describe('RecordResolveService', () => {
 
   it('should display an error message if an error is thrown', async () => {
     spyOn(data, 'getItemByArchiveNbr').and.returnValue(undefined);
-    const apiSpy = spyOn(api.record, 'get').and.rejectWith(
+    spyOn(api.record, 'get').and.rejectWith(
       new RecordResponse({
         isSuccessful: false,
         Results: [
@@ -115,8 +118,8 @@ describe('RecordResolveService', () => {
       })
     );
     let displayedErrorMessage: string;
-    spyOn(message, 'showError').and.callFake((message: string) => {
-      displayedErrorMessage = message;
+    spyOn(message, 'showError').and.callFake((data: MessageDisplayOptions) => {
+      displayedErrorMessage = data.message;
     });
 
     await expectAsync(service.resolve(route.snapshot, null)).toBeRejected();

--- a/src/app/models/archive-vo.spec.ts
+++ b/src/app/models/archive-vo.spec.ts
@@ -1,0 +1,78 @@
+/* @format */
+import { DataStatus } from './data-status.enum';
+import { ArchiveVO, FolderVO, RecordVO } from '.';
+
+describe('ArchiveVO', () => {
+  it('should exist', () => {
+    expect(new ArchiveVO({})).toBeTruthy();
+  });
+  it('can check pending status', () => {
+    expect(new ArchiveVO({}).isPending()).toBeFalse();
+
+    expect(
+      new ArchiveVO({ status: 'status.generic.ok' }).isPending()
+    ).toBeFalse();
+
+    expect(
+      new ArchiveVO({ status: 'status.generic.deleted' }).isPending()
+    ).toBeFalse();
+
+    expect(
+      new ArchiveVO({ status: 'status.generic.pending' }).isPending()
+    ).toBeTrue();
+  });
+  describe('ItemVO conversion', () => {
+    it('should do nothing on a null case', () => {
+      expect(new ArchiveVO({}).ItemVOs).toBeUndefined();
+    });
+    it('should do nothing on an empty array', () => {
+      expect(new ArchiveVO({ ItemVOs: [] }).ItemVOs.length).toBe(0);
+    });
+    it('should ignore items without a type', () => {
+      expect(new ArchiveVO({ ItemVOs: [{ type: null }] }).ItemVOs.length).toBe(
+        0
+      );
+    });
+    it('should initialize folder items as folderVos', () => {
+      expect(
+        new ArchiveVO({ ItemVOs: [{ type: 'type.folder.private' }] }).ItemVOs[0]
+      ).toBeInstanceOf(FolderVO);
+    });
+    it('should initialize any other items as recordVos', () => {
+      const items = new ArchiveVO({
+        ItemVOs: [
+          { type: 'type.record.image' },
+          { type: 'weird.unexpected.type' },
+        ],
+      }).ItemVOs;
+
+      expect(items[0]).toBeInstanceOf(RecordVO);
+      expect(items[1]).toBeInstanceOf(RecordVO);
+    });
+    it('should not initialize children of FolderVOs', () => {
+      const folder = new ArchiveVO({
+        ItemVOs: [
+          {
+            type: 'type.folder.private',
+            ChildItemVOs: [{ type: 'type.record.image' }],
+          },
+        ],
+      }).ItemVOs[0] as FolderVO;
+
+      expect(folder.ChildItemVOs[0]).not.toBeInstanceOf(RecordVO);
+      expect(folder.ChildItemVOs[0]).not.toBeInstanceOf(FolderVO);
+    });
+    it('should set datastatus to lean for all ItemVOs', () => {
+      const items = new ArchiveVO({
+        ItemVOs: [
+          { type: 'type.record.image' },
+          { type: 'type.folder.private' },
+        ],
+      }).ItemVOs;
+
+      for (const item of items) {
+        expect(item.dataStatus).toBe(DataStatus.Lean);
+      }
+    });
+  });
+});

--- a/src/app/models/archive-vo.spec.ts
+++ b/src/app/models/archive-vo.spec.ts
@@ -6,6 +6,7 @@ describe('ArchiveVO', () => {
   it('should exist', () => {
     expect(new ArchiveVO({})).toBeTruthy();
   });
+
   it('can check pending status', () => {
     expect(new ArchiveVO({}).isPending()).toBeFalse();
 
@@ -21,23 +22,28 @@ describe('ArchiveVO', () => {
       new ArchiveVO({ status: 'status.generic.pending' }).isPending()
     ).toBeTrue();
   });
+
   describe('ItemVO conversion', () => {
     it('should do nothing on a null case', () => {
       expect(new ArchiveVO({}).ItemVOs).toBeUndefined();
     });
+
     it('should do nothing on an empty array', () => {
       expect(new ArchiveVO({ ItemVOs: [] }).ItemVOs.length).toBe(0);
     });
+
     it('should ignore items without a type', () => {
       expect(new ArchiveVO({ ItemVOs: [{ type: null }] }).ItemVOs.length).toBe(
         0
       );
     });
+
     it('should initialize folder items as folderVos', () => {
       expect(
         new ArchiveVO({ ItemVOs: [{ type: 'type.folder.private' }] }).ItemVOs[0]
       ).toBeInstanceOf(FolderVO);
     });
+
     it('should initialize any other items as recordVos', () => {
       const items = new ArchiveVO({
         ItemVOs: [
@@ -49,6 +55,7 @@ describe('ArchiveVO', () => {
       expect(items[0]).toBeInstanceOf(RecordVO);
       expect(items[1]).toBeInstanceOf(RecordVO);
     });
+
     it('should not initialize children of FolderVOs', () => {
       const folder = new ArchiveVO({
         ItemVOs: [
@@ -62,6 +69,7 @@ describe('ArchiveVO', () => {
       expect(folder.ChildItemVOs[0]).not.toBeInstanceOf(RecordVO);
       expect(folder.ChildItemVOs[0]).not.toBeInstanceOf(FolderVO);
     });
+
     it('should set datastatus to lean for all ItemVOs', () => {
       const items = new ArchiveVO({
         ItemVOs: [

--- a/src/app/models/archive-vo.ts
+++ b/src/app/models/archive-vo.ts
@@ -55,7 +55,7 @@ export class ArchiveVO extends BaseVO implements DynamicListChild {
           if (item.type.includes('folder')) {
             return new FolderVO(item, false, DataStatus.Lean);
           } else {
-            return new RecordVO(item, false, DataStatus.Lean);
+            return new RecordVO(item, { dataStatus: DataStatus.Lean });
           }
         }
       );

--- a/src/app/models/record-vo.spec.ts
+++ b/src/app/models/record-vo.spec.ts
@@ -17,6 +17,7 @@ describe('RecordVO', () => {
   it('should exist', () => {
     expect(new RecordVO({})).toBeTruthy();
   });
+
   it('should sort ShareVOs by pending status', () => {
     const shares = new RecordVO({
       ShareVOs: [
@@ -32,6 +33,7 @@ describe('RecordVO', () => {
       'status.generic.ok',
     ]);
   });
+
   it('should sort ShareVOs by access role after pending status', () => {
     const shares = new RecordVO({
       ShareVOs: [
@@ -53,6 +55,7 @@ describe('RecordVO', () => {
       'access.role.viewer',
     ]);
   });
+
   it('should sort ShareVOs by Archive Name after access role', () => {
     const shares = new RecordVO({
       ShareVOs: [
@@ -68,11 +71,13 @@ describe('RecordVO', () => {
       'Zzz',
     ]);
   });
+
   it('can set a custom dataStatus', () => {
     const record = new RecordVO({}, { dataStatus: DataStatus.Full });
 
     expect(record.dataStatus).toBe(DataStatus.Full);
   });
+
   it('formats dates properly', () => {
     const record = new RecordVO({
       displayDT: '2023-01-19T19:33:03',
@@ -86,12 +91,14 @@ describe('RecordVO', () => {
     expect(record.derivedDT).toBe(null);
     expect(record.derivedEndDT).toBe(null);
   });
+
   it('can update a record', () => {
     const record = new RecordVO({ displayName: 'Unit Test' });
     record.update({ displayName: 'Potato' });
 
     expect(record.displayName).toBe('Potato');
   });
+
   it('initializes any ShareVOs provided when updated', () => {
     const record = new RecordVO({});
     record.update({ ShareVOs: [{}] });

--- a/src/app/models/record-vo.spec.ts
+++ b/src/app/models/record-vo.spec.ts
@@ -1,0 +1,101 @@
+/* @format */
+import { DataStatus } from './data-status.enum';
+import { RecordVO, ShareVO } from '.';
+
+describe('RecordVO', () => {
+  function extendBaseShareVO(
+    share: Partial<ShareVO>,
+    fullName: string = 'Unit Test'
+  ): ShareVO {
+    return new ShareVO({
+      status: 'status.generic.ok',
+      accessRole: 'access.role.viewer',
+      ArchiveVO: { fullName },
+      ...share,
+    });
+  }
+  it('should exist', () => {
+    expect(new RecordVO({})).toBeTruthy();
+  });
+  it('should sort ShareVOs by pending status', () => {
+    const shares = new RecordVO({
+      ShareVOs: [
+        extendBaseShareVO({ status: 'status.generic.deleted' }),
+        extendBaseShareVO({ status: 'status.generic.ok' }),
+        extendBaseShareVO({ status: 'status.generic.pending' }),
+      ],
+    }).ShareVOs;
+
+    expect(shares.map((n) => n.status)).toEqual([
+      'status.generic.pending',
+      'status.generic.deleted',
+      'status.generic.ok',
+    ]);
+  });
+  it('should sort ShareVOs by access role after pending status', () => {
+    const shares = new RecordVO({
+      ShareVOs: [
+        extendBaseShareVO({ accessRole: 'access.role.viewer' }),
+        extendBaseShareVO({ accessRole: 'access.role.contributor' }),
+        extendBaseShareVO({ accessRole: 'access.role.editor' }),
+        extendBaseShareVO({ accessRole: 'access.role.curator' }),
+        extendBaseShareVO({ accessRole: 'access.role.manager' }),
+        extendBaseShareVO({ accessRole: 'access.role.owner' }),
+      ],
+    }).ShareVOs;
+
+    expect(shares.map((n) => n.accessRole)).toEqual([
+      'access.role.owner',
+      'access.role.manager',
+      'access.role.curator',
+      'access.role.editor',
+      'access.role.contributor',
+      'access.role.viewer',
+    ]);
+  });
+  it('should sort ShareVOs by Archive Name after access role', () => {
+    const shares = new RecordVO({
+      ShareVOs: [
+        extendBaseShareVO({}, 'Zzz'),
+        extendBaseShareVO({}, 'zYz'),
+        extendBaseShareVO({}, 'abc'),
+      ],
+    }).ShareVOs;
+
+    expect(shares.map((n) => n.ArchiveVO.fullName)).toEqual([
+      'abc',
+      'zYz',
+      'Zzz',
+    ]);
+  });
+  it('can set a custom dataStatus', () => {
+    const record = new RecordVO({}, false, DataStatus.Full);
+
+    expect(record.dataStatus).toBe(DataStatus.Full);
+  });
+  it('formats dates properly', () => {
+    const record = new RecordVO({
+      displayDT: '2023-01-19T19:33:03',
+      displayEndDT: '2023-01-19T19:33:03.000Z',
+      derivedDT: null,
+      derivedEndDT: 'potato',
+    });
+
+    expect(record.displayDT).toBe('2023-01-19T19:33:03.000Z');
+    expect(record.displayEndDT).toBe('2023-01-19T19:33:03.000Z');
+    expect(record.derivedDT).toBe(null);
+    expect(record.derivedEndDT).toBe(null);
+  });
+  it('can update a record', () => {
+    const record = new RecordVO({ displayName: 'Unit Test' });
+    record.update({ displayName: 'Potato' });
+
+    expect(record.displayName).toBe('Potato');
+  });
+  it('initializes any ShareVOs provided when updated', () => {
+    const record = new RecordVO({});
+    record.update({ ShareVOs: [{}] });
+
+    expect(record.ShareVOs[0]).toBeInstanceOf(ShareVO);
+  });
+});

--- a/src/app/models/record-vo.spec.ts
+++ b/src/app/models/record-vo.spec.ts
@@ -69,7 +69,7 @@ describe('RecordVO', () => {
     ]);
   });
   it('can set a custom dataStatus', () => {
-    const record = new RecordVO({}, false, DataStatus.Full);
+    const record = new RecordVO({}, { dataStatus: DataStatus.Full });
 
     expect(record.dataStatus).toBe(DataStatus.Full);
   });

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { BaseVO, BaseVOData, DynamicListChild } from '@models/base-vo';
 import { DataStatus } from '@models/data-status.enum';
 import { ShareVO, sortShareVOs } from '@models/share-vo';
@@ -11,8 +12,23 @@ import { LocnVOData } from './locn-vo';
 import { TagVOData } from './tag-vo';
 import { ArchiveVO } from './archive-vo';
 
-export class RecordVO extends BaseVO implements ChildItemData, HasParentFolder, DynamicListChild {
-  public cleanParams = ['recordId', 'archiveNbr', 'folder_linkId', 'parentFolder_linkId', 'parentFolderId', 'uploadFileName'];
+interface RecordVoOptions {
+  dataStatus: DataStatus;
+  initChildren: boolean;
+}
+
+export class RecordVO
+  extends BaseVO
+  implements ChildItemData, HasParentFolder, DynamicListChild
+{
+  public cleanParams = [
+    'recordId',
+    'archiveNbr',
+    'folder_linkId',
+    'parentFolder_linkId',
+    'parentFolderId',
+    'uploadFileName',
+  ];
   public isRecord = true;
   public isFolder = false;
 
@@ -100,15 +116,17 @@ export class RecordVO extends BaseVO implements ChildItemData, HasParentFolder, 
   public ShareVOs: ShareVO[];
   public AccessVO;
 
-  constructor(voData: RecordVOData, initChildren?: boolean, dataStatus?: DataStatus) {
+  constructor(voData: RecordVOData, options?: Partial<RecordVoOptions>) {
     super(voData);
 
     if (this.ShareVOs) {
-      this.ShareVOs = sortShareVOs(this.ShareVOs.map((data) => new ShareVO(data)));
+      this.ShareVOs = sortShareVOs(
+        this.ShareVOs.map((data) => new ShareVO(data))
+      );
     }
 
-    if (dataStatus) {
-      this.dataStatus = dataStatus;
+    if (options?.dataStatus) {
+      this.dataStatus = options.dataStatus;
     }
 
     this.formatDates();
@@ -121,9 +139,9 @@ export class RecordVO extends BaseVO implements ChildItemData, HasParentFolder, 
     this.derivedEndDT = formatDateISOString(this.derivedEndDT);
   }
 
-  public update (voData: RecordVOData | RecordVO): void {
+  public update(voData: RecordVOData | RecordVO): void {
     if (voData) {
-      for ( const key in voData ) {
+      for (const key in voData) {
         if (voData[key] !== undefined && typeof voData[key] !== 'function') {
           this[key] = voData[key];
         }
@@ -197,5 +215,5 @@ export interface RecordVOData extends BaseVOData {
   RecordExifVO?: any;
   ShareVOs?: any;
   AccessVO?: any;
-  isFolder?:boolean;
+  isFolder?: boolean;
 }

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -14,7 +14,6 @@ import { ArchiveVO } from './archive-vo';
 
 interface RecordVoOptions {
   dataStatus: DataStatus;
-  initChildren: boolean;
 }
 
 export class RecordVO

--- a/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.spec.ts
@@ -19,13 +19,11 @@ function addParam(url, param) {
 
 const minItem = new RecordVO(
   { folder_linkId: 1 },
-  false,
-  DataStatus.Placeholder
+  { dataStatus: DataStatus.Placeholder }
 );
 const leanItem = new RecordVO(
   { folder_linkId: 1, thumbURL200: image200 },
-  false,
-  DataStatus.Lean
+  { dataStatus: DataStatus.Lean }
 );
 const fullItem = new RecordVO(
   {
@@ -35,24 +33,21 @@ const fullItem = new RecordVO(
     thumbURL1000: image1000,
     type: 'type.record.image',
   },
-  false,
-  DataStatus.Full
+  { dataStatus: DataStatus.Full }
 );
 
 const minItem2 = new RecordVO(
   {
     folder_linkId: 2,
   },
-  false,
-  DataStatus.Placeholder
+  { dataStatus: DataStatus.Placeholder }
 );
 const leanItem2 = new RecordVO(
   {
     folder_linkId: 2,
     thumbURL200: addParam(image200, 'item2'),
   },
-  false,
-  DataStatus.Lean
+  { dataStatus: DataStatus.Lean }
 );
 const fullItem2 = new RecordVO(
   {
@@ -61,8 +56,7 @@ const fullItem2 = new RecordVO(
     thumbURL500: addParam(image500, 'item2'),
     thumbURL1000: addParam(image500, 'item2'),
   },
-  false,
-  DataStatus.Full
+  { dataStatus: DataStatus.Full }
 );
 
 @Component({

--- a/src/app/shared/services/api/publish.repo.ts
+++ b/src/app/shared/services/api/publish.repo.ts
@@ -37,7 +37,7 @@ export class PublishResponse extends BaseResponse {
       return null;
     }
 
-    return new RecordVO(data[0][0].RecordVO, initChildren);
+    return new RecordVO(data[0][0].RecordVO, { initChildren });
   }
 
   public getFolderVO(initChildren?: boolean) {

--- a/src/app/shared/services/api/publish.repo.ts
+++ b/src/app/shared/services/api/publish.repo.ts
@@ -31,13 +31,13 @@ export class PublishRepo extends BaseRepo {
 }
 
 export class PublishResponse extends BaseResponse {
-  public getRecordVO(initChildren?: boolean) {
+  public getRecordVO() {
     const data = this.getResultsData();
     if (!data || !data.length || !data[0][0].RecordVO) {
       return null;
     }
 
-    return new RecordVO(data[0][0].RecordVO, { initChildren });
+    return new RecordVO(data[0][0].RecordVO);
   }
 
   public getFolderVO(initChildren?: boolean) {

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -260,14 +260,14 @@ export class RecordResponse extends BaseResponse {
       return null;
     }
 
-    return new RecordVO(data[0][0].RecordVO, initChildren);
+    return new RecordVO(data[0][0].RecordVO, { initChildren });
   }
 
   public getRecordVOs(initChildren?: boolean) {
     const data = this.getResultsData();
 
     return data.map((result) => {
-      return new RecordVO(result[0].RecordVO, initChildren);
+      return new RecordVO(result[0].RecordVO, { initChildren });
     });
   }
 }

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -254,20 +254,20 @@ export class RecordRepo extends BaseRepo {
 }
 
 export class RecordResponse extends BaseResponse {
-  public getRecordVO(initChildren?: boolean) {
+  public getRecordVO() {
     const data = this.getResultsData();
     if (!data || !data.length) {
       return null;
     }
 
-    return new RecordVO(data[0][0].RecordVO, { initChildren });
+    return new RecordVO(data[0][0].RecordVO);
   }
 
-  public getRecordVOs(initChildren?: boolean) {
+  public getRecordVOs() {
     const data = this.getResultsData();
 
     return data.map((result) => {
-      return new RecordVO(result[0].RecordVO, { initChildren });
+      return new RecordVO(result[0].RecordVO);
     });
   }
 }

--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -115,14 +115,14 @@ export class SearchResponse extends BaseResponse {
 
     return searchVO.ChildItemVOs.map((i) => {
       if (i.recordId) {
-        return new RecordVO(i, { initChildren });
+        return new RecordVO(i);
       } else {
         return new FolderVO(i, initChildren);
       }
     });
   }
 
-  public getRecordVOs(initChildren?: boolean) {
+  public getRecordVOs() {
     const data = this.getResultsData();
 
     if (!data.length) {
@@ -130,7 +130,7 @@ export class SearchResponse extends BaseResponse {
     }
 
     return data[0].map((result) => {
-      return new RecordVO(result.RecordVO, { initChildren });
+      return new RecordVO(result.RecordVO);
     });
   }
 }

--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -115,7 +115,7 @@ export class SearchResponse extends BaseResponse {
 
     return searchVO.ChildItemVOs.map((i) => {
       if (i.recordId) {
-        return new RecordVO(i, initChildren);
+        return new RecordVO(i, { initChildren });
       } else {
         return new FolderVO(i, initChildren);
       }
@@ -130,7 +130,7 @@ export class SearchResponse extends BaseResponse {
     }
 
     return data[0].map((result) => {
-      return new RecordVO(result.RecordVO, initChildren);
+      return new RecordVO(result.RecordVO, { initChildren });
     });
   }
 }


### PR DESCRIPTION
This PR is the result of some work I don't want to completely throw away after reaching a dead end. We've identified that the bug described in [PER-9138](https://permanent.atlassian.net/browse/PER-9138) is caused by some inconsistencies in the back-end response to `record/get`.

However, I thought maybe we could create a front end bug fix while waiting for that back end fix, since in the bug the front end clearly has an idea of the correct access role at first and is only overwritten by the back end later. Unfortunately, the way Access Roles and Sharing permissions are communicated are a bit confusing and unclear and there was no good place to end up putting this logic that did not feel like a hack. My initial solution was to ignore the `accessRole` property on RecordVOs that are shared with the current archive and look at the `ShareVOs` field instead for the access role, but this didn't end up working. It ultimately lead to the question: Where should we be looking for the accessRole? The ShareVOs list? Or the AccessVO object? The answer became clear after thinking about this... it should just be provided in the `accessRole` field by the back-end correctly to begin with.

But as part of this work I ended up writing a good amount of tests and I even did some refactoring of the RecordVO class to take in an options object instead of unlabeled parameters. I also removed one of the parameters that went completely unused. That is what this PR is: the results of some testing and refactoring for an actual solution that didn't end up working.

The obvious question is: Should this PR also include the same refactoring strategies on FolderVO as well? It's kind of weird that only RecordVO was refactored, but should *"not refactoring a completely separate class immediately"* be a good reason to block a PR? I'm open to discussion. Ideally if I did cover FolderVO and refactor it, I'd probably also get rid of some duplicate code between the classes which wouldn't exactly be a trivial refactor. Since this is basically a "bonus" PR from dead end work, I don't want it to be too complicated; I just don't want these tests to be lost.