### PR TITLE
Implement API for new member checklist

### DIFF
--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -1,0 +1,56 @@
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
+import { environment } from '@root/environments/environment';
+import { ChecklistItem } from '../types/checklist-item';
+import { UserChecklistService } from './user-checklist.service';
+
+describe('UserChecklistService', () => {
+  let service: UserChecklistService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [HttpV2Service],
+    });
+    service = TestBed.inject(UserChecklistService);
+    http = TestBed.inject(HttpTestingController);
+    TestBed.inject(HttpV2Service).setAuthToken('test');
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('can fetch the checklist contents', (done) => {
+    const expected: ChecklistItem[] = [
+      {
+        id: 'test_item',
+        title: 'Test the checklist API service',
+        completed: true,
+      },
+    ];
+
+    service
+      .getChecklistItems()
+      .then((items) => {
+        expect(items.length).toBe(1);
+        expect(items[0]).toEqual(expected[0]);
+      })
+      .finally(() => {
+        done();
+      });
+
+    const req = http.expectOne(`${environment.apiUrl}/v2/event/checklist`);
+
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
+    expect(req.request.headers.get('Authorization')).not.toBeNull();
+    req.flush(expected);
+  });
+});

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
+import { ChecklistApi } from '../types/checklist-api';
+import { ChecklistItem } from '../types/checklist-item';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserChecklistService implements ChecklistApi {
+  constructor(private httpv2: HttpV2Service) {}
+
+  public getChecklistItems(): Promise<ChecklistItem[]> {
+    return firstValueFrom(
+      this.httpv2.get<ChecklistItem>('/v2/event/checklist'),
+    );
+  }
+}

--- a/src/app/user-checklist/user-checklist.module.ts
+++ b/src/app/user-checklist/user-checklist.module.ts
@@ -5,6 +5,8 @@ import { UserChecklistComponent } from './components/user-checklist/user-checkli
 import { ChecklistIconComponent } from './components/checklist-icon/checklist-icon.component';
 import { TaskIconComponent } from './components/task-icon/task-icon.component';
 import { MinimizeIconComponent } from './components/minimize-icon/minimize-icon.component';
+import { CHECKLIST_API } from './types/checklist-api';
+import { UserChecklistService } from './services/user-checklist.service';
 
 @NgModule({
   declarations: [
@@ -15,5 +17,11 @@ import { MinimizeIconComponent } from './components/minimize-icon/minimize-icon.
   ],
   exports: [UserChecklistComponent],
   imports: [CommonModule],
+  providers: [
+    {
+      provide: CHECKLIST_API,
+      useClass: UserChecklistService,
+    },
+  ],
 })
 export class UserChecklistModule {}


### PR DESCRIPTION
This PR creates the `UserChecklistService` which implements the `ChecklistApi` interface used by the New Member Checklist component and sets it up to be provided by Angular's Dependency Injection system.

Currently since the component is not visible in the UI, the only way to test this is through unit tests and verifying that the code is calling the correct endpoint properly. This is a simple endpoint (it's just a GET with no parameters besides the auth token) so the unit test suite is very basic.

Any API calls used for hiding the checklist will be handled in the upcoming "hide checklist" functionality ticket.