### PR TITLE
Fix upload button being broken in older browsers

### DIFF
--- a/src/app/core/components/upload-button/upload-button.component.spec.ts
+++ b/src/app/core/components/upload-button/upload-button.component.spec.ts
@@ -3,7 +3,7 @@ import * as Testing from '@root/test/testbedConfig';
 import { cloneDeep } from 'lodash';
 
 import { DataService } from '@shared/services/data/data.service';
-import { FolderVO, ArchiveVO } from '@root/app/models';
+import { FolderVO, ArchiveVO, AccountVO } from '@root/app/models';
 import { AccountService } from '@shared/services/account/account.service';
 
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
@@ -103,5 +103,17 @@ describe('UploadButtonComponent', () => {
     await fixture.whenStable();
 
     expect(fileInput.files.length).toEqual(0);
+  });
+
+  it('will not block propagation of the file input click event', async () => {
+    dataService.setCurrentFolder(
+      new FolderVO({
+        type: 'type.folder.private',
+        accessRole: 'access.role.viewer',
+      })
+    );
+    accountService.setAccount(new AccountVO({ accountId: 1 }));
+
+    expect(component.filePickerClick()).not.toBeFalsy();
   });
 });

--- a/src/app/core/components/upload-button/upload-button.component.ts
+++ b/src/app/core/components/upload-button/upload-button.component.ts
@@ -121,10 +121,10 @@ export class UploadButtonComponent
     event.target.value = '';
   }
 
-  async filePickerClick() {
+  filePickerClick(): boolean {
     const workspace = this.getFolderWorkspaceType(this.currentFolder);
     const account = this.account.getAccount();
-    await this.analytics.notifyObservers({
+    this.analytics.notifyObservers({
       entity: 'account',
       action: 'initiate_upload',
       version: 1,
@@ -138,9 +138,10 @@ export class UploadButtonComponent
         },
       },
     });
+    return true;
   }
 
-  getFolderWorkspaceType(folder: FolderVO) {
+  private getFolderWorkspaceType(folder: FolderVO) {
     return folder.type.includes('private') ? 'Private Files' : 'Public Files';
   }
 

--- a/src/app/shared/services/analytics/analytics.service.spec.ts
+++ b/src/app/shared/services/analytics/analytics.service.spec.ts
@@ -25,7 +25,7 @@ describe('AnalyticsService', () => {
   it('should add an observer', async () => {
     const { instance } = await shallow.createService();
     const mockObserver: AnalyticsObserver = {
-      update: (data: EventData) => {},
+      update: async (data: EventData) => {},
     };
 
     instance.addObserver(mockObserver);

--- a/src/app/shared/services/analytics/analytics.service.ts
+++ b/src/app/shared/services/analytics/analytics.service.ts
@@ -5,7 +5,7 @@ import { MixpanelData, MixpanelService } from '../mixpanel/mixpanel.service';
 export type EventData = MixpanelData;
 
 export interface AnalyticsObserver {
-  update(eventData: EventData): void;
+  update(eventData: EventData): Promise<void>;
 }
 
 @Injectable({

--- a/src/app/shared/services/mixpanel/mixpanel.service.spec.ts
+++ b/src/app/shared/services/mixpanel/mixpanel.service.spec.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { TestBed } from '@angular/core/testing';
 import {
   HttpClientTestingModule,
@@ -50,11 +51,14 @@ describe('MixpanelRepo', () => {
       body: { analytics: { event: 'testEvent', data: {} } },
     };
 
-    repo.update(testData).catch(() => {
-      fail();
-    }).finally(() => {
-      done();
-    });
+    repo
+      .update(testData)
+      .catch(() => {
+        fail();
+      })
+      .finally(() => {
+        done();
+      });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/v2/event`);
 
@@ -75,11 +79,14 @@ describe('MixpanelRepo', () => {
       body: { analytics: { event: 'testEvent', data: {} } },
     };
 
-    repo.update(testData).catch(() => {
-      fail();
-    }).finally(() => {
-      done();
-    });
+    repo
+      .update(testData)
+      .catch(() => {
+        fail();
+      })
+      .finally(() => {
+        done();
+      });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/v2/event`);
 
@@ -103,11 +110,14 @@ describe('MixpanelRepo', () => {
       body: { analytics: { event: 'testEvent', data: {} } },
     };
 
-    repo.update(testData).catch(() => {
-      fail();
-    }).finally(() => {
-      done();
-    });
+    repo
+      .update(testData)
+      .catch(() => {
+        fail();
+      })
+      .finally(() => {
+        done();
+      });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/v2/event`);
 

--- a/src/app/shared/services/mixpanel/mixpanel.service.spec.ts
+++ b/src/app/shared/services/mixpanel/mixpanel.service.spec.ts
@@ -38,7 +38,7 @@ describe('MixpanelRepo', () => {
     }
   }
 
-  it('should send correct data with analyticsDebug=false', async () => {
+  it('should send correct data with analyticsDebug=false', (done) => {
     prepareAccountStorage('12345');
     environment.analyticsDebug = false;
 
@@ -50,18 +50,20 @@ describe('MixpanelRepo', () => {
       body: { analytics: { event: 'testEvent', data: {} } },
     };
 
-    repo.update(testData).then((response) => {
-      expect(response).toBeTruthy();
+    repo.update(testData).catch(() => {
+      fail();
+    }).finally(() => {
+      done();
     });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/v2/event`);
 
     expect(req.request.method).toEqual('POST');
     expect(req.request.body.body.analytics.distinctId).toEqual('12345');
-    req.flush({ success: true });
+    req.flush({});
   });
 
-  it('should send correct data with analyticsDebug=true', async () => {
+  it('should send correct data with analyticsDebug=true', (done) => {
     prepareAccountStorage('67890');
     environment.analyticsDebug = true;
 
@@ -73,8 +75,10 @@ describe('MixpanelRepo', () => {
       body: { analytics: { event: 'testEvent', data: {} } },
     };
 
-    repo.update(testData).then((response) => {
-      expect(response).toBeTruthy();
+    repo.update(testData).catch(() => {
+      fail();
+    }).finally(() => {
+      done();
     });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/v2/event`);
@@ -86,7 +90,7 @@ describe('MixpanelRepo', () => {
     req.flush({ success: true });
   });
 
-  it('should prefer localStorage over sessionStorage', async () => {
+  it('should prefer localStorage over sessionStorage', (done) => {
     prepareAccountStorage('12345', true); // localStorage
     prepareAccountStorage('67890', false); // sessionStorage
     environment.analyticsDebug = false;
@@ -99,8 +103,10 @@ describe('MixpanelRepo', () => {
       body: { analytics: { event: 'testEvent', data: {} } },
     };
 
-    repo.update(testData).then((response) => {
-      expect(response).toBeTruthy();
+    repo.update(testData).catch(() => {
+      fail();
+    }).finally(() => {
+      done();
     });
 
     const req = httpMock.expectOne(`${environment.apiUrl}/v2/event`);

--- a/src/app/shared/services/mixpanel/mixpanel.service.ts
+++ b/src/app/shared/services/mixpanel/mixpanel.service.ts
@@ -80,7 +80,12 @@ export class MixpanelService implements AnalyticsObserver {
         data.body.analytics.distinctId = mixpanelIdentifier;
       }
 
-      await firstValueFrom(this.httpV2.post('/v2/event', data, null));
+      await firstValueFrom(this.httpV2.post('/v2/event', data, null)).catch(
+        () => {
+          // Silently ignore an HTTP error, since we don't want calling code to
+          // have to handle analytics errors.
+        }
+      );
     }
   }
 }

--- a/src/app/shared/services/mixpanel/mixpanel.service.ts
+++ b/src/app/shared/services/mixpanel/mixpanel.service.ts
@@ -1,7 +1,7 @@
 /* @format*/
 import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { environment } from '@root/environments/environment';
-import { AccountVO } from '@models/account-vo';
 import { HttpV2Service } from '../http-v2/http-v2.service';
 import { AnalyticsObserver } from '../analytics/analytics.service';
 
@@ -67,7 +67,7 @@ export class MixpanelData {
 export class MixpanelService implements AnalyticsObserver {
   constructor(private httpV2: HttpV2Service) {}
 
-  public update(data: MixpanelData) {
+  public async update(data: MixpanelData) {
     const account =
       localStorage.getItem('account') || sessionStorage.getItem('account');
 
@@ -80,7 +80,7 @@ export class MixpanelService implements AnalyticsObserver {
         data.body.analytics.distinctId = mixpanelIdentifier;
       }
 
-      this.httpV2.post('/v2/event', data, null);
+      await firstValueFrom(this.httpV2.post('/v2/event', data, null));
     }
   }
 }

--- a/src/app/shared/services/mixpanel/mixpanel.service.ts
+++ b/src/app/shared/services/mixpanel/mixpanel.service.ts
@@ -2,7 +2,6 @@
 import { Injectable } from '@angular/core';
 import { environment } from '@root/environments/environment';
 import { AccountVO } from '@models/account-vo';
-import { firstValueFrom } from 'rxjs';
 import { HttpV2Service } from '../http-v2/http-v2.service';
 import { AnalyticsObserver } from '../analytics/analytics.service';
 
@@ -68,7 +67,7 @@ export class MixpanelData {
 export class MixpanelService implements AnalyticsObserver {
   constructor(private httpV2: HttpV2Service) {}
 
-  public async update(data: MixpanelData) {
+  public update(data: MixpanelData) {
     const account =
       localStorage.getItem('account') || sessionStorage.getItem('account');
 
@@ -81,7 +80,7 @@ export class MixpanelService implements AnalyticsObserver {
         data.body.analytics.distinctId = mixpanelIdentifier;
       }
 
-      return await firstValueFrom(this.httpV2.post('/v2/event', data, null));
+      this.httpV2.post('/v2/event', data, null);
     }
   }
 }


### PR DESCRIPTION
The upload button has stopped working for some users with older browsers. Unfortunately, we were not able to fully study this behavior in an older browser, but we have some educated guesses on what is causing the issue. Specifically, it may be related to the analytics code that is triggering when a user clicks the upload button. An error may potentially be triggered in this analytics function call, and when an error is thrown in the button's `onClick` handler, the click event is canceled and any default behavior (in this case, opening the file upload dialog) is canceled as well.

The fixes in this PR include:
1. Make the `MixpanelService.update` method silently fail if an HTTP error happens.
1. Calling the analytics function without `await` so if a promise rejection happens, the `onClick` handler itself does not reject or throw.
2. Explicitly return true on the `onClick` handler just to be sure that default behavior continues to be called.