### PR TITLE
Pass Auth header only to specific v1 endpoints instead of all

### DIFF
--- a/src/app/shared/services/api/account.repo.ts
+++ b/src/app/shared/services/api/account.repo.ts
@@ -12,7 +12,7 @@ export class AccountRepo extends BaseRepo {
     return this.http.sendRequestPromise<AccountResponse>(
       '/account/get',
       [account],
-      AccountResponse
+      { responseClass: AccountResponse }
     );
   }
 
@@ -61,7 +61,7 @@ export class AccountRepo extends BaseRepo {
     return this.http.sendRequestPromise<AccountResponse>(
       '/account/update',
       data,
-      AccountResponse
+      { responseClass: AccountResponse }
     );
   }
 
@@ -78,7 +78,7 @@ export class AccountRepo extends BaseRepo {
     return this.http.sendRequestPromise<AccountResponse>(
       '/account/delete',
       data,
-      AccountResponse
+      { responseClass: AccountResponse }
     );
   }
 
@@ -92,7 +92,7 @@ export class AccountRepo extends BaseRepo {
     return this.http.sendRequestPromise<AccountResponse>(
       '/account/updatePreference',
       data,
-      AccountResponse
+      { responseClass: AccountResponse }
     );
   }
 

--- a/src/app/shared/services/api/archive.repo.ts
+++ b/src/app/shared/services/api/archive.repo.ts
@@ -23,11 +23,9 @@ export class ArchiveRepo extends BaseRepo {
       };
     });
 
-    return this.http.sendRequestPromise<ArchiveResponse>(
-      '/archive/get',
-      data,
-      ArchiveResponse
-    );
+    return this.http.sendRequestPromise<ArchiveResponse>('/archive/get', data, {
+      responseClass: ArchiveResponse,
+    });
   }
 
   public getAllArchives(accountVO: AccountVO): Promise<ArchiveResponse> {
@@ -42,7 +40,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/getAllArchives',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -56,7 +54,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/change',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -70,7 +68,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/update',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -84,7 +82,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/delete',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -100,7 +98,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/post',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -114,7 +112,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/accept',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -128,7 +126,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/decline',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -142,7 +140,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/getShares',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -160,7 +158,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/share',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -178,7 +176,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/transferOwnership',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -193,11 +191,9 @@ export class ArchiveRepo extends BaseRepo {
       },
     ];
 
-    return this.http.sendRequestPromise(
-      '/archive/updateShare',
-      data,
-      ArchiveResponse
-    );
+    return this.http.sendRequestPromise('/archive/updateShare', data, {
+      responseClass: ArchiveResponse,
+    });
   }
 
   public removeMember(
@@ -214,7 +210,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/unshare',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -236,11 +232,9 @@ export class ArchiveRepo extends BaseRepo {
       return;
     }
 
-    return this.http.sendRequestPromise<ArchiveResponse>(
-      endpoint,
-      data,
-      ArchiveResponse
-    );
+    return this.http.sendRequestPromise<ArchiveResponse>(endpoint, data, {
+      responseClass: ArchiveResponse,
+    });
   }
 
   public addUpdateProfileItems(profileItems: ProfileItemVOData[]) {
@@ -253,7 +247,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/profile_item/safeAddUpdate',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 
@@ -267,7 +261,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/profile_item/delete',
       data,
-      ArchiveResponse
+      { responseClass: ArchiveResponse }
     );
   }
 

--- a/src/app/shared/services/api/archive.repo.ts
+++ b/src/app/shared/services/api/archive.repo.ts
@@ -98,7 +98,7 @@ export class ArchiveRepo extends BaseRepo {
     return this.http.sendRequestPromise<ArchiveResponse>(
       '/archive/post',
       data,
-      { responseClass: ArchiveResponse }
+      { responseClass: ArchiveResponse, useAuthorizationHeader: true }
     );
   }
 

--- a/src/app/shared/services/api/auth.repo.ts
+++ b/src/app/shared/services/api/auth.repo.ts
@@ -18,11 +18,9 @@ import { getFirst } from '../http-v2/http-v2.service';
 
 export class AuthRepo extends BaseRepo {
   public isLoggedIn(): Promise<AuthResponse> {
-    return this.http.sendRequestPromise(
-      '/auth/loggedIn',
-      undefined,
-      AuthResponse
-    );
+    return this.http.sendRequestPromise('/auth/loggedIn', undefined, {
+      responseClass: AuthResponse,
+    });
   }
 
   public logIn(
@@ -44,7 +42,7 @@ export class AuthRepo extends BaseRepo {
     return this.http.sendRequest<AuthResponse>(
       '/auth/login',
       [{ AccountVO: accountVO, AccountPasswordVO: accountPasswordVO }],
-      AuthResponse
+      { responseClass: AuthResponse }
     );
   }
 
@@ -66,7 +64,7 @@ export class AuthRepo extends BaseRepo {
     return this.http.sendRequest<AuthResponse>(
       '/auth/verify',
       [{ AccountVO: accountVO, AuthVO: authVO }],
-      AuthResponse
+      { responseClass: AuthResponse }
     );
   }
 
@@ -78,7 +76,7 @@ export class AuthRepo extends BaseRepo {
     return this.http.sendRequest<AuthResponse>(
       '/auth/sendEmailForgotPassword',
       [{ AccountVO: accountVO }],
-      AuthResponse
+      { responseClass: AuthResponse }
     );
   }
 
@@ -110,7 +108,7 @@ export class AuthRepo extends BaseRepo {
     return this.http.sendRequestPromise<AuthResponse>(
       '/account/changePassword',
       data,
-      AuthResponse
+      { responseClass: AuthResponse }
     );
   }
 
@@ -123,7 +121,7 @@ export class AuthRepo extends BaseRepo {
     return this.http.sendRequestPromise<AuthResponse>(
       '/auth/resendMailCreatedAccount',
       [account],
-      AuthResponse
+      { responseClass: AuthResponse }
     );
   }
 
@@ -136,7 +134,7 @@ export class AuthRepo extends BaseRepo {
     return this.http.sendRequestPromise<AuthResponse>(
       '/auth/resendTextCreatedAccount',
       [account],
-      AuthResponse
+      { responseClass: AuthResponse }
     );
   }
 

--- a/src/app/shared/services/api/billing.repo.ts
+++ b/src/app/shared/services/api/billing.repo.ts
@@ -24,7 +24,7 @@ export class BillingRepo extends BaseRepo {
     return this.http.sendRequestPromise<BillingResponse>(
       '/billing/claimPledge',
       data,
-      BillingResponse
+      { responseClass: BillingResponse }
     );
   }
 
@@ -39,7 +39,7 @@ export class BillingRepo extends BaseRepo {
     return this.http.sendRequestPromise<BillingResponse>(
       '/billing/getBillingLedgerNonfinancial',
       data,
-      BillingResponse
+      { responseClass: BillingResponse }
     );
   }
 
@@ -54,7 +54,7 @@ export class BillingRepo extends BaseRepo {
     return this.http.sendRequestPromise<BillingResponse>(
       '/billing/getBillingLedgerFinancial',
       data,
-      BillingResponse
+      { responseClass: BillingResponse }
     );
   }
 
@@ -65,11 +65,9 @@ export class BillingRepo extends BaseRepo {
       },
     ];
 
-    return this.http.sendRequestPromise<BillingResponse>(
-      '/promo/entry',
-      data,
-      BillingResponse
-    );
+    return this.http.sendRequestPromise<BillingResponse>('/promo/entry', data, {
+      responseClass: BillingResponse,
+    });
   }
 
   public giftStorage(

--- a/src/app/shared/services/api/connector.repo.ts
+++ b/src/app/shared/services/api/connector.repo.ts
@@ -18,7 +18,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequest<ConnectorResponse>(
       '/connector/getOverview',
       connectors,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -32,7 +32,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequest<ConnectorResponse>(
       '/connector/familysearchSetup',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -52,7 +52,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       `/connector/familysearchAuthorize`,
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -66,7 +66,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequest<ConnectorResponse>(
       '/connector/familysearchDisconnect',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -80,7 +80,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/getFamilysearchUser',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -94,7 +94,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/getFamilysearchTreeUser',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -112,7 +112,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/getFamilysearchAncestry',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -130,7 +130,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/getFamilysearchMemories',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -166,7 +166,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/familysearchMemoryImportRequest',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -186,7 +186,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/familysearchMemorySyncRequest',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -206,7 +206,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/familysearchMemoryUploadRequest',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 
@@ -232,7 +232,7 @@ export class ConnectorRepo extends BaseRepo {
     return this.http.sendRequestPromise<ConnectorResponse>(
       '/connector/familysearchFactImportRequest',
       data,
-      ConnectorResponse
+      { responseClass: ConnectorResponse }
     );
   }
 }

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -1,15 +1,29 @@
+/* @format */
 import { FolderVO, FolderVOData, ItemVO } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { DataStatus } from '@models/data-status.enum';
 
-const MIN_WHITELIST: (keyof FolderVO)[] = ['folderId', 'archiveNbr', 'folder_linkId'];
-const DEFAULT_WHITELIST: (keyof FolderVO)[] = [...MIN_WHITELIST, 'displayName', 'description', 'displayDT', 'displayEndDT', 'view'];
+const MIN_WHITELIST: (keyof FolderVO)[] = [
+  'folderId',
+  'archiveNbr',
+  'folder_linkId',
+];
+const DEFAULT_WHITELIST: (keyof FolderVO)[] = [
+  ...MIN_WHITELIST,
+  'displayName',
+  'description',
+  'displayDT',
+  'displayEndDT',
+  'view',
+];
 
 export class FolderRepo extends BaseRepo {
   public getRoot(): Promise<FolderResponse> {
-    return this.http.sendRequestPromise<FolderResponse>('/folder/getRoot', [], FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>('/folder/getRoot', [], {
+      responseClass: FolderResponse,
+    });
   }
 
   public get(folderVOs: FolderVO[]): Promise<FolderResponse> {
@@ -18,12 +32,14 @@ export class FolderRepo extends BaseRepo {
         FolderVO: {
           archiveNbr: folderVO.archiveNbr,
           folder_linkId: folderVO.folder_linkId,
-          folderId: folderVO.folderId
-        }
+          folderId: folderVO.folderId,
+        },
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/get', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>('/folder/get', data, {
+      responseClass: FolderResponse,
+    });
   }
 
   public getWithChildren(folderVOs: FolderVO[]): Promise<FolderResponse> {
@@ -32,12 +48,16 @@ export class FolderRepo extends BaseRepo {
         FolderVO: {
           archiveNbr: folderVO.archiveNbr,
           folder_linkId: folderVO.folder_linkId,
-          folderId: folderVO.folderId
-        }
+          folderId: folderVO.folderId,
+        },
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/getWithChildren', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>(
+      '/folder/getWithChildren',
+      data,
+      { responseClass: FolderResponse }
+    );
   }
 
   public navigate(folderVO: FolderVO): Observable<FolderResponse> {
@@ -48,43 +68,57 @@ export class FolderRepo extends BaseRepo {
       response.displayName = 'Private';
     }
 
-    const data = [{
-      FolderVO: new FolderVO(response)
-    }];
+    const data = [
+      {
+        FolderVO: new FolderVO(response),
+      },
+    ];
 
-    return this.http.sendRequest<FolderResponse>('/folder/navigateMin', data, FolderResponse);
+    return this.http.sendRequest<FolderResponse>('/folder/navigateMin', data, {
+      responseClass: FolderResponse,
+    });
   }
 
   public navigateLean(folderVO: FolderVO): Observable<FolderResponse> {
-    const data = [{
-      FolderVO: new FolderVO(folderVO)
-    }];
+    const data = [
+      {
+        FolderVO: new FolderVO(folderVO),
+      },
+    ];
 
-    return this.http.sendRequest<FolderResponse>('/folder/navigateLean', data, FolderResponse);
+    return this.http.sendRequest<FolderResponse>('/folder/navigateLean', data, {
+      responseClass: FolderResponse,
+    });
   }
-
 
   public getLeanItems(folderVOs: FolderVO[]): Observable<FolderResponse> {
     const data = folderVOs.map((folderVO) => {
       return {
-        FolderVO: new FolderVO(folderVO)
+        FolderVO: new FolderVO(folderVO),
       };
     });
 
-    return this.http.sendRequest<FolderResponse>('/folder/getLeanItems', data, FolderResponse);
+    return this.http.sendRequest<FolderResponse>('/folder/getLeanItems', data, {
+      responseClass: FolderResponse,
+    });
   }
 
   public post(folderVOs: FolderVO[]): Promise<FolderResponse> {
     const data = folderVOs.map((folderVO) => {
       return {
-        FolderVO: new FolderVO(folderVO)
+        FolderVO: new FolderVO(folderVO),
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/post', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>('/folder/post', data, {
+      responseClass: FolderResponse,
+    });
   }
 
-  public update(folderVOs: FolderVO[], whitelist = DEFAULT_WHITELIST): Promise<FolderResponse> {
+  public update(
+    folderVOs: FolderVO[],
+    whitelist = DEFAULT_WHITELIST
+  ): Promise<FolderResponse> {
     if (whitelist !== DEFAULT_WHITELIST) {
       whitelist = [...whitelist, ...MIN_WHITELIST];
     }
@@ -98,14 +132,21 @@ export class FolderRepo extends BaseRepo {
       }
 
       return {
-        FolderVO: new FolderVO(updateData)
+        FolderVO: new FolderVO(updateData),
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/update', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>(
+      '/folder/update',
+      data,
+      { responseClass: FolderResponse }
+    );
   }
 
-  public updateRoot(folderVOs: FolderVO[], whitelist = DEFAULT_WHITELIST): Promise<FolderResponse> {
+  public updateRoot(
+    folderVOs: FolderVO[],
+    whitelist = DEFAULT_WHITELIST
+  ): Promise<FolderResponse> {
     if (whitelist !== DEFAULT_WHITELIST) {
       whitelist = [...whitelist, ...MIN_WHITELIST];
     }
@@ -119,57 +160,81 @@ export class FolderRepo extends BaseRepo {
       }
 
       return {
-        FolderVO: new FolderVO(updateData)
+        FolderVO: new FolderVO(updateData),
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/updateRootColumns', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>(
+      '/folder/updateRootColumns',
+      data,
+      { responseClass: FolderResponse }
+    );
   }
 
   public delete(folderVOs: FolderVO[]): Promise<FolderResponse> {
     const data = folderVOs.map((folderVO) => {
       return {
-        FolderVO: new FolderVO(folderVO)
+        FolderVO: new FolderVO(folderVO),
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/delete', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>(
+      '/folder/delete',
+      data,
+      { responseClass: FolderResponse }
+    );
   }
 
-  public move(folderVOs: FolderVO[], destination: FolderVO): Promise<FolderResponse> {
+  public move(
+    folderVOs: FolderVO[],
+    destination: FolderVO
+  ): Promise<FolderResponse> {
     const data = folderVOs.map((folderVO) => {
       return {
         FolderVO: new FolderVO(folderVO),
         FolderDestVO: {
-          folder_linkId: destination.folder_linkId
-        }
+          folder_linkId: destination.folder_linkId,
+        },
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/move', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>('/folder/move', data, {
+      responseClass: FolderResponse,
+    });
   }
 
-  public copy(folderVOs: FolderVO[], destination: FolderVO): Promise<FolderResponse> {
+  public copy(
+    folderVOs: FolderVO[],
+    destination: FolderVO
+  ): Promise<FolderResponse> {
     const data = folderVOs.map((folderVO) => {
       return {
         FolderVO: new FolderVO(folderVO),
         FolderDestVO: {
-          folder_linkId: destination.folder_linkId
-        }
+          folder_linkId: destination.folder_linkId,
+        },
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/copy', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>('/folder/copy', data, {
+      responseClass: FolderResponse,
+    });
   }
 
   public getPublicRoot(archiveNbr: string) {
-    const data = [{
-      ArchiveVO: {
-        archiveNbr
-      }
-    }];
+    const data = [
+      {
+        ArchiveVO: {
+          archiveNbr,
+        },
+      },
+    ];
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/getPublicRoot', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>(
+      '/folder/getPublicRoot',
+      data,
+      { responseClass: FolderResponse }
+    );
   }
 
   public sort(folderVOs: FolderVO[]): Promise<FolderResponse> {
@@ -177,27 +242,36 @@ export class FolderRepo extends BaseRepo {
       return {
         FolderVO: new FolderVO({
           folder_linkId: folderVO.folder_linkId,
-          sort: folderVO.sort
-        })
+          sort: folderVO.sort,
+        }),
       };
     });
 
-    return this.http.sendRequestPromise<FolderResponse>('/folder/sort', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>('/folder/sort', data, {
+      responseClass: FolderResponse,
+    });
   }
 
   public createZip(items: ItemVO[]): Promise<FolderResponse> {
-    const data = [{
-      ZipVO: {
-        items: items.map(i => i.archiveNbr).join(',')
-      }
-    }];
+    const data = [
+      {
+        ZipVO: {
+          items: items.map((i) => i.archiveNbr).join(','),
+        },
+      },
+    ];
 
-    return this.http.sendRequestPromise<FolderResponse>('/zip/post', data, FolderResponse);
+    return this.http.sendRequestPromise<FolderResponse>('/zip/post', data, {
+      responseClass: FolderResponse,
+    });
   }
 }
 
 export class FolderResponse extends BaseResponse {
-  public getFolderVO(initChildren?: boolean, dataStatus: DataStatus = DataStatus.Placeholder) {
+  public getFolderVO(
+    initChildren?: boolean,
+    dataStatus: DataStatus = DataStatus.Placeholder
+  ) {
     const data = this.getResultsData();
     if (!data || !data.length) {
       return null;

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -200,6 +200,7 @@ export class FolderRepo extends BaseRepo {
 
     return this.http.sendRequestPromise<FolderResponse>('/folder/move', data, {
       responseClass: FolderResponse,
+      useAuthorizationHeader: true,
     });
   }
 
@@ -218,6 +219,7 @@ export class FolderRepo extends BaseRepo {
 
     return this.http.sendRequestPromise<FolderResponse>('/folder/copy', data, {
       responseClass: FolderResponse,
+      useAuthorizationHeader: true,
     });
   }
 

--- a/src/app/shared/services/api/invite.repo.ts
+++ b/src/app/shared/services/api/invite.repo.ts
@@ -1,4 +1,12 @@
-import { InviteVO, RecordVO, FolderVO, AccountVO, ArchiveVO, ItemVO } from '@root/app/models';
+/* @format */
+import {
+  InviteVO,
+  RecordVO,
+  FolderVO,
+  AccountVO,
+  ArchiveVO,
+  ItemVO,
+} from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { flatten } from 'lodash';
 
@@ -6,31 +14,47 @@ export class InviteRepo extends BaseRepo {
   public send(invites: InviteVO[]): Promise<InviteResponse> {
     const data = invites.map((invite) => {
       return {
-        InviteVO: invite
+        InviteVO: invite,
       };
     });
 
-    return this.http.sendRequestPromise<InviteResponse>('/invite/inviteSend', data, InviteResponse);
+    return this.http.sendRequestPromise<InviteResponse>(
+      '/invite/inviteSend',
+      data,
+      { responseClass: InviteResponse }
+    );
   }
 
-  public sendMemberInvite(member: AccountVO, archive: ArchiveVO): Promise<InviteResponse> {
-    const data = [{
-      InviteVO: {
-        accessRole: member.accessRole,
-        byArchiveId: archive.archiveId,
-        email: member.primaryEmail,
-        fullName: member.fullName,
-        type: 'type.invite.archive'
-      }
-    }];
+  public sendMemberInvite(
+    member: AccountVO,
+    archive: ArchiveVO
+  ): Promise<InviteResponse> {
+    const data = [
+      {
+        InviteVO: {
+          accessRole: member.accessRole,
+          byArchiveId: archive.archiveId,
+          email: member.primaryEmail,
+          fullName: member.fullName,
+          type: 'type.invite.archive',
+        },
+      },
+    ];
 
-    return this.http.sendRequestPromise<InviteResponse>('/invite/byEmailAddress', data, InviteResponse);
+    return this.http.sendRequestPromise<InviteResponse>(
+      '/invite/byEmailAddress',
+      data,
+      { responseClass: InviteResponse }
+    );
   }
 
-  public sendShareInvite(invites: InviteVO[], itemToShare: ItemVO): Promise<InviteResponse> {
+  public sendShareInvite(
+    invites: InviteVO[],
+    itemToShare: ItemVO
+  ): Promise<InviteResponse> {
     const data = invites.map((invite) => {
       const vos: any = {
-        InviteVO: invite
+        InviteVO: invite,
       };
 
       if (itemToShare.isRecord) {
@@ -42,41 +66,67 @@ export class InviteRepo extends BaseRepo {
       return vos;
     });
 
-    return this.http.sendRequestPromise<InviteResponse>('/invite/share', data, InviteResponse);
+    return this.http.sendRequestPromise<InviteResponse>('/invite/share', data, {
+      responseClass: InviteResponse,
+    });
   }
 
-  public getShareInviteInfo(inviteEmail: string, inviteCode: string, shareItemId: number, shareItemType: 'r' | 'f') {
-    const data = [{
-      primaryEmail: inviteEmail,
-      inviteCode: inviteCode,
-      shid: shareItemId,
-      tp: shareItemType
-    }];
+  public getShareInviteInfo(
+    inviteEmail: string,
+    inviteCode: string,
+    shareItemId: number,
+    shareItemType: 'r' | 'f'
+  ) {
+    const data = [
+      {
+        primaryEmail: inviteEmail,
+        inviteCode: inviteCode,
+        shid: shareItemId,
+        tp: shareItemType,
+      },
+    ];
 
-    return this.http.sendRequestPromise<InviteResponse>('/invite/getShareInviteInfo', data, InviteResponse);
+    return this.http.sendRequestPromise<InviteResponse>(
+      '/invite/getShareInviteInfo',
+      data,
+      { responseClass: InviteResponse }
+    );
   }
-
 
   public getFullShareInvite(token: string) {
-    const data = [{
-      token
-    }];
+    const data = [
+      {
+        token,
+      },
+    ];
 
-    return this.http.sendRequestPromise<InviteResponse>('/invite/getFullShareInvite', data, InviteResponse);
+    return this.http.sendRequestPromise<InviteResponse>(
+      '/invite/getFullShareInvite',
+      data,
+      { responseClass: InviteResponse }
+    );
   }
 
   public getInvites() {
-    return this.http.sendRequestPromise<InviteResponse>('/invite/getMyInvites', [{}], InviteResponse);
+    return this.http.sendRequestPromise<InviteResponse>(
+      '/invite/getMyInvites',
+      [{}],
+      { responseClass: InviteResponse }
+    );
   }
 
   public resendInvites(invites: InviteVO[]) {
     const data = invites.map((invite) => {
       return {
-        InviteVO: invite
+        InviteVO: invite,
       };
     });
 
-    return this.http.sendRequestPromise<InviteResponse>('/invite/inviteResend', data, InviteResponse);
+    return this.http.sendRequestPromise<InviteResponse>(
+      '/invite/inviteResend',
+      data,
+      { responseClass: InviteResponse }
+    );
   }
 }
 

--- a/src/app/shared/services/api/locn.repo.ts
+++ b/src/app/shared/services/api/locn.repo.ts
@@ -1,34 +1,49 @@
-import { ArchiveVO, TagVOData, TagLinkVOData, LocnVOData } from '@root/app/models';
+/* @format */
+import { LocnVOData } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 
 export class LocnRepo extends BaseRepo {
   public geomapLatLng(lat: number, lng: number) {
     const vo: LocnVOData = {
       latitude: lat,
-      longitude: lng
+      longitude: lng,
     };
 
-    const data = [{
-      LocnVO: vo
-    }];
+    const data = [
+      {
+        LocnVO: vo,
+      },
+    ];
 
-    return this.http.sendRequestPromise<LocnResponse>('/locn/geomapLatLong', data, LocnResponse);
+    return this.http.sendRequestPromise<LocnResponse>(
+      '/locn/geomapLatLong',
+      data,
+      { responseClass: LocnResponse }
+    );
   }
 
   public create(locn: LocnVOData) {
-    const data = [{
-      LocnVO: locn
-    }];
+    const data = [
+      {
+        LocnVO: locn,
+      },
+    ];
 
-    return this.http.sendRequestPromise<LocnResponse>('/locn/post', data, LocnResponse);
+    return this.http.sendRequestPromise<LocnResponse>('/locn/post', data, {
+      responseClass: LocnResponse,
+    });
   }
 
   public update(locn: LocnVOData) {
-    const data = [{
-      LocnVO: locn
-    }];
+    const data = [
+      {
+        LocnVO: locn,
+      },
+    ];
 
-    return this.http.sendRequestPromise<LocnResponse>('/locn/update', data, LocnResponse);
+    return this.http.sendRequestPromise<LocnResponse>('/locn/update', data, {
+      responseClass: LocnResponse,
+    });
   }
 }
 

--- a/src/app/shared/services/api/notification.repo.ts
+++ b/src/app/shared/services/api/notification.repo.ts
@@ -1,27 +1,42 @@
+/* @format */
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { NotificationVOData } from '@models/notification-vo';
 
 export class NotificationRepo extends BaseRepo {
   public getNotifications(): Promise<NotificationResponse> {
-    return this.http.sendRequestPromise<NotificationResponse>('/notification/getMyNotifications', [{}], NotificationResponse);
+    return this.http.sendRequestPromise<NotificationResponse>(
+      '/notification/getMyNotifications',
+      [{}],
+      { responseClass: NotificationResponse }
+    );
   }
 
-  public getNotificationsSince(lastNotification: NotificationVOData): Promise<NotificationResponse> {
+  public getNotificationsSince(
+    lastNotification: NotificationVOData
+  ): Promise<NotificationResponse> {
     const data = {
-      NotificationVO: lastNotification
+      NotificationVO: lastNotification,
     };
 
-    return this.http.sendRequestPromise<NotificationResponse>('/notification/getMyNotificationsSince', [data], NotificationResponse);
+    return this.http.sendRequestPromise<NotificationResponse>(
+      '/notification/getMyNotificationsSince',
+      [data],
+      { responseClass: NotificationResponse }
+    );
   }
 
   public update(notifications: NotificationVOData[]) {
-    const data = notifications.map(n => {
+    const data = notifications.map((n) => {
       return {
-        NotificationVO: n
+        NotificationVO: n,
       };
     });
 
-    return this.http.sendRequestPromise<NotificationResponse>('/notification/updateNotification', data, NotificationResponse);
+    return this.http.sendRequestPromise<NotificationResponse>(
+      '/notification/updateNotification',
+      data,
+      { responseClass: NotificationResponse }
+    );
   }
 }
 
@@ -33,6 +48,6 @@ export class NotificationResponse extends BaseResponse {
       return [];
     }
 
-    return data[0].map(result => result.NotificationVO);
+    return data[0].map((result) => result.NotificationVO);
   }
 }

--- a/src/app/shared/services/api/publish.repo.ts
+++ b/src/app/shared/services/api/publish.repo.ts
@@ -1,32 +1,55 @@
+/* @format */
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { FolderVO, RecordVO } from '@root/app/models';
 import { PublishIaData } from '@models/publish-ia-vo';
 
 export class PublishRepo extends BaseRepo {
   public getResource(urlToken: string): Promise<PublishResponse> {
-    const data = [{
-      PublishurlVO: {
-        urltoken: urlToken
-      }
-    }];
+    const data = [
+      {
+        PublishurlVO: {
+          urltoken: urlToken,
+        },
+      },
+    ];
 
-    return this.http.sendRequestPromise<PublishResponse>('/publish/getResource', data, PublishResponse);
+    return this.http.sendRequestPromise<PublishResponse>(
+      '/publish/getResource',
+      data,
+      { responseClass: PublishResponse }
+    );
   }
 
-  public publishToInternetArchive(publishIa: PublishIaData): Promise<PublishResponse> {
-    const data = [{
-      Publish_iaVO: publishIa
-    }];
+  public publishToInternetArchive(
+    publishIa: PublishIaData
+  ): Promise<PublishResponse> {
+    const data = [
+      {
+        Publish_iaVO: publishIa,
+      },
+    ];
 
-    return this.http.sendRequestPromise<PublishResponse>('/publish_ia/publish', data, PublishResponse);
+    return this.http.sendRequestPromise<PublishResponse>(
+      '/publish_ia/publish',
+      data,
+      { responseClass: PublishResponse }
+    );
   }
 
-  public getInternetArchiveLink(publishIa: Pick<PublishIaData, 'folder_linkId'>): Promise<PublishResponse> {
-    const data = [{
-      Publish_iaVO: publishIa
-    }];
+  public getInternetArchiveLink(
+    publishIa: Pick<PublishIaData, 'folder_linkId'>
+  ): Promise<PublishResponse> {
+    const data = [
+      {
+        Publish_iaVO: publishIa,
+      },
+    ];
 
-    return this.http.sendRequestPromise<PublishResponse>('/publish_ia/getLink', data, PublishResponse);
+    return this.http.sendRequestPromise<PublishResponse>(
+      '/publish_ia/getLink',
+      data,
+      { responseClass: PublishResponse }
+    );
   }
 }
 
@@ -46,7 +69,7 @@ export class PublishResponse extends BaseResponse {
       return null;
     }
 
-    return  new FolderVO(data[0][0].FolderVO, initChildren);
+    return new FolderVO(data[0][0].FolderVO, initChildren);
   }
 
   public getPublishIaVO(): PublishIaData {

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -216,6 +216,7 @@ export class RecordRepo extends BaseRepo {
 
     return this.http.sendRequestPromise<RecordResponse>('/record/move', data, {
       responseClass: RecordResponse,
+      useAuthorizationHeader: true,
     });
   }
 
@@ -238,6 +239,7 @@ export class RecordRepo extends BaseRepo {
 
     return this.http.sendRequestPromise<RecordResponse>('/record/copy', data, {
       responseClass: RecordResponse,
+      useAuthorizationHeader: true,
     });
   }
 

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -58,11 +58,9 @@ export class RecordRepo extends BaseRepo {
       };
     });
 
-    return this.http.sendRequestPromise<RecordResponse>(
-      '/record/get',
-      data,
-      RecordResponse
-    );
+    return this.http.sendRequestPromise<RecordResponse>('/record/get', data, {
+      responseClass: RecordResponse,
+    });
   }
 
   public getLean(
@@ -80,7 +78,7 @@ export class RecordRepo extends BaseRepo {
     return this.http.sendRequestPromise<RecordResponse>(
       '/record/getLean',
       data,
-      RecordResponse
+      { responseClass: RecordResponse }
     );
   }
 
@@ -174,7 +172,7 @@ export class RecordRepo extends BaseRepo {
     return this.http.sendRequestPromise<RecordResponse>(
       '/record/update',
       data,
-      RecordResponse
+      { responseClass: RecordResponse }
     );
   }
 
@@ -195,7 +193,7 @@ export class RecordRepo extends BaseRepo {
     return this.http.sendRequestPromise<RecordResponse>(
       '/record/delete',
       data,
-      RecordResponse
+      { responseClass: RecordResponse }
     );
   }
 
@@ -216,11 +214,9 @@ export class RecordRepo extends BaseRepo {
       this.getThumbnailCache().invalidateFolder(destination.folder_linkId);
     }
 
-    return this.http.sendRequestPromise<RecordResponse>(
-      '/record/move',
-      data,
-      RecordResponse
-    );
+    return this.http.sendRequestPromise<RecordResponse>('/record/move', data, {
+      responseClass: RecordResponse,
+    });
   }
 
   public copy(
@@ -240,11 +236,9 @@ export class RecordRepo extends BaseRepo {
       this.getThumbnailCache().invalidateFolder(destination.folder_linkId);
     }
 
-    return this.http.sendRequestPromise<RecordResponse>(
-      '/record/copy',
-      data,
-      RecordResponse
-    );
+    return this.http.sendRequestPromise<RecordResponse>('/record/copy', data, {
+      responseClass: RecordResponse,
+    });
   }
 
   private getThumbnailCache(): ThumbnailCache {

--- a/src/app/shared/services/api/relation.repo.ts
+++ b/src/app/shared/services/api/relation.repo.ts
@@ -1,59 +1,82 @@
+/* @format */
 import { RelationVO, ArchiveVO } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { flatten } from 'lodash';
 
 export class RelationRepo extends BaseRepo {
   public getAll(archiveVO: ArchiveVO) {
-    const data = [{
-      RelationVO: {
-        archiveId: archiveVO.archiveId
-      }
-    }];
+    const data = [
+      {
+        RelationVO: {
+          archiveId: archiveVO.archiveId,
+        },
+      },
+    ];
 
-    return this.http.sendRequestPromise<RelationResponse>('/relation/getAll', data, RelationResponse);
+    return this.http.sendRequestPromise<RelationResponse>(
+      '/relation/getAll',
+      data,
+      { responseClass: RelationResponse }
+    );
   }
 
   public create(relationVO: RelationVO) {
     const data = {
       RelationVO: {
         relationArchiveId: relationVO.relationArchiveId,
-        type: relationVO.type
-      }
+        type: relationVO.type,
+      },
     };
 
-    return this.http.sendRequestPromise<RelationResponse>('/relation/post', [data], RelationResponse);
+    return this.http.sendRequestPromise<RelationResponse>(
+      '/relation/post',
+      [data],
+      { responseClass: RelationResponse }
+    );
   }
 
   public update(relationVO: RelationVO) {
     const data = {
       RelationVO: {
         relationId: relationVO.relationId,
-        type: relationVO.type
-      }
+        type: relationVO.type,
+      },
     };
 
-    return this.http.sendRequestPromise<RelationResponse>('/relation/update', [data], RelationResponse);
+    return this.http.sendRequestPromise<RelationResponse>(
+      '/relation/update',
+      [data],
+      { responseClass: RelationResponse }
+    );
   }
 
   public accept(relationVO: RelationVO, relationMyVO: RelationVO) {
     const data = {
       RelationVO: {
-        relationId: relationVO.relationId
+        relationId: relationVO.relationId,
       },
-      RelationMyVO: relationMyVO
+      RelationMyVO: relationMyVO,
     };
 
-    return this.http.sendRequestPromise<RelationResponse>('/relation/acceptRelation', [data], RelationResponse);
+    return this.http.sendRequestPromise<RelationResponse>(
+      '/relation/acceptRelation',
+      [data],
+      { responseClass: RelationResponse }
+    );
   }
 
   public delete(relationVO: RelationVO) {
     const data = {
       RelationVO: {
         relationId: relationVO.relationId,
-      }
+      },
     };
 
-    return this.http.sendRequestPromise<RelationResponse>('/relation/delete', [data], RelationResponse);
+    return this.http.sendRequestPromise<RelationResponse>(
+      '/relation/delete',
+      [data],
+      { responseClass: RelationResponse }
+    );
   }
 }
 

--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -1,4 +1,4 @@
-import { query } from '@angular/animations';
+/* @format */
 import {
   ArchiveVO,
   RecordVO,
@@ -24,7 +24,7 @@ export class SearchRepo extends BaseRepo {
     return this.http.sendRequest<SearchResponse>(
       '/search/archiveByEmail',
       data,
-      SearchResponse
+      { responseClass: SearchResponse }
     );
   }
 
@@ -37,11 +37,9 @@ export class SearchRepo extends BaseRepo {
       },
     ];
 
-    return this.http.sendRequest<SearchResponse>(
-      '/search/archive',
-      data,
-      SearchResponse
-    );
+    return this.http.sendRequest<SearchResponse>('/search/archive', data, {
+      responseClass: SearchResponse,
+    });
   }
 
   public itemsByNameObservable(
@@ -60,7 +58,7 @@ export class SearchRepo extends BaseRepo {
     return this.http.sendRequest<SearchResponse>(
       '/search/folderAndRecord',
       [data],
-      SearchResponse
+      { responseClass: SearchResponse }
     );
   }
 

--- a/src/app/shared/services/api/share.repo.ts
+++ b/src/app/shared/services/api/share.repo.ts
@@ -1,26 +1,43 @@
-import { FolderVO, ArchiveVO, ShareVO, RecordVO, ShareByUrlVO } from '@root/app/models';
+/* @format */
+import {
+  FolderVO,
+  ArchiveVO,
+  ShareVO,
+  RecordVO,
+  ShareByUrlVO,
+} from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 import { flatten, compact } from 'lodash';
 
 export class ShareRepo extends BaseRepo {
   public getShares() {
-    return this.http.sendRequestPromise<ShareResponse>('/share/getShares', [], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>('/share/getShares', [], {
+      responseClass: ShareResponse,
+    });
   }
 
   public update(share: ShareVO) {
     const data = {
-      ShareVO: share
+      ShareVO: share,
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/update', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/update',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public upsert(share: ShareVO) {
     const data = {
-      ShareVO: share
+      ShareVO: share,
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/upsert', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/upsert',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public remove(share: ShareVO) {
@@ -28,11 +45,15 @@ export class ShareRepo extends BaseRepo {
       ShareVO: {
         shareId: share.shareId,
         folder_linkId: share.folder_linkId,
-        archiveId: share.archiveId
-      }
+        archiveId: share.archiveId,
+      },
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/delete', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/delete',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public generateShareLink(item: RecordVO | FolderVO) {
@@ -40,15 +61,19 @@ export class ShareRepo extends BaseRepo {
 
     if (item.isRecord) {
       data.RecordVO = {
-        folder_linkId: item.folder_linkId
+        folder_linkId: item.folder_linkId,
       };
     } else {
       data.FolderVO = {
-        folder_linkId: item.folder_linkId
+        folder_linkId: item.folder_linkId,
       };
     }
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/generateShareLink', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/generateShareLink',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public getShareLink(item: RecordVO | FolderVO) {
@@ -56,62 +81,86 @@ export class ShareRepo extends BaseRepo {
 
     if (item.isRecord) {
       data.RecordVO = {
-        folder_linkId: item.folder_linkId
+        folder_linkId: item.folder_linkId,
       };
     } else {
       data.FolderVO = {
-        folder_linkId: item.folder_linkId
+        folder_linkId: item.folder_linkId,
       };
     }
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/getLink', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/getLink',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public checkShareLink(urlToken: string) {
     const data = {
       Shareby_urlVO: {
-        urlToken
-      }
+        urlToken,
+      },
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/checkShareLink', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/checkShareLink',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public updateShareLink(vo: ShareByUrlVO) {
     const data = {
-      Shareby_urlVO: vo
+      Shareby_urlVO: vo,
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/updateShareLink', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/updateShareLink',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public removeShareLink(vo: ShareByUrlVO) {
     const data = {
-      Shareby_urlVO: vo
+      Shareby_urlVO: vo,
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/dropShareLink', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/dropShareLink',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public requestShareAccess(urlToken: string) {
     const data = {
       Shareby_urlVO: {
-        urlToken
-      }
+        urlToken,
+      },
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/requestShareAccess', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/requestShareAccess',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 
   public getShareForPreview(shareId, folder_linkId) {
     const data = {
       ShareVO: {
         shareId: parseInt(shareId, 10),
-        folder_linkId: parseInt(folder_linkId, 10)
-      }
+        folder_linkId: parseInt(folder_linkId, 10),
+      },
     };
 
-    return this.http.sendRequestPromise<ShareResponse>('/share/getShareForPreview', [data], ShareResponse);
+    return this.http.sendRequestPromise<ShareResponse>(
+      '/share/getShareForPreview',
+      [data],
+      { responseClass: ShareResponse }
+    );
   }
 }
 
@@ -142,7 +191,13 @@ export class ShareResponse extends BaseResponse {
 
   public getShareByUrlVO() {
     const data = this.getResultsData();
-    if (!data || !data.length || !data[0] || !data[0][0].Shareby_urlVO || !data[0][0].Shareby_urlVO.shareUrl) {
+    if (
+      !data ||
+      !data.length ||
+      !data[0] ||
+      !data[0][0].Shareby_urlVO ||
+      !data[0][0].Shareby_urlVO.shareUrl
+    ) {
       return null;
     }
 

--- a/src/app/shared/services/api/system.repo.ts
+++ b/src/app/shared/services/api/system.repo.ts
@@ -1,6 +1,5 @@
-import { ArchiveVO } from '@root/app/models';
+/* @format */
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
-import { flatten } from 'lodash';
 
 interface SystemExceptionVO {
   errorType;
@@ -10,8 +9,7 @@ interface SystemExceptionVO {
   detail;
 }
 
-export class SystemResponse extends BaseResponse {
-}
+export class SystemResponse extends BaseResponse {}
 
 export class SystemRepo extends BaseRepo {
   public logError(error: Error) {
@@ -20,14 +18,19 @@ export class SystemRepo extends BaseRepo {
       errorCode: 0,
       thrownBy: error.stack?.substr(0, 128),
       caughtBy: '',
-      detail: error.stack?.substr(0, 2000)
+      detail: error.stack?.substr(0, 2000),
     };
 
-    const data = [{
-      SystemExceptionVO: vo
-    }];
+    const data = [
+      {
+        SystemExceptionVO: vo,
+      },
+    ];
 
-    return this.http.sendRequestPromise<SystemResponse>('/system/logError', data, SystemResponse);
+    return this.http.sendRequestPromise<SystemResponse>(
+      '/system/logError',
+      data,
+      { responseClass: SystemResponse }
+    );
   }
 }
-

--- a/src/app/shared/services/api/tag.repo.ts
+++ b/src/app/shared/services/api/tag.repo.ts
@@ -3,65 +3,83 @@ import { BaseResponse, BaseRepo } from '@shared/services/api/base';
 
 export class TagRepo extends BaseRepo {
   public create(tag: TagVOData, tagLink: TagLinkVOData) {
-    const data = [{
-      TagVO: {
-        name: tag.name
+    const data = [
+      {
+        TagVO: {
+          name: tag.name,
+        },
+        TagLinkVO: tagLink,
       },
-      TagLinkVO: tagLink
-    }];
+    ];
 
-    return this.http.sendRequestPromise<TagResponse>('/tag/post', data, TagResponse);
+    return this.http.sendRequestPromise<TagResponse>('/tag/post', data, {
+      responseClass: TagResponse,
+    });
   }
 
   public deleteTagLink(tag: TagVOData, tagLink: TagLinkVOData) {
-    const data = [{
-      TagVO: tag,
-      TagLinkVO: tagLink
-    }];
+    const data = [
+      {
+        TagVO: tag,
+        TagLinkVO: tagLink,
+      },
+    ];
 
-    return this.http.sendRequestPromise<TagResponse>('/tag/deleteTagLink', data, TagResponse);
+    return this.http.sendRequestPromise<TagResponse>(
+      '/tag/deleteTagLink',
+      data,
+      { responseClass: TagResponse }
+    );
   }
 
   public getTagsByArchive(archive: ArchiveVO): Promise<TagResponse> {
-    const data = [{
-      ArchiveVO: {
-        archiveId: archive.archiveId
-      }
-    }];
+    const data = [
+      {
+        ArchiveVO: {
+          archiveId: archive.archiveId,
+        },
+      },
+    ];
 
-    return this.http.sendRequestPromise<TagResponse>('/tag/getTagsByArchive', data, TagResponse);
+    return this.http.sendRequestPromise<TagResponse>(
+      '/tag/getTagsByArchive',
+      data,
+      { responseClass: TagResponse }
+    );
   }
 
   public delete(tag: TagVO | TagVO[]): Promise<TagResponse> {
-    let data: Array<{TagVO: TagVO}> = [];
+    let data: Array<{ TagVO: TagVO }> = [];
     if (Array.isArray(tag)) {
       data = tag.map((t) => ({
-          TagVO: new TagVO(t),
-        }
-      ));
+        TagVO: new TagVO(t),
+      }));
     } else {
       data.push({
         TagVO: new TagVO(tag),
       });
     }
 
-    return this.http.sendRequestPromise<TagResponse>('/tag/delete', data, TagResponse);
+    return this.http.sendRequestPromise<TagResponse>('/tag/delete', data, {
+      responseClass: TagResponse,
+    });
   }
 
   public update(tag: TagVO | TagVO[]): Promise<TagResponse> {
-    let data: Array<{TagVO: TagVO}> = [];
+    let data: Array<{ TagVO: TagVO }> = [];
     if (Array.isArray(tag)) {
       data = tag.map((t) => ({
-          TagVO: new TagVO(t),
-        }
-      ));
+        TagVO: new TagVO(t),
+      }));
     } else {
       data.push({
         TagVO: new TagVO(tag),
       });
     }
 
-    return this.http.sendRequestPromise<TagResponse>('/tag/updateTag', data, TagResponse);
+    return this.http.sendRequestPromise<TagResponse>('/tag/updateTag', data, {
+      responseClass: TagResponse,
+    });
   }
 }
 

--- a/src/app/shared/services/http/http.service.spec.ts
+++ b/src/app/shared/services/http/http.service.spec.ts
@@ -18,6 +18,10 @@ describe('HttpService', () => {
     storage.local.clear();
   });
 
+  afterAll(() => {
+    storage.local.clear();
+  });
+
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
@@ -30,9 +34,19 @@ describe('HttpService', () => {
 
   it('should make Authorization headers if an auth token is set', () => {
     storage.local.set('AUTH_TOKEN', 'testing_token');
-    const headers = service.generateHeaders();
+    const headers = service.generateHeaders({ useAuthorizationHeader: true });
 
     expect(headers.keys().length).toBe(1);
     expect(headers.get('Authorization')).toBe('Bearer testing_token');
+  });
+
+  it('should not make Authorization headers if not specified by options parameter', () => {
+    storage.local.set('AUTH_TOKEN', 'testing_token');
+
+    expect(service.generateHeaders().keys().length).toBe(0);
+    expect(service.generateHeaders({}).keys().length).toBe(0);
+    expect(
+      service.generateHeaders({ useAuthorizationHeader: false }).keys().length
+    ).toBe(0);
   });
 });

--- a/src/app/shared/services/http/http.service.ts
+++ b/src/app/shared/services/http/http.service.ts
@@ -34,7 +34,11 @@ export class HttpService {
     const url = this.apiUrl + endpoint;
 
     return this.http
-      .post(url, { RequestVO: requestVO }, { headers: this.generateHeaders() })
+      .post(
+        url,
+        { RequestVO: requestVO },
+        { headers: this.generateHeaders(options) }
+      )
       .pipe(
         map((response: any) => {
           if (response) {
@@ -67,9 +71,11 @@ export class HttpService {
       .toPromise();
   }
 
-  public generateHeaders(): HttpHeaders {
+  public generateHeaders(options?: {
+    useAuthorizationHeader?: boolean;
+  }): HttpHeaders {
     const authToken: string | undefined = this.storage.local.get('AUTH_TOKEN');
-    if (authToken) {
+    if (options?.useAuthorizationHeader && authToken) {
       return new HttpHeaders({ Authorization: `Bearer ${authToken}` });
     }
     return new HttpHeaders();

--- a/src/app/shared/services/http/http.service.ts
+++ b/src/app/shared/services/http/http.service.ts
@@ -11,6 +11,11 @@ import { StorageService } from '@shared/services/storage/storage.service';
 
 const CSRF_KEY = 'CSRF';
 
+interface RequestOptions {
+  responseClass?: any;
+  useAuthorizationHeader?: boolean;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -23,7 +28,7 @@ export class HttpService {
   public sendRequest<T = BaseResponse>(
     endpoint: string,
     data: any = [{}],
-    responseClass?: any
+    options?: RequestOptions
   ): Observable<T> {
     const requestVO = new RequestVO(this.storage.session.get(CSRF_KEY), data);
     const url = this.apiUrl + endpoint;
@@ -35,8 +40,8 @@ export class HttpService {
           if (response) {
             this.storage.session.set(CSRF_KEY, JSON.stringify(response.csrf));
           }
-          if (responseClass) {
-            return new responseClass(response);
+          if (options?.responseClass) {
+            return new options.responseClass(response);
           } else {
             return new this.defaultResponseClass(response);
           }
@@ -47,9 +52,9 @@ export class HttpService {
   public sendRequestPromise<T = BaseResponse>(
     endpoint: string,
     data: any = [{}],
-    responseClass?: any
+    options?: RequestOptions
   ): Promise<T> {
-    return this.sendRequest(endpoint, data, responseClass)
+    return this.sendRequest(endpoint, data, options)
       .pipe(
         map((response: any | BaseResponse) => {
           if (!response.isSuccessful) {


### PR DESCRIPTION
It turns out that #396 introduced some undetected breaking changes, as some v1 endpoints do not behave well if passed an authorization header. While we should fix the known problematic endpoints, I think it's best that we only pass the auth header to the v1 endpoints need it and that we know work properly with it.