### PR TITLE
Redirect specific path to public gallery

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -50,6 +50,11 @@ const customRedirects: RoutesWithData = [
     redirectTo: '/p/archive/07r7-0000',
     pathMatch: 'full',
   },
+  {
+    path: SecretsService.getStatic('HIDDEN_PATH'),
+    redirectTo: '/gallery',
+    pathMatch: 'prefix',
+  },
 ];
 
 const routes: RoutesWithData = [

--- a/src/optional-secrets.js
+++ b/src/optional-secrets.js
@@ -15,6 +15,10 @@ const optionalSecrets = [
     name: 'MIXPANEL_TOKEN',
     default: '',
   },
+  {
+    name: 'HIDDEN_PATH',
+    default: '',
+  },
 ];
 
 module.exports = optionalSecrets;


### PR DESCRIPTION
Doing this on the client side is not ideal, but seems to be our best bet at the moment. I've also added a load balancer redirect and set `public` on the archive to false. See [this Google doc](https://docs.google.com/document/d/1QVSd_kyKn4itxcYOsXDX9h3VxNGwnNM0BB7qHzZwxVU/edit#heading=h.6x7aanr50tsj) for more information. Ideas very welcome!