### PR TITLE
Fix upload-sourcemaps action

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@v2

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -70,7 +70,7 @@ jobs:
           cp -r dist/mdot dist/share
           cp -r dist/mdot dist/p
           declare -x VERSION=mdot@$(sentry-cli releases propose-version)
-          sentry-cli releases set-commits $VERSION --auto
+          sentry-cli releases set-commits $VERSION --auto --ignore-missing
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -69,7 +69,7 @@ jobs:
           cp -r dist/mdot dist/app
           cp -r dist/mdot dist/share
           cp -r dist/mdot dist/p
-          declare -x VERSION=mdot@$(jq -r '.version' package.json)
+          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
           sentry-cli releases set-commits $VERSION --auto
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -61,7 +61,7 @@ jobs:
           cp -r dist/mdot dist/app
           cp -r dist/mdot dist/share
           cp -r dist/mdot dist/p
-          declare -x VERSION=mdot@$(jq -r '.version' package.json)
+          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
           sentry-cli releases set-commits $VERSION --auto
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@v2
         with:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -62,7 +62,7 @@ jobs:
           cp -r dist/mdot dist/share
           cp -r dist/mdot dist/p
           declare -x VERSION=mdot@$(sentry-cli releases propose-version)
-          sentry-cli releases set-commits $VERSION --auto
+          sentry-cli releases set-commits $VERSION --auto --ignore-missing
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -61,7 +61,7 @@ jobs:
           cp -r dist/mdot dist/app
           cp -r dist/mdot dist/share
           cp -r dist/mdot dist/p
-          declare -x VERSION=mdot@$(jq -r '.version' package.json)
+          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
           sentry-cli releases set-commits $VERSION --auto
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@v2
         with:

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -62,7 +62,7 @@ jobs:
           cp -r dist/mdot dist/share
           cp -r dist/mdot dist/p
           declare -x VERSION=mdot@$(sentry-cli releases propose-version)
-          sentry-cli releases set-commits $VERSION --auto
+          sentry-cli releases set-commits $VERSION --auto --ignore-missing
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:


### PR DESCRIPTION
The Sentry CLI tries to associate a specific group of commits with a "release" to keep track of when errors happen. Unfortunately, this broke in any new PRs based on the current main branch. I believe this is because the current release, `mdot@2.13.5`, has over 1500 commits in it. Fix this by:
* Fetching the whole commit history when using the upload-sourcemaps action
* Using commit hash to track version information instead of the package.json version