### PR TITLE
Enable `jasmine/no-spec-dupes` linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,9 @@ module.exports = {
         'jasmine/new-line-before-expect': 'error',
         'jasmine/no-disabled-tests': 'error',
         'jasmine/new-line-between-declarations': 'error',
+        'jasmine/no-spec-dupes': 'error',
         // We intend to enable these eventually:
         'jasmine/no-promise-without-done-fail': 'off',
-        'jasmine/no-spec-dupes': 'off',
         'jasmine/no-unsafe-spy': 'off',
         'jasmine/prefer-promise-strategies': 'off',
         'jasmine/prefer-toHaveBeenCalledWith': 'off',

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
@@ -168,16 +168,4 @@ describe('CreateNewArchiveComponent #onboarding', () => {
 
     expect(button.disabled).toBe(true);
   });
-
-  it('the create archive button should not work without any reasons selected', async () => {
-    const { find, instance, fixture } = await shallow.render();
-    instance.screen = 'reasons';
-    instance.selectedReasons = [];
-
-    fixture.detectChanges();
-
-    const button = find('.create-archive').nativeElement;
-
-    expect(button.disabled).toBe(true);
-  });
 });

--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -184,7 +184,7 @@ describe('SearchService', () => {
   });
 
   describe('getTagResults', () => {
-    it('handles an empty search term', () => {
+    it('handles an empty tag search term', () => {
       expect(search('')).toEqual([]);
     });
 
@@ -200,7 +200,7 @@ describe('SearchService', () => {
       expect(searchResults[0].name).toBe('Potato');
     });
 
-    it('should ignore location in fuzzy searches', () => {
+    it('should ignore location in fuzzy tag searches', () => {
       tags.setTags([
         { name: 'VeryLongTagNameThatProbablyWontEvenHappenInProduction' },
       ]);
@@ -208,7 +208,7 @@ describe('SearchService', () => {
       expect(search('Production').length).toBe(1);
     });
 
-    it('should limit results if limit is provided', () => {
+    it('should limit results if tag limit is provided', () => {
       tags.setTags([{ name: 'Potato' }, { name: 'Potato Two' }]);
 
       expect(search('Potato', 1).length).toBe(1);

--- a/src/app/shared/services/storage/storage.service.spec.ts
+++ b/src/app/shared/services/storage/storage.service.spec.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { TestBed, inject } from '@angular/core/testing';
 
 import { StorageService } from '@shared/services/storage/storage.service';
@@ -7,115 +8,158 @@ describe('StorageService', () => {
   const testValue = 'testValue';
   const testObject = {
     key1: 'value1',
-    key2: 'value2'
+    key2: 'value2',
   };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [StorageService]
+      providers: [StorageService],
     });
 
     window.sessionStorage.clear();
     window.localStorage.clear();
   });
 
-  it('should be created', inject([StorageService], (service: StorageService) => {
-    expect(service).toBeTruthy();
-  }));
-
-  it('should save a string value to SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.sessionStorage) {
-      service.session.set(testKey, testValue);
-
-      expect(window.sessionStorage.getItem(testKey)).toEqual(testValue);
+  it('should be created', inject(
+    [StorageService],
+    (service: StorageService) => {
+      expect(service).toBeTruthy();
     }
-  }));
+  ));
 
-  it('should retrieve a string value from SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.sessionStorage) {
-      window.sessionStorage.setItem(testKey, testValue);
+  it('should save a string value to SessionStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.sessionStorage) {
+        service.session.set(testKey, testValue);
+
+        expect(window.sessionStorage.getItem(testKey)).toEqual(testValue);
+      }
+    }
+  ));
+
+  it('should retrieve a string value from SessionStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.sessionStorage) {
+        window.sessionStorage.setItem(testKey, testValue);
+
+        expect(service.session.get(testKey)).toEqual(testValue);
+      }
+    }
+  ));
+
+  it('should save an object value to SessionStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.sessionStorage) {
+        service.session.set(testKey, testObject);
+
+        expect(JSON.parse(window.sessionStorage.getItem(testKey))).toEqual(
+          testObject
+        );
+      }
+    }
+  ));
+
+  it('should retrieve an object value from SessionStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.sessionStorage) {
+        window.sessionStorage.setItem(testKey, JSON.stringify(testObject));
+
+        expect(service.session.get(testKey)).toEqual(testObject);
+      }
+    }
+  ));
+
+  it('should handle an undefined value from SessionStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.sessionStorage) {
+        expect(service.session.get(testKey)).toBeFalsy();
+      }
+    }
+  ));
+
+  it('should handle storing a null-ish value to SessionStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.sessionStorage) {
+        service.session.set(testKey, null);
+
+        expect(service.session.get(testKey)).toBeNull();
+        service.session.delete(testKey);
+        service.session.set(testKey, false);
+
+        expect(service.session.get(testKey)).toBeFalsy();
+      }
+    }
+  ));
+
+  it('should save a value to memory when SessionStorage not present', inject(
+    [StorageService],
+    (service: StorageService) => {
+      service.session.setStoreInMemory(true);
+      service.session.set(testKey, testValue);
 
       expect(service.session.get(testKey)).toEqual(testValue);
     }
-  }));
+  ));
 
-  it('should save an object value to SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.sessionStorage) {
-      service.session.set(testKey, testObject);
+  it('should save a string value to LocalStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.localStorage) {
+        service.local.set(testKey, testValue);
 
-      expect(JSON.parse(window.sessionStorage.getItem(testKey))).toEqual(testObject);
+        expect(window.localStorage.getItem(testKey)).toEqual(testValue);
+      }
     }
-  }));
+  ));
 
-  it('should retrieve an object value from SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.sessionStorage) {
-      window.sessionStorage.setItem(testKey, JSON.stringify(testObject));
+  it('should retrieve a string value from LocalStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.localStorage) {
+        window.localStorage.setItem(testKey, testValue);
 
-      expect(service.session.get(testKey)).toEqual(testObject);
+        expect(service.local.get(testKey)).toEqual(testValue);
+      }
     }
-  }));
+  ));
 
-  it('should handle an undefined value from SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.sessionStorage) {
-      expect(service.session.get(testKey)).toBeFalsy();
+  it('should save an object value to LocalStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.localStorage) {
+        service.local.set(testKey, testObject);
+
+        expect(JSON.parse(window.localStorage.getItem(testKey))).toEqual(
+          testObject
+        );
+      }
     }
-  }));
+  ));
 
-  it('should handle storing a null-ish value to SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.sessionStorage) {
-      service.session.set(testKey, null);
+  it('should retrieve an object value from LocalStorage', inject(
+    [StorageService],
+    (service: StorageService) => {
+      if (window.localStorage) {
+        window.localStorage.setItem(testKey, JSON.stringify(testObject));
 
-      expect(service.session.get(testKey)).toBeNull();
-      service.session.delete(testKey);
-      service.session.set(testKey, false);
-
-      expect(service.session.get(testKey)).toBeFalsy();
+        expect(service.local.get(testKey)).toEqual(testObject);
+      }
     }
-  }));
+  ));
 
-  it('should save a value to memory when SessionStorage not present', inject([StorageService], (service: StorageService) => {
-    service.session.setStoreInMemory(true);
-    service.session.set(testKey, testValue);
-
-    expect(service.session.get(testKey)).toEqual(testValue);
-  }));
-
-  it('should save a string value to LocalStorage', inject([StorageService], (service: StorageService) => {
-    if (window.localStorage) {
+  it('should save a value to memory when LocalStorage not present', inject(
+    [StorageService],
+    (service: StorageService) => {
+      service.local.setStoreInMemory(true);
       service.local.set(testKey, testValue);
-
-      expect(window.localStorage.getItem(testKey)).toEqual(testValue);
-    }
-  }));
-
-  it('should retrieve a string value from LocalStorage', inject([StorageService], (service: StorageService) => {
-    if (window.localStorage) {
-      window.localStorage.setItem(testKey, testValue);
 
       expect(service.local.get(testKey)).toEqual(testValue);
     }
-  }));
-
-  it('should save an object value to SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.localStorage) {
-      service.local.set(testKey, testObject);
-
-      expect(JSON.parse(window.localStorage.getItem(testKey))).toEqual(testObject);
-    }
-  }));
-
-  it('should retrieve an object value from SessionStorage', inject([StorageService], (service: StorageService) => {
-    if (window.localStorage) {
-      window.localStorage.setItem(testKey, JSON.stringify(testObject));
-
-      expect(service.local.get(testKey)).toEqual(testObject);
-    }
-  }));
-
-  it('should save a value to memory when LocalStorage not present', inject([StorageService], (service: StorageService) => {
-    service.local.setStoreInMemory(true);
-    service.local.set(testKey, testValue);
-
-    expect(service.local.get(testKey)).toEqual(testValue);
-  }));
+  ));
 });


### PR DESCRIPTION
This rule prohibits tests from having the same name, so that they can be properly identified when they fail. Enable this rule and trigger an error if it's broken since by default it triggers a warning, and then fix the few violations of this linting rule.