### PR TITLE
Call v1 endpoints with the Authorization header

### DIFF
--- a/src/app/shared/services/http/http.service.spec.ts
+++ b/src/app/shared/services/http/http.service.spec.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpService } from '@shared/services/http/http.service';
@@ -32,6 +33,6 @@ describe('HttpService', () => {
     const headers = service.generateHeaders();
 
     expect(headers.keys().length).toBe(1);
-    expect(headers.get("Authorization")).toBe("Bearer testing_token");
+    expect(headers.get('Authorization')).toBe('Bearer testing_token');
   });
 });

--- a/src/app/shared/services/http/http.service.spec.ts
+++ b/src/app/shared/services/http/http.service.spec.ts
@@ -1,19 +1,37 @@
-import { TestBed, inject } from '@angular/core/testing';
-import { HttpClientModule } from '@angular/common/http';
-
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpService } from '@shared/services/http/http.service';
+import { StorageService } from '../storage/storage.service';
 
 describe('HttpService', () => {
+  let service: HttpService;
+  let storage: StorageService;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        HttpClientModule
-      ],
-      providers: [HttpService]
+      imports: [HttpClientTestingModule],
+      providers: [HttpService, StorageService],
     });
+    service = TestBed.inject(HttpService);
+    storage = TestBed.inject(StorageService);
+    storage.local.clear();
   });
 
-  it('should be created', inject([HttpService], (service: HttpService) => {
+  it('should be created', () => {
     expect(service).toBeTruthy();
-  }));
+  });
+
+  it('should not make Authorization headers by default', () => {
+    const headers = service.generateHeaders();
+
+    expect(headers.keys().length).toBe(0);
+  });
+
+  it('should make Authorization headers if an auth token is set', () => {
+    storage.local.set('AUTH_TOKEN', 'testing_token');
+    const headers = service.generateHeaders();
+
+    expect(headers.keys().length).toBe(1);
+    expect(headers.get("Authorization")).toBe("Bearer testing_token");
+  });
 });


### PR DESCRIPTION
We want to pass an authorization header to v1 endpoints now, since some of them require it now. This PR generates the proper headers if an auth token exists and passes them to v1 requests.

**Steps to test:**
1. Log in to the web-app
2. Do something that calls a v1 endpoint
3. Verify that the Authorization header is included in the request
4. Verify that Authorization headers are not passed to unauthenticated requests, such as viewing a public archives when logged out.