### PR TITLE
Enable jasmine/no-promise-without-done-fail linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,8 +15,8 @@ module.exports = {
         'jasmine/no-disabled-tests': 'error',
         'jasmine/new-line-between-declarations': 'error',
         'jasmine/no-spec-dupes': 'error',
+        'jasmine/no-promise-without-done-fail': 'error',
         // We intend to enable these eventually:
-        'jasmine/no-promise-without-done-fail': 'off',
         'jasmine/no-unsafe-spy': 'off',
         'jasmine/prefer-promise-strategies': 'off',
         'jasmine/prefer-toHaveBeenCalledWith': 'off',

--- a/src/app/shared/services/api/directive.repo.spec.ts
+++ b/src/app/shared/services/api/directive.repo.spec.ts
@@ -44,11 +44,14 @@ describe('DirectiveRepo', () => {
 
   it('can get a Directive from an Archive', (done) => {
     repo.httpV2.setAuthToken('test_token');
-    repo.get(testArchive).then((directive) => {
-      expect(directive).not.toBeNull();
-      expect(directive.note).toBe('Test Note');
-      done();
-    });
+    repo
+      .get(testArchive)
+      .then((directive) => {
+        expect(directive).not.toBeNull();
+        expect(directive.note).toBe('Test Note');
+        done();
+      })
+      .catch(done.fail);
 
     const req = httpMock.expectOne(apiUrl('/v2/directive/archive/1234'));
 
@@ -85,11 +88,14 @@ describe('DirectiveRepo', () => {
         type: 'admin',
       },
     };
-    repo.create(newDirectiveData).then((directive) => {
-      expect(directive instanceof Directive).toBeTrue();
-      expect(directive.archiveId).toBe(1);
-      done();
-    });
+    repo
+      .create(newDirectiveData)
+      .then((directive) => {
+        expect(directive instanceof Directive).toBeTrue();
+        expect(directive.archiveId).toBe(1);
+        done();
+      })
+      .catch(done.fail);
 
     const req = httpMock.expectOne(apiUrl('/v2/directive'));
 
@@ -104,12 +110,15 @@ describe('DirectiveRepo', () => {
       note: 'New Note',
     };
 
-    repo.update(directiveUpdate).then((directive) => {
-      expect(directive instanceof Directive).toBeTrue();
-      expect(directive.directiveId).toBe('test-id');
-      expect(directive.note).toBe('New Note');
-      done();
-    });
+    repo
+      .update(directiveUpdate)
+      .then((directive) => {
+        expect(directive instanceof Directive).toBeTrue();
+        expect(directive.directiveId).toBe('test-id');
+        expect(directive.note).toBe('New Note');
+        done();
+      })
+      .catch(done.fail);
 
     const req = httpMock.expectOne(apiUrl('/v2/directive/test-id'));
 
@@ -126,13 +135,16 @@ describe('DirectiveRepo', () => {
   });
 
   it('can get a legacy contact', (done) => {
-    repo.getLegacyContact().then((legacyContact) => {
-      expect(legacyContact.legacyContactId).toBe('test-id');
-      expect(legacyContact.accountId).toBe('test-accountid');
-      expect(legacyContact.name).toBe('Test Legacy Contact');
-      expect(legacyContact.email).toBe('test@example.com');
-      done();
-    });
+    repo
+      .getLegacyContact()
+      .then((legacyContact) => {
+        expect(legacyContact.legacyContactId).toBe('test-id');
+        expect(legacyContact.accountId).toBe('test-accountid');
+        expect(legacyContact.name).toBe('Test Legacy Contact');
+        expect(legacyContact.email).toBe('test@example.com');
+        done();
+      })
+      .catch(done.fail);
 
     const req = httpMock.expectOne(apiUrl('/v2/legacy-contact'));
 
@@ -160,7 +172,8 @@ describe('DirectiveRepo', () => {
         expect(legacyContact.name).toBe('New User');
         expect(legacyContact.email).toBe('new@example.com');
         done();
-      });
+      })
+      .catch(done.fail);
 
     const req = httpMock.expectOne(apiUrl('/v2/legacy-contact'));
 
@@ -189,7 +202,8 @@ describe('DirectiveRepo', () => {
         expect(legacyContact.name).toBe('Updated User');
         expect(legacyContact.email).toBe('updated@example.com');
         done();
-      });
+      })
+      .catch(done.fail);
 
     const req = httpMock.expectOne(apiUrl('/v2/legacy-contact/test-id'));
 

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -76,7 +76,8 @@ describe('HttpV2Service', () => {
       .then((response: any) => {
         expect(response.status).toBe('available');
         done();
-      });
+      })
+      .catch(done.fail);
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
 
@@ -106,7 +107,8 @@ describe('HttpV2Service', () => {
         expect(resp.status).toBe('available');
         expect(resp.constructorCalled).toBeTrue();
         done();
-      });
+      })
+      .catch(done.fail);
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
     request.flush({ status: 'available' });
@@ -124,7 +126,8 @@ describe('HttpV2Service', () => {
       .then(() => {
         expect(storage.session.get('CSRF')).toBe('potato');
         done();
-      });
+      })
+      .catch(done.fail);
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
     request.flush(response);
   });
@@ -136,7 +139,8 @@ describe('HttpV2Service', () => {
       .then(() => {
         expect(storage.session.get('CSRF')).toBe('csrf_token');
         done();
-      });
+      })
+      .catch(done.fail);
 
     const request = httpTestingController.expectOne(
       apiUrl('/api/v2/health?test=potato'),
@@ -155,7 +159,8 @@ describe('HttpV2Service', () => {
       .then(() => {
         expect(storage.session.get('CSRF')).toBe('csrf_token');
         done();
-      });
+      })
+      .catch(done.fail);
 
     const request = httpTestingController.expectOne(
       apiUrl('/api/v2/health?id=32'),
@@ -174,7 +179,8 @@ describe('HttpV2Service', () => {
       .then(() => {
         expect(storage.session.get('CSRF')).toBe('1234');
         done();
-      });
+      })
+      .catch(done.fail);
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
 
@@ -212,7 +218,8 @@ describe('HttpV2Service', () => {
       .then((resp) => {
         expect(resp.length).toBe(2);
         done();
-      });
+      })
+      .catch(done.fail);
 
     const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
     request.flush([{ status: 'available' }, { status: 'unavailable' }]);

--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -41,9 +41,10 @@ describe('UserChecklistService', () => {
       .then((items) => {
         expect(items.length).toBe(1);
         expect(items[0]).toEqual(expected[0]);
-      })
-      .finally(() => {
         done();
+      })
+      .catch(() => {
+        done.fail();
       });
 
     const req = http.expectOne(`${environment.apiUrl}/v2/event/checklist`);


### PR DESCRIPTION
This linting rule forces tests to make sure they catch any errors in promises to guarantee that the test runs end properly.