### PR TITLE
Wrap text properly on item description field

### DIFF
--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
@@ -39,7 +39,6 @@ select {
   margin-right: -1 * $inline-padding-x;
   position: relative;
   border-color: rgba($input-border-color, 0);
-  word-break: break-all;
 }
 
 select {


### PR DESCRIPTION
In #4, the description field was made to break words when wrapping text (although it's a bit unclear what bug this was specifically fixing). This commit undoes that so that words wrap more naturally and also match what is displayed when editing text.

Resolves PER-9510: Description should not cut words in half when saved