### PR TITLE
Create new component to select archive type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@angular/router": "17.0.8",
         "@fortawesome/angular-fontawesome": "^0.14.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.28",
+        "@fortawesome/free-regular-svg-icons": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^5.13.0",
         "@ng-bootstrap/ng-bootstrap": "16.0.0",
         "@popperjs/core": "^2.11.8",
@@ -6352,6 +6353,27 @@
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.2.tgz",
+      "integrity": "sha512-iabw/f5f8Uy2nTRtJ13XZTS1O5+t+anvlamJ3zJGLEVE2pKsAWhPv2lq01uQlfgCX7VaveT3EVs515cCN9jRbw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+      "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -38035,6 +38057,21 @@
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.2.tgz",
+      "integrity": "sha512-iabw/f5f8Uy2nTRtJ13XZTS1O5+t+anvlamJ3zJGLEVE2pKsAWhPv2lq01uQlfgCX7VaveT3EVs515cCN9jRbw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.2"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+          "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw=="
+        }
       }
     },
     "@fortawesome/free-solid-svg-icons": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@angular/router": "17.0.8",
     "@fortawesome/angular-fontawesome": "^0.14.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
+    "@fortawesome/free-regular-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@ng-bootstrap/ng-bootstrap": "16.0.0",
     "@popperjs/core": "^2.11.8",

--- a/src/app/dialog-cdk/dialog-cdk.module.ts
+++ b/src/app/dialog-cdk/dialog-cdk.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DialogModule as AngularCdkDialogModule } from '@angular/cdk/dialog';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, AngularCdkDialogModule],
+})
+export class DialogCdkModule {}

--- a/src/app/dialog-cdk/dialog-cdk.service.spec.ts
+++ b/src/app/dialog-cdk/dialog-cdk.service.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { Dialog } from '@angular/cdk/dialog';
+import { Component } from '@angular/core';
+import { DialogCdkService } from './dialog-cdk.service';
+
+@Component({
+  selector: 'pr-dummy',
+  standalone: true,
+  imports: [],
+  template: 'Hello world',
+})
+class DummyComponent {}
+
+describe('DialogCdkService', () => {
+  let service: DialogCdkService;
+  let dialog: Dialog;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DialogCdkService);
+    dialog = TestBed.inject(Dialog);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('it wraps around Angular CDK dialog.open', () => {
+    const open = spyOn(dialog, 'open').and.stub();
+    const config = {
+      width: '640px',
+      height: '480px',
+      panelClass: 'test-dialog',
+    };
+    service.open(DummyComponent, config);
+
+    expect(open).toHaveBeenCalledWith(DummyComponent, config);
+  });
+});

--- a/src/app/dialog-cdk/dialog-cdk.service.ts
+++ b/src/app/dialog-cdk/dialog-cdk.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, TemplateRef } from '@angular/core';
+import { Dialog, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import { BasePortalOutlet, ComponentType } from '@angular/cdk/portal';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DialogCdkService {
+  constructor(private dialog: Dialog) {}
+
+  public open<T, U, V>(
+    component: ComponentType<T> | TemplateRef<T>,
+    config?: DialogConfig<V, DialogRef<U, T>, BasePortalOutlet>
+  ): DialogRef<U, T> {
+    return this.dialog.open(component, config);
+  }
+}

--- a/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.html
+++ b/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.html
@@ -1,0 +1,1 @@
+<fa-icon [icon]="icons[type] ?? icons['type:myself']"></fa-icon>

--- a/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.spec.ts
+++ b/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ArchiveTypeIconComponent } from './archive-type-icon.component';
+
+describe('ArchiveTypeIconComponent', () => {
+  let component: ArchiveTypeIconComponent;
+  let fixture: ComponentFixture<ArchiveTypeIconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ArchiveTypeIconComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ArchiveTypeIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faHeart, faUser } from '@fortawesome/free-regular-svg-icons';
+import { faScroll } from '@fortawesome/free-solid-svg-icons';
+import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
+
+@Component({
+  selector: 'pr-archive-type-icon',
+  standalone: true,
+  imports: [FontAwesomeModule],
+  templateUrl: './archive-type-icon.component.html',
+})
+export class ArchiveTypeIconComponent {
+  @Input() public type: OnboardingTypes = OnboardingTypes.myself;
+  public readonly icons = {
+    'type:myself': faHeart,
+    'type:individual': faUser,
+    'type:family': faHeart,
+    'type:famhist': faScroll,
+  };
+}

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
@@ -16,7 +16,7 @@
       (click)="selectType(option.type)"
     >
       <div class="icon">
-        <fa-icon [icon]="icons[option.type] ?? icons['type:myself']"></fa-icon>
+        <pr-archive-type-icon [type]="option.type"></pr-archive-type-icon>
       </div>
       <div class="text">
         <div class="type-name">{{ option.text }}</div>

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
@@ -14,6 +14,7 @@
       class="archive-type"
       [id]="option.type.replace(':', '-')"
       (click)="selectType(option.type)"
+      type="button"
     >
       <div class="icon">
         <pr-archive-type-icon [type]="option.type"></pr-archive-type-icon>

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
@@ -1,0 +1,11 @@
+<div class="archive-type-select-dialog">
+  @for (option of options; track option.text) {
+  <div
+    class="archive-type"
+    [id]="option.type.replace(':', '-')"
+    (click)="selectType(option.type)"
+  >
+    {{ option.text }}
+  </div>
+  }
+</div>

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.html
@@ -1,11 +1,29 @@
 <div class="archive-type-select-dialog">
-  @for (option of options; track option.text) {
-  <div
-    class="archive-type"
-    [id]="option.type.replace(':', '-')"
-    (click)="selectType(option.type)"
-  >
-    {{ option.text }}
+  <div class="header">
+    <div class="bookend"></div>
+    <div class="dialog-label">Archive Type</div>
+    <div class="bookend">
+      <button class="close-button" (click)="closeDialog()">
+        <fa-icon [icon]="close"></fa-icon>
+      </button>
+    </div>
   </div>
-  }
+  <div class="scroll-area">
+    @for (option of options; track option.text) {
+    <button
+      class="archive-type"
+      [id]="option.type.replace(':', '-')"
+      (click)="selectType(option.type)"
+    >
+      <div class="icon">
+        <fa-icon [icon]="icons[option.type] ?? icons['type:myself']"></fa-icon>
+      </div>
+      <div class="text">
+        <div class="type-name">{{ option.text }}</div>
+        <div class="type-description">{{ descriptions[option.type] }}</div>
+      </div>
+    </button>
+    <hr class="divider" />
+    }
+  </div>
 </div>

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.scss
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.scss
@@ -36,12 +36,11 @@
   .dialog-label {
     color: $darkBlue;
     text-align: center;
-    /* Large/Medium */
     font-family: 'Usual', sans-serif;
     font-size: 1em;
     font-style: normal;
     font-weight: 600;
-    line-height: 24px; /* 150% */
+    line-height: 24px;
     letter-spacing: -0.16px;
   }
 

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.scss
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.scss
@@ -1,0 +1,4 @@
+.archive-type-select-dialog {
+  background: #fff;
+  border-radius: 12px 12px 0px 0px;
+}

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.scss
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.scss
@@ -1,4 +1,97 @@
+@import 'variables';
+
 .archive-type-select-dialog {
+  font-family: 'UsualRegular', sans-serif;
   background: #fff;
   border-radius: 12px 12px 0px 0px;
+  display: flex;
+  width: 673px;
+  height: 100vh;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  flex-shrink: 0;
+  font-style: normal;
+}
+
+.scroll-area {
+  display: flex;
+  overflow-y: auto;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  flex: 1 1 auto;
+}
+
+.header {
+  width: 100%;
+  display: flex;
+  height: 64px;
+  padding: 16px;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+  align-self: stretch;
+
+  .dialog-label {
+    color: $darkBlue;
+    text-align: center;
+    /* Large/Medium */
+    font-family: 'Usual', sans-serif;
+    font-size: 1em;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 24px; /* 150% */
+    letter-spacing: -0.16px;
+  }
+
+  .close-button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+}
+
+.archive-type {
+  width: 100%;
+  font-size: 1.125rem;
+  cursor: pointer;
+  text-align: left;
+  border: none;
+  background: transparent;
+  display: flex;
+  padding: 0px 32px;
+  align-items: flex-start;
+  gap: 24px;
+  align-self: stretch;
+
+  .text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+    flex: 1 0 0;
+
+    .type-name {
+      color: $darkBlue;
+      font-weight: 600;
+      line-height: 24px;
+    }
+
+    .type-description {
+      color: #646464;
+      font-weight: 400;
+      line-height: 32px;
+    }
+  }
+}
+
+.divider {
+  height: 1px;
+  flex-shrink: 0;
+  align-self: stretch;
+  margin: 0;
+  border-radius: 30px;
+  opacity: 0.16;
+  background: $darkBlue;
 }

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.spec.ts
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.spec.ts
@@ -1,0 +1,42 @@
+import { DialogCloseOptions, DialogRef } from '@angular/cdk/dialog';
+import { Shallow } from 'shallow-render';
+import { archiveOptions } from '../types/archive-types';
+import { ArchiveTypeSelectDialogComponent } from './archive-type-select-dialog.component';
+
+describe('ArchiveTypeSelectDialogComponent', () => {
+  let shallow: Shallow<ArchiveTypeSelectDialogComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(ArchiveTypeSelectDialogComponent)
+      .provide({
+        provide: DialogRef,
+        useValue: {
+          close() {},
+        },
+      })
+      .dontMock(DialogRef);
+  });
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance).toBeTruthy();
+  });
+
+  it('should have multiple options for archive types', async () => {
+    const { find } = await shallow.render();
+
+    expect(find('.archive-type').length).toEqual(archiveOptions.length);
+  });
+
+  it('should close the dialog and return type when clicking a type', async () => {
+    const { find, inject } = await shallow.render();
+    const dialogRef = inject(DialogRef);
+    const close = spyOn(dialogRef, 'close');
+    find('#type-myself').nativeElement.click();
+    find('#type-org').nativeElement.click();
+
+    expect(close).toHaveBeenCalledWith('type:myself');
+    expect(close).toHaveBeenCalledWith('type:org');
+  });
+});

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.ts
@@ -1,0 +1,20 @@
+import { DialogRef } from '@angular/cdk/dialog';
+import { Component } from '@angular/core';
+import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
+import { archiveOptions, archiveDescriptions } from '../types/archive-types';
+
+@Component({
+  selector: 'pr-archive-type-select-dialog',
+  standalone: true,
+  imports: [],
+  templateUrl: './archive-type-select-dialog.component.html',
+  styleUrl: './archive-type-select-dialog.component.scss',
+})
+export class ArchiveTypeSelectDialogComponent {
+  public readonly options = [...archiveOptions];
+  constructor(private dialogRef: DialogRef) {}
+
+  public selectType(type: OnboardingTypes): void {
+    this.dialogRef.close(type);
+  }
+}

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.ts
@@ -1,20 +1,35 @@
 import { DialogRef } from '@angular/cdk/dialog';
 import { Component } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faHeart, faUser } from '@fortawesome/free-regular-svg-icons';
+import { faScroll, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
 import { archiveOptions, archiveDescriptions } from '../types/archive-types';
 
 @Component({
   selector: 'pr-archive-type-select-dialog',
   standalone: true,
-  imports: [],
+  imports: [FontAwesomeModule],
   templateUrl: './archive-type-select-dialog.component.html',
   styleUrl: './archive-type-select-dialog.component.scss',
 })
 export class ArchiveTypeSelectDialogComponent {
+  public readonly close = faTimes;
   public readonly options = [...archiveOptions];
+  public readonly descriptions = { ...archiveDescriptions };
+  public readonly icons = {
+    'type:myself': faHeart,
+    'type:individual': faUser,
+    'type:family': faHeart,
+    'type:famhist': faScroll,
+  };
   constructor(private dialogRef: DialogRef) {}
 
   public selectType(type: OnboardingTypes): void {
     this.dialogRef.close(type);
+  }
+
+  public closeDialog() {
+    this.dialogRef.close();
   }
 }

--- a/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-select-dialog/archive-type-select-dialog.component.ts
@@ -1,15 +1,15 @@
 import { DialogRef } from '@angular/cdk/dialog';
 import { Component } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faHeart, faUser } from '@fortawesome/free-regular-svg-icons';
-import { faScroll, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
 import { archiveOptions, archiveDescriptions } from '../types/archive-types';
+import { ArchiveTypeIconComponent } from '../archive-type-icon/archive-type-icon.component';
 
 @Component({
   selector: 'pr-archive-type-select-dialog',
   standalone: true,
-  imports: [FontAwesomeModule],
+  imports: [FontAwesomeModule, ArchiveTypeIconComponent],
   templateUrl: './archive-type-select-dialog.component.html',
   styleUrl: './archive-type-select-dialog.component.scss',
 })
@@ -17,12 +17,6 @@ export class ArchiveTypeSelectDialogComponent {
   public readonly close = faTimes;
   public readonly options = [...archiveOptions];
   public readonly descriptions = { ...archiveDescriptions };
-  public readonly icons = {
-    'type:myself': faHeart,
-    'type:individual': faUser,
-    'type:family': faHeart,
-    'type:famhist': faScroll,
-  };
   constructor(private dialogRef: DialogRef) {}
 
   public selectType(type: OnboardingTypes): void {

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.html
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.html
@@ -1,4 +1,4 @@
-<button class="archive-type-select" (click)="onClick()">
+<button class="archive-type-select" (click)="onClick()" type="button">
   <div class="icon">
     <pr-archive-type-icon [type]="currentType"></pr-archive-type-icon>
   </div>

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.html
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.html
@@ -1,4 +1,10 @@
-<div (click)="onClick()">
-  <div class="type-name">{{ typeName }}</div>
-  <div class="type-description">{{ typeDescription }}</div>
-</div>
+<button class="archive-type-select" (click)="onClick()">
+  <div class="icon">
+    <pr-archive-type-icon [type]="currentType"></pr-archive-type-icon>
+  </div>
+  <div class="archive-type">
+    <div class="type-name">{{ typeName }}</div>
+    <div class="type-description">{{ typeDescription }}</div>
+  </div>
+  <div class="dropdown-arrow"><fa-icon [icon]="chevronDown"></fa-icon></div>
+</button>

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.html
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.html
@@ -1,0 +1,4 @@
+<div (click)="onClick()">
+  <div class="type-name">{{ typeName }}</div>
+  <div class="type-description">{{ typeDescription }}</div>
+</div>

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.scss
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.scss
@@ -1,0 +1,41 @@
+.archive-type-select {
+  cursor: pointer;
+  width: 100%;
+  display: flex;
+  padding: 32px;
+  align-items: flex-start;
+  gap: 24px;
+  align-self: stretch;
+
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(97deg, #8d0085 0%, #ff9400 100%);
+
+  font-family: 'UsualRegular', sans-serif;
+  font-style: normal;
+  color: #fff;
+}
+
+.archive-type {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  flex: 1 0 0;
+  font-style: normal;
+
+  .type-name {
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 24px;
+  }
+
+  .type-description {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 18px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 32px;
+  }
+}

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.spec.ts
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Shallow } from 'shallow-render';
+import { Subject } from 'rxjs';
+import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
+import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
+import { archiveDescriptions } from '../types/archive-types';
+import { GlamArchiveTypeSelectComponent } from './archive-type-select.component';
+
+describe('ArchiveTypeSelectComponent', () => {
+  let shallow: Shallow<GlamArchiveTypeSelectComponent>;
+  let dialogRef: Subject<OnboardingTypes | undefined>;
+
+  function expectCommunityDisplayed(find) {
+    expect(find('.type-name').nativeElement.innerText).toContain('Community');
+    expect(find('.type-description').nativeElement.innerText).toContain(
+      archiveDescriptions['type:community']
+    );
+  }
+
+  beforeEach(() => {
+    if (dialogRef) {
+      dialogRef.complete();
+    }
+    dialogRef = new Subject<OnboardingTypes | undefined>();
+    shallow = new Shallow(GlamArchiveTypeSelectComponent)
+      .provide({
+        provide: DialogCdkService,
+        useValue: {
+          open() {
+            return {
+              closed: dialogRef,
+            };
+          },
+        },
+      })
+      .dontMock(DialogCdkService);
+  });
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance).toBeTruthy();
+  });
+
+  it('should open a selection dialog on click', async () => {
+    const { instance, inject } = await shallow.render();
+    const dialogService = inject(DialogCdkService);
+    const open = spyOn(dialogService, 'open').and.callThrough();
+    instance.onClick();
+
+    expect(open).toHaveBeenCalled();
+  });
+
+  it('should change displayed archive type when the dialog returns with a type', async () => {
+    const { find, instance, fixture } = await shallow.render();
+    instance.onClick();
+    dialogRef.next(OnboardingTypes.community);
+    fixture.detectChanges();
+
+    expectCommunityDisplayed(find);
+  });
+
+  it('can change type multiple times', async () => {
+    const { find, instance, fixture } = await shallow.render();
+    instance.onClick();
+    dialogRef.next(OnboardingTypes.famhist);
+    instance.onClick();
+    dialogRef.next(OnboardingTypes.community);
+    fixture.detectChanges();
+
+    expectCommunityDisplayed(find);
+  });
+
+  it('should not change the displayed archive type if the dialog is closed without any selection', async () => {
+    const { find, fixture, instance } = await shallow.render();
+    instance.onClick();
+    dialogRef.next(OnboardingTypes.community);
+    instance.onClick();
+    dialogRef.next(undefined);
+
+    fixture.detectChanges();
+
+    expectCommunityDisplayed(find);
+  });
+
+  it('handles an invalid onboardingtype', async () => {
+    const { find, fixture, instance } = await shallow.render();
+    instance.onClick();
+    dialogRef.next(OnboardingTypes.community);
+    instance.onClick();
+    dialogRef.next('not-valid-type' as OnboardingTypes);
+
+    fixture.detectChanges();
+
+    expectCommunityDisplayed(find);
+  });
+
+  it('emits the selected archive type', async () => {
+    const { outputs, instance } = await shallow.render();
+    instance.onClick();
+    dialogRef.next(OnboardingTypes.famhist);
+
+    expect(outputs.typeSelected.emit).toHaveBeenCalledWith(
+      OnboardingTypes.famhist
+    );
+  });
+});

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.ts
@@ -1,0 +1,50 @@
+import { Component, Output, EventEmitter } from '@angular/core';
+import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
+import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
+import { ArchiveTypeSelectDialogComponent } from '../archive-type-select-dialog/archive-type-select-dialog.component';
+
+import { archiveOptions, archiveDescriptions } from '../types/archive-types';
+
+@Component({
+  selector: 'pr-glam-archive-type-select',
+  standalone: true,
+  imports: [],
+  templateUrl: './archive-type-select.component.html',
+  styleUrl: './archive-type-select.component.scss',
+})
+export class GlamArchiveTypeSelectComponent {
+  @Output() public typeSelected = new EventEmitter<OnboardingTypes>();
+  public currentType: OnboardingTypes = OnboardingTypes.myself;
+  public typeName: string;
+  public typeDescription: string;
+
+  constructor(private dialog: DialogCdkService) {
+    this.refreshArchiveTypeText();
+  }
+
+  public onClick(): void {
+    this.dialog
+      .open(ArchiveTypeSelectDialogComponent, {
+        panelClass: 'dialog',
+      })
+      .closed.subscribe((value?: OnboardingTypes) => {
+        if (value) {
+          if (!this.getOptionByType(value)) {
+            return;
+          }
+          this.currentType = value;
+          this.refreshArchiveTypeText();
+          this.typeSelected.emit(value);
+        }
+      });
+  }
+
+  private getOptionByType(value: OnboardingTypes) {
+    return archiveOptions.find((val) => val.type === value);
+  }
+
+  private refreshArchiveTypeText(): void {
+    this.typeName = this.getOptionByType(this.currentType).text;
+    this.typeDescription = archiveDescriptions[this.currentType];
+  }
+}

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.component.ts
@@ -1,14 +1,16 @@
 import { Component, Output, EventEmitter } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
 import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
 import { ArchiveTypeSelectDialogComponent } from '../archive-type-select-dialog/archive-type-select-dialog.component';
-
 import { archiveOptions, archiveDescriptions } from '../types/archive-types';
+import { ArchiveTypeIconComponent } from '../archive-type-icon/archive-type-icon.component';
 
 @Component({
   selector: 'pr-glam-archive-type-select',
   standalone: true,
-  imports: [],
+  imports: [FontAwesomeModule, ArchiveTypeIconComponent],
   templateUrl: './archive-type-select.component.html',
   styleUrl: './archive-type-select.component.scss',
 })
@@ -17,6 +19,7 @@ export class GlamArchiveTypeSelectComponent {
   public currentType: OnboardingTypes = OnboardingTypes.myself;
   public typeName: string;
   public typeDescription: string;
+  public chevronDown = faChevronDown;
 
   constructor(private dialog: DialogCdkService) {
     this.refreshArchiveTypeText();

--- a/src/app/onboarding/components/glam/archive-type-select/archive-type-select.stories.ts
+++ b/src/app/onboarding/components/glam/archive-type-select/archive-type-select.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { argsToTemplate } from '@storybook/angular';
+import { action } from '@storybook/addon-actions';
+import { withActions } from '@storybook/addon-actions/decorator';
+import { GlamArchiveTypeSelectComponent } from './archive-type-select.component';
+
+const typeSelected = action('typeSelected');
+
+const meta: Meta<GlamArchiveTypeSelectComponent> = {
+  title: 'Glam Onboarding: Archive Type Select',
+  component: GlamArchiveTypeSelectComponent,
+  tags: ['onboarding', 'glam'],
+  render: (args: GlamArchiveTypeSelectComponent) => ({
+    props: {
+      ...args,
+      typeSelected,
+    },
+    template: `<pr-glam-archive-type-select ${argsToTemplate({
+      ...args,
+      typeSelected,
+    })}></pr-glam-archive-type-select>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<GlamArchiveTypeSelectComponent>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/app/onboarding/components/glam/types/archive-types.ts
+++ b/src/app/onboarding/components/glam/types/archive-types.ts
@@ -1,0 +1,59 @@
+import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
+
+export const archiveOptions = [
+  {
+    value: 'type.archive.person',
+    text: 'Personal',
+    type: OnboardingTypes.myself,
+  },
+  {
+    value: 'type.archive.person',
+    text: 'An individual',
+    type: OnboardingTypes.individual,
+  },
+  {
+    value: 'type.archive.group',
+    text: 'Family',
+    type: OnboardingTypes.family,
+  },
+  {
+    value: 'type.archive.group',
+    text: "My family's history",
+    type: OnboardingTypes.famhist,
+  },
+  {
+    value: 'type.archive.group',
+    text: 'Community',
+    type: OnboardingTypes.community,
+  },
+  {
+    value: 'type.archive.organization',
+    text: 'Organization',
+    type: OnboardingTypes.org,
+  },
+  {
+    value: 'type.archive.person',
+    text: 'Other',
+    type: OnboardingTypes.other,
+  },
+  {
+    value: 'type.archive.person',
+    text: "I'm not sure yet",
+    type: OnboardingTypes.unsure,
+  },
+];
+
+export const archiveDescriptions = {
+  'type:myself': 'Create an archive that captures my personal life journey.',
+  'type:individual':
+    'Create an archive that captures an individual person’s life journey other than your own.',
+  'type:family': 'Create an archive that captures my family life.',
+  'type:famhist':
+    'Create an archive that preserves the memory of my ancestors, family history, or genealogy.',
+  'type:community':
+    'Create an archive that preserves the history of a community, group, or other association of people.',
+  'type:org':
+    'Create an archive that preserves the history of an organization or nonprofit.',
+  'type:other': '',
+  'type:unsure': '',
+};

--- a/src/app/onboarding/onboarding.module.ts
+++ b/src/app/onboarding/onboarding.module.ts
@@ -9,6 +9,7 @@ import { SharedModule } from '@shared/shared.module';
 import { CoreModule } from '@core/core.module';
 import { SkipOnboardingDialogComponent } from '@core/components/skip-onboarding-dialog/skip-onboarding-dialog.component';
 import { DialogModule } from '../dialog/dialog.module';
+import { DialogCdkModule } from '../dialog-cdk/dialog-cdk.module';
 import { OnboardingRoutingModule } from './onboarding.routes';
 import { OnboardingComponent } from './components/onboarding/onboarding.component';
 import { WelcomeScreenComponent } from './components/welcome-screen/welcome-screen.component';
@@ -28,6 +29,7 @@ import { ArchiveTypeSelectComponent } from './components/archive-type-select/arc
     SharedModule,
     CoreModule,
     DialogModule,
+    DialogCdkModule,
   ],
 })
 export class OnboardingModule {

--- a/src/app/onboarding/onboarding.module.ts
+++ b/src/app/onboarding/onboarding.module.ts
@@ -5,6 +5,11 @@ import {
 } from '@root/app/dialog/dialog.module';
 import { ComponentFactoryResolver, NgModule, Optional } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import {
+  FontAwesomeModule,
+  FaIconLibrary,
+} from '@fortawesome/angular-fontawesome';
+import { faHeart } from '@fortawesome/free-solid-svg-icons';
 import { SharedModule } from '@shared/shared.module';
 import { CoreModule } from '@core/core.module';
 import { SkipOnboardingDialogComponent } from '@core/components/skip-onboarding-dialog/skip-onboarding-dialog.component';
@@ -30,6 +35,7 @@ import { ArchiveTypeSelectComponent } from './components/archive-type-select/arc
     CoreModule,
     DialogModule,
     DialogCdkModule,
+    FontAwesomeModule,
   ],
 })
 export class OnboardingModule {
@@ -41,8 +47,10 @@ export class OnboardingModule {
   ];
   constructor(
     private dialog: Dialog,
-    private resolver: ComponentFactoryResolver
+    private resolver: ComponentFactoryResolver,
+    private library: FaIconLibrary
   ) {
+    library.addIcons(faHeart);
     if (this.dialog) {
       this.dialog.registerComponents(
         this.dialogComponents,

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,3 +1,5 @@
+@import '@angular/cdk/overlay-prebuilt.css';
+
 @import 'variables';
 @import 'vendor/bootstrap/bootstrap-custom';
 @import 'vendor/ionicons/ionicons';


### PR DESCRIPTION
This PR adds some new components to be used in the newly redesigned "GLAM" onboarding flow. These components are currently unused since integrating them will be done later, but the components can be tested with Storybook.

One pretty significant change here is that the new archive type selection component uses the [Angular CDK Dialog](https://material.angular.io/cdk/dialog/overview) service instead of our custom-rolled `DialogService`. As discussed in #269, the current `DialogService` is a bit problematic and we want to eventually move away from it. One big problem with it I noticed while working on this ticket is that it violates some design principles (the [Open Closed Principle](https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle) and probably others) as the DialogService needs to know about the names of possible components that it can host ([see this type definition](https://github.com/PermanentOrg/web-app/blob/bbd7fa91e9bbc9cc7dc0bde5e032cbf664df97ea/src/app/dialog/dialog.service.ts#L23)) and also needs module-level configuration to work properly.

I did not want to continue going along with this design for these glam components, especially since these components are probably more volatile than normal (they may be moved around the codebase, they currently exist as standalone components, they may be renamed to remove "glam" from their name in the future). So I decided to use the CDK DialogService for these components instead. To do so, I ended up creating a wrapper service so that we could potentially end up using a form of [branch by abstraction](https://martinfowler.com/bliki/BranchByAbstraction.html) to migrate older code over. Also I wanted it to be clear when components were using the new CDK DialogService. In the future when we migrate over fully, we shouldn't really need the wrapper service anymore and we should import the `AngularCdkDialogModule` directly instead.

Steps to test:
1. Run `npm run storybook`
2. Test the "Glam Onboarding: Archive Type Select" story

Incomplete design questions:
- We currently do not have access to all of the FontAwesome icons used in the design. Do we want to use different icons for archive types? Or should we get FontAwesome pro?
- The design does not show any new descriptions for "Other" or "I"m not sure yet". I've left them empty for now, but what should these say and what icons should they use?