### PR TITLE
Integrate folder caching into web-app

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -33,6 +33,7 @@ import { PledgeModule } from '../pledge/pledge.module';
 import { AnnouncementModule } from '../announcement/announcement.module';
 import { ManageMetadataModule } from '../archive-settings/manage-metadata/manage-metadata.module';
 import { DirectiveModule } from '../directive/directive.module';
+import { FilesystemModule } from '../filesystem/filesystem.module';
 import { ArchiveSwitcherComponent } from './components/archive-switcher/archive-switcher.component';
 import { MultiSelectStatusComponent } from './components/multi-select-status/multi-select-status.component';
 import { EditService } from './services/edit/edit.service';
@@ -80,6 +81,7 @@ import { AdvancedSettingsComponent } from './components/advanced-settings/advanc
     PledgeModule,
     ManageMetadataModule,
     DirectiveModule,
+    FilesystemModule,
   ],
   declarations: [
     MainComponent,

--- a/src/app/core/resolves/folder-resolve.service.ts
+++ b/src/app/core/resolves/folder-resolve.service.ts
@@ -1,14 +1,12 @@
+/* @format */
 import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
   RouterStateSnapshot,
   Router,
-  ActivatedRoute,
 } from '@angular/router';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { find, cloneDeep } from 'lodash';
-import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { MessageService } from '@shared/services/message/message.service';
 
@@ -22,9 +20,7 @@ import { FilesystemService } from '@root/app/filesystem/filesystem.service';
 @Injectable()
 export class FolderResolveService {
   constructor(
-    private api: ApiService,
     private accountService: AccountService,
-    private activatedRoute: ActivatedRoute,
     private message: MessageService,
     private router: Router,
     private filesystem: FilesystemService

--- a/src/app/file-browser/components/file-list/file-list.component.ts
+++ b/src/app/file-browser/components/file-list/file-list.component.ts
@@ -323,11 +323,7 @@ export class FileListComponent
 
     if (this.showSidebar) {
       this.getScrollElement().scrollTo(0, 0);
-    } else {
-      // (this.scrollElement.nativeElement as HTMLElement).scrollIntoView(true);
     }
-
-    this.dataService.refreshCurrentFolder();
 
     const queryParams = this.route.snapshot.queryParamMap;
     if (queryParams.has('showItem')) {

--- a/src/app/filesystem/filesystem-api.service.spec.ts
+++ b/src/app/filesystem/filesystem-api.service.spec.ts
@@ -1,0 +1,84 @@
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { environment } from '@root/environments/environment';
+import { FolderResponse } from '@shared/services/api/folder.repo';
+import { FilesystemApiService } from './filesystem-api.service';
+
+describe('FilesystemApiService', () => {
+  let service: FilesystemApiService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(FilesystemApiService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should be able to navigate', (done) => {
+    service
+      .navigate({ folderId: 0 })
+      .then((folder) => {
+        expect(folder.displayName).toBe('Unit Test');
+      })
+      .catch((response) => {
+        fail(response);
+      })
+      .finally(() => {
+        done();
+      });
+
+    const req = http.expectOne(`${environment.apiUrl}/folder/navigateLean`);
+
+    req.flush({
+      isSuccessful: true,
+      Results: [
+        {
+          data: [
+            {
+              FolderVO: {
+                folderId: 0,
+                displayName: 'Unit Test',
+                ChildItemVOs: [],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    http.verify();
+  });
+
+  it('will throw the invalid folder response for a failed request', (done) => {
+    service
+      .navigate({ folderId: 0 })
+      .then(() => {
+        fail('Expected a rejected promise, but it resolved instead');
+      })
+      .catch((response: FolderResponse) => {
+        expect(response.getMessage()).toBe('Unit Test Error');
+      })
+      .finally(() => {
+        done();
+      });
+
+    const req = http.expectOne(`${environment.apiUrl}/folder/navigateLean`);
+
+    req.flush({
+      isSuccessful: false,
+      message: 'Unit Test Error',
+    });
+
+    http.verify();
+  });
+});

--- a/src/app/filesystem/filesystem-api.service.ts
+++ b/src/app/filesystem/filesystem-api.service.ts
@@ -1,0 +1,33 @@
+/* @format */
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import { FolderVO, RecordVO } from '@models/index';
+import { ApiService } from '@shared/services/api/api.service';
+import { FilesystemApi } from './types/filesystem-api';
+import {
+  FolderIdentifier,
+  RecordIdentifier,
+} from './types/filesystem-identifier';
+import { ArchiveIdentifier } from './types/archive-identifier';
+import { DataStatus } from '@models/data-status.enum';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FilesystemApiService implements FilesystemApi {
+  constructor(private api: ApiService) {}
+
+  public async navigate(folder: FolderIdentifier): Promise<FolderVO> {
+    const response = await firstValueFrom(
+      this.api.folder.navigateLean(new FolderVO(folder))
+    );
+    if (!response.isSuccessful) {
+      throw response;
+    }
+    return response.getFolderVO(true, DataStatus.Lean);
+  }
+
+  public getRecord: (record: RecordIdentifier) => Promise<RecordVO>;
+  public getRoot: (archive: ArchiveIdentifier) => Promise<FolderVO>;
+}

--- a/src/app/filesystem/filesystem-api.service.ts
+++ b/src/app/filesystem/filesystem-api.service.ts
@@ -4,13 +4,13 @@ import { firstValueFrom } from 'rxjs';
 
 import { FolderVO, RecordVO } from '@models/index';
 import { ApiService } from '@shared/services/api/api.service';
+import { DataStatus } from '@models/data-status.enum';
 import { FilesystemApi } from './types/filesystem-api';
 import {
   FolderIdentifier,
   RecordIdentifier,
 } from './types/filesystem-identifier';
 import { ArchiveIdentifier } from './types/archive-identifier';
-import { DataStatus } from '@models/data-status.enum';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/filesystem/filesystem.module.ts
+++ b/src/app/filesystem/filesystem.module.ts
@@ -1,0 +1,13 @@
+/* @format */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedModule } from '@shared/shared.module';
+import { FilesystemService } from './filesystem.service';
+import { FilesystemApiService } from './filesystem-api.service';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, SharedModule],
+  providers: [FilesystemService, FilesystemApiService],
+})
+export class FilesystemModule {}

--- a/src/app/filesystem/filesystem.service.spec.ts
+++ b/src/app/filesystem/filesystem.service.spec.ts
@@ -1,0 +1,38 @@
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import { FolderVO } from '@models/index';
+import { FilesystemService } from './filesystem.service';
+import { FilesystemApiService } from './filesystem-api.service';
+
+describe('FilesystemService', () => {
+  let service: FilesystemService;
+  let fetchedFolder: boolean;
+
+  beforeEach(() => {
+    fetchedFolder = false;
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: FilesystemApiService,
+          useValue: {
+            async navigate() {
+              fetchedFolder = true;
+              return new FolderVO({});
+            },
+          },
+        },
+      ],
+    });
+    service = TestBed.inject(FilesystemService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('can get a folder through the API', async () => {
+    await service.getFolder({ folderId: 1 });
+
+    expect(fetchedFolder).toBeTrue();
+  });
+});

--- a/src/app/filesystem/filesystem.service.ts
+++ b/src/app/filesystem/filesystem.service.ts
@@ -1,0 +1,21 @@
+/* @format */
+import { Injectable } from '@angular/core';
+import { FolderVO } from '@models/index';
+import { FolderIdentifier } from './types/filesystem-identifier';
+import { PermanentFilesystem } from './permanent-filesystem';
+import { FilesystemApiService } from './filesystem-api.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FilesystemService {
+  public permanentFilesystem: PermanentFilesystem;
+
+  constructor(private api: FilesystemApiService) {
+    this.permanentFilesystem = new PermanentFilesystem(this.api);
+  }
+
+  public async getFolder(identifier: FolderIdentifier): Promise<FolderVO> {
+    return this.permanentFilesystem.getFolder(identifier);
+  }
+}

--- a/src/app/filesystem/folder-cache.spec.ts
+++ b/src/app/filesystem/folder-cache.spec.ts
@@ -33,6 +33,7 @@ describe('FolderCache', () => {
 
     expect(cache.getFolder({ folder_linkId: 1 }).displayName).toBe('Unit Test');
   });
+
   it('should not update a folder if its API value equals its cached value', () => {
     // This tests preventing unnecessary rerenders if no changes are found
     const folder = new FolderVO({ folder_linkId: 1 });

--- a/src/app/filesystem/folder-cache.spec.ts
+++ b/src/app/filesystem/folder-cache.spec.ts
@@ -33,6 +33,15 @@ describe('FolderCache', () => {
 
     expect(cache.getFolder({ folder_linkId: 1 }).displayName).toBe('Unit Test');
   });
+  it('should not update a folder if its API value equals its cached value', () => {
+    // This tests preventing unnecessary rerenders if no changes are found
+    const folder = new FolderVO({ folder_linkId: 1 });
+    const updateSpy = spyOn(folder, 'update').and.callThrough();
+    cache.saveFolder(folder);
+    cache.saveFolder(new FolderVO({ folder_linkId: 1 }));
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
 
   describe('Folder Identifiers', () => {
     let folder: FolderVO;

--- a/src/app/filesystem/folder-cache.ts
+++ b/src/app/filesystem/folder-cache.ts
@@ -1,3 +1,4 @@
+import { isEqual, omit } from 'lodash';
 import { FolderVO } from '@models/index';
 import { FolderIdentifier } from './types/filesystem-identifier';
 import { KeysOfUnion } from './types/keysofunion';
@@ -26,9 +27,15 @@ export class FolderCache {
   public saveFolder(folder: FolderVO): void {
     const cachedFolder = this.getFolder(folder);
     if (cachedFolder) {
-      Object.assign(cachedFolder, folder);
+      if (!this.areFoldersEqual(cachedFolder, folder)) {
+        cachedFolder.update(folder);
+      }
     } else {
       this.folders.push(folder);
     }
+  }
+
+  private areFoldersEqual(a: FolderVO, b: FolderVO): boolean {
+    return isEqual(omit(a, 'update'), omit(b, 'update'));
   }
 }

--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -112,9 +112,9 @@ export class FolderVO extends BaseVO implements ChildItemData, HasParentFolder, 
     if (initChildren) {
       this.ChildItemVOs = this.ChildItemVOs.map((item: any) => {
         if (item.folderId) {
-          return new FolderVO(item, false);
+          return new FolderVO(item, false, dataStatus);
         } else {
-          return new RecordVO(item);
+          return new RecordVO(item, false, dataStatus);
         }
       });
     }

--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -114,7 +114,7 @@ export class FolderVO extends BaseVO implements ChildItemData, HasParentFolder, 
         if (item.folderId) {
           return new FolderVO(item, false, dataStatus);
         } else {
-          return new RecordVO(item, false, dataStatus);
+          return new RecordVO(item, {dataStatus});
         }
       });
     }

--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { BaseVO, BaseVOData, DynamicListChild } from '@models/base-vo';
 import { RecordVO } from '@models/record-vo';
 import { DataStatus } from '@models/data-status.enum';
@@ -27,7 +28,10 @@ export interface ChildItemData {
   isNewlyCreated: boolean;
 }
 
-export class FolderVO extends BaseVO implements ChildItemData, HasParentFolder, DynamicListChild {
+export class FolderVO
+  extends BaseVO
+  implements ChildItemData, HasParentFolder, DynamicListChild
+{
   public isFolder = true;
   public isRecord = false;
 
@@ -106,7 +110,11 @@ export class FolderVO extends BaseVO implements ChildItemData, HasParentFolder, 
   public posStart;
   public posLimit;
 
-  constructor(voData: FolderVOData, initChildren?: boolean, dataStatus?: DataStatus) {
+  constructor(
+    voData: FolderVOData,
+    initChildren?: boolean,
+    dataStatus?: DataStatus
+  ) {
     super(voData);
 
     if (initChildren) {
@@ -114,13 +122,15 @@ export class FolderVO extends BaseVO implements ChildItemData, HasParentFolder, 
         if (item.folderId) {
           return new FolderVO(item, false, dataStatus);
         } else {
-          return new RecordVO(item, {dataStatus});
+          return new RecordVO(item, { dataStatus });
         }
       });
     }
 
     if (this.ShareVOs) {
-      this.ShareVOs = sortShareVOs(this.ShareVOs.map((data) => new ShareVO(data)));
+      this.ShareVOs = sortShareVOs(
+        this.ShareVOs.map((data) => new ShareVO(data))
+      );
     }
 
     if (dataStatus) {
@@ -137,9 +147,9 @@ export class FolderVO extends BaseVO implements ChildItemData, HasParentFolder, 
     this.derivedEndDT = formatDateISOString(this.derivedEndDT);
   }
 
-  public update (voData: FolderVOData | FolderVO, keepChildItems = false): void {
+  public update(voData: FolderVOData | FolderVO, keepChildItems = false): void {
     if (voData) {
-      for ( const key in voData ) {
+      for (const key in voData) {
         if (keepChildItems && key === 'ChildItemVOs') {
           continue;
         }

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -2,6 +2,7 @@ import { FolderVO, FolderVOData, ItemVO } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
+import { DataStatus } from '@models/data-status.enum';
 
 const MIN_WHITELIST: (keyof FolderVO)[] = ['folderId', 'archiveNbr', 'folder_linkId'];
 const DEFAULT_WHITELIST: (keyof FolderVO)[] = [...MIN_WHITELIST, 'displayName', 'description', 'displayDT', 'displayEndDT', 'view'];
@@ -196,13 +197,13 @@ export class FolderRepo extends BaseRepo {
 }
 
 export class FolderResponse extends BaseResponse {
-  public getFolderVO(initChildren?: boolean) {
+  public getFolderVO(initChildren?: boolean, dataStatus: DataStatus = DataStatus.Placeholder) {
     const data = this.getResultsData();
     if (!data || !data.length) {
       return null;
     }
 
-    return new FolderVO(data[0][0].FolderVO, initChildren);
+    return new FolderVO(data[0][0].FolderVO, initChildren, dataStatus);
   }
 
   public getFolderVOs(initChildren?: boolean) {


### PR DESCRIPTION
This PR actually integrates the previously hidden PermanentFilesystem class into the application. This is done by creating the `PermanentFilesystemService`, a wrapper service that allows this functionality to be imported into other modules across the application. The service also provides the proper implementation of the `FilesystemApi` interface, which wraps around the `ApiService` and processes the `FolderResponse` automatically.

Steps to test:
1. Open the web-app and make sure you have multiple folders with their own contents
2. Navigate into each folder once
3. Without refreshing, open the developer console and enable network throttling
4. Navigate into the folders you went into before. They should load immediately from the folder cache even if the `navigateLean` response has not finished.
5. You should not notice any extraneous `navigate` API calls, or large shifts in UI after the API calls finish.
6. Make sure that public / shared folders still work as expected as well