### PR TITLE
Hide new member checklist if marked hidden in backend

### DIFF
--- a/src/app/models/account-vo.ts
+++ b/src/app/models/account-vo.ts
@@ -1,6 +1,6 @@
+/* @format */
 import { BaseVO, BaseVOData } from '@models/base-vo';
 import { AccessRoleType } from './access-role';
-
 
 interface NotificationTypes {
   alerts?: boolean;
@@ -49,7 +49,8 @@ export interface AccountVOData extends BaseVOData {
   emailStatus?: any;
   phoneStatus?: any;
   notificationPreferences?: NotificationPreferencesI;
-  allowSftpDeletion?: boolean
+  allowSftpDeletion?: boolean;
+  hideChecklist?: boolean;
 }
 
 export interface NotificationPreferencesI {
@@ -93,11 +94,15 @@ export class AccountVO extends BaseVO {
   public phoneStatus;
   public notificationPreferences: NotificationPreferencesI;
   public allowSftpDeletion;
+  public hideChecklist: boolean;
 
   constructor(voData: AccountVOData) {
     super(voData);
 
-    if (this.notificationPreferences && typeof this.notificationPreferences === 'string') {
+    if (
+      this.notificationPreferences &&
+      typeof this.notificationPreferences === 'string'
+    ) {
       this.notificationPreferences = JSON.parse(this.notificationPreferences);
     }
   }

--- a/src/app/user-checklist/components/user-checklist/shared-mocks.ts
+++ b/src/app/user-checklist/components/user-checklist/shared-mocks.ts
@@ -1,4 +1,6 @@
 /* @format */
+import { AccountVO, AccountVOData } from '@models/account-vo';
+import { ArchiveVO } from '@models/index';
 import { ChecklistApi } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 
@@ -16,5 +18,21 @@ export class DummyChecklistApi implements ChecklistApi {
       throw new Error('Unit test forced error');
     }
     return DummyChecklistApi.items;
+  }
+}
+
+export class DummyAccountService {
+  public static accountVoData: Partial<AccountVOData> = {};
+
+  public static reset(): void {
+    this.accountVoData = {};
+  }
+
+  public getAccount(): AccountVO {
+    return new AccountVO(DummyAccountService.accountVoData);
+  }
+
+  public getArchive(): ArchiveVO {
+    return new ArchiveVO({});
   }
 }

--- a/src/app/user-checklist/components/user-checklist/shared-mocks.ts
+++ b/src/app/user-checklist/components/user-checklist/shared-mocks.ts
@@ -1,6 +1,5 @@
 /* @format */
-import { AccountVO, AccountVOData } from '@models/account-vo';
-import { ArchiveVO } from '@models/index';
+import { AccessRoleType } from '@models/access-role';
 import { ChecklistApi } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 
@@ -8,11 +7,13 @@ export class DummyChecklistApi implements ChecklistApi {
   public static error: boolean = false;
   public static items: ChecklistItem[] = [];
   public static accountHidden: boolean = false;
+  public static archiveAccess: AccessRoleType = 'access.role.owner';
 
   public static reset(): void {
     this.items = [];
     this.error = false;
     this.accountHidden = false;
+    this.archiveAccess = 'access.role.owner';
   }
 
   public async getChecklistItems(): Promise<ChecklistItem[]> {
@@ -24,5 +25,9 @@ export class DummyChecklistApi implements ChecklistApi {
 
   public isAccountHidingChecklist(): boolean {
     return DummyChecklistApi.accountHidden;
+  }
+
+  public isArchiveOwnedByAccount(): boolean {
+    return DummyChecklistApi.archiveAccess === 'access.role.owner';
   }
 }

--- a/src/app/user-checklist/components/user-checklist/shared-mocks.ts
+++ b/src/app/user-checklist/components/user-checklist/shared-mocks.ts
@@ -7,10 +7,12 @@ import { ChecklistItem } from '../../types/checklist-item';
 export class DummyChecklistApi implements ChecklistApi {
   public static error: boolean = false;
   public static items: ChecklistItem[] = [];
+  public static accountHidden: boolean = false;
 
   public static reset(): void {
     this.items = [];
     this.error = false;
+    this.accountHidden = false;
   }
 
   public async getChecklistItems(): Promise<ChecklistItem[]> {
@@ -19,20 +21,8 @@ export class DummyChecklistApi implements ChecklistApi {
     }
     return DummyChecklistApi.items;
   }
-}
 
-export class DummyAccountService {
-  public static accountVoData: Partial<AccountVOData> = {};
-
-  public static reset(): void {
-    this.accountVoData = {};
-  }
-
-  public getAccount(): AccountVO {
-    return new AccountVO(DummyAccountService.accountVoData);
-  }
-
-  public getArchive(): ArchiveVO {
-    return new ArchiveVO({});
+  public isAccountHidingChecklist(): boolean {
+    return DummyChecklistApi.accountHidden;
   }
 }

--- a/src/app/user-checklist/components/user-checklist/shared-mocks.ts
+++ b/src/app/user-checklist/components/user-checklist/shared-mocks.ts
@@ -8,12 +8,14 @@ export class DummyChecklistApi implements ChecklistApi {
   public static items: ChecklistItem[] = [];
   public static accountHidden: boolean = false;
   public static archiveAccess: AccessRoleType = 'access.role.owner';
+  public static savedAccount: boolean = false;
 
   public static reset(): void {
     this.items = [];
     this.error = false;
     this.accountHidden = false;
     this.archiveAccess = 'access.role.owner';
+    this.savedAccount = false;
   }
 
   public async getChecklistItems(): Promise<ChecklistItem[]> {
@@ -21,6 +23,13 @@ export class DummyChecklistApi implements ChecklistApi {
       throw new Error('Unit test forced error');
     }
     return DummyChecklistApi.items;
+  }
+
+  public async setChecklistHidden(): Promise<void> {
+    if (DummyChecklistApi.error) {
+      throw new Error('Unit test forced error');
+    }
+    DummyChecklistApi.savedAccount = true;
   }
 
   public isAccountHidingChecklist(): boolean {

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.html
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.html
@@ -57,7 +57,9 @@
         }
       </ul>
       <div class="footer">
-        <button class="dont-show-again">Don't show me this again</button>
+        <button class="dont-show-again" (click)="hideChecklistForever()">
+          Don't show me this again
+        </button>
       </div>
     </div>
   } @else {

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
@@ -1,11 +1,10 @@
 /* @format */
 import { Shallow } from 'shallow-render';
-import { AccountService } from '@shared/services/account/account.service';
 import { CHECKLIST_API } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 import { UserChecklistModule } from '../../user-checklist.module';
 import { UserChecklistComponent } from './user-checklist.component';
-import { DummyAccountService, DummyChecklistApi } from './shared-mocks';
+import { DummyChecklistApi } from './shared-mocks';
 
 describe('UserChecklistComponent', () => {
   let shallow: Shallow<UserChecklistComponent>;
@@ -27,18 +26,15 @@ describe('UserChecklistComponent', () => {
   }
 
   beforeEach(async () => {
-    DummyAccountService.reset();
     DummyChecklistApi.reset();
     DummyChecklistApi.items = [createTestTask()];
-    shallow = new Shallow(UserChecklistComponent, UserChecklistModule)
-      .provideMock({
-        provide: CHECKLIST_API,
-        useClass: DummyChecklistApi,
-      })
-      .provideMock({
-        provide: AccountService,
-        useClass: DummyAccountService,
-      });
+    shallow = new Shallow(
+      UserChecklistComponent,
+      UserChecklistModule,
+    ).provideMock({
+      provide: CHECKLIST_API,
+      useClass: DummyChecklistApi,
+    });
   });
 
   it('should create', async () => {
@@ -113,7 +109,7 @@ describe('UserChecklistComponent', () => {
   });
 
   it('is hidden if the account has the hideChecklist setting enabled', async () => {
-    DummyAccountService.accountVoData = { hideChecklist: true };
+    DummyChecklistApi.accountHidden = true;
 
     const { find } = await shallow.render();
 

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
@@ -1,10 +1,11 @@
 /* @format */
 import { Shallow } from 'shallow-render';
+import { AccountService } from '@shared/services/account/account.service';
 import { CHECKLIST_API } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 import { UserChecklistModule } from '../../user-checklist.module';
 import { UserChecklistComponent } from './user-checklist.component';
-import { DummyChecklistApi } from './shared-mocks';
+import { DummyAccountService, DummyChecklistApi } from './shared-mocks';
 
 describe('UserChecklistComponent', () => {
   let shallow: Shallow<UserChecklistComponent>;
@@ -26,15 +27,18 @@ describe('UserChecklistComponent', () => {
   }
 
   beforeEach(async () => {
+    DummyAccountService.reset();
     DummyChecklistApi.reset();
     DummyChecklistApi.items = [createTestTask()];
-    shallow = new Shallow(
-      UserChecklistComponent,
-      UserChecklistModule,
-    ).provideMock({
-      provide: CHECKLIST_API,
-      useClass: DummyChecklistApi,
-    });
+    shallow = new Shallow(UserChecklistComponent, UserChecklistModule)
+      .provideMock({
+        provide: CHECKLIST_API,
+        useClass: DummyChecklistApi,
+      })
+      .provideMock({
+        provide: AccountService,
+        useClass: DummyAccountService,
+      });
   });
 
   it('should create', async () => {
@@ -102,6 +106,14 @@ describe('UserChecklistComponent', () => {
 
   it('is hidden completely if no tasks come back from the API', async () => {
     DummyChecklistApi.items = [];
+
+    const { find } = await shallow.render();
+
+    expectComponentToBeInvisible(find);
+  });
+
+  it('is hidden if the account has the hideChecklist setting enabled', async () => {
+    DummyAccountService.accountVoData = { hideChecklist: true };
 
     const { find } = await shallow.render();
 

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
@@ -116,6 +116,14 @@ describe('UserChecklistComponent', () => {
     expectComponentToBeInvisible(find);
   });
 
+  it('is hidden if the account does not own the archive', async () => {
+    DummyChecklistApi.archiveAccess = 'access.role.viewer';
+
+    const { find } = await shallow.render();
+
+    expectComponentToBeInvisible(find);
+  });
+
   describe('Percentage completion', () => {
     async function expectPercentage(
       completed: number,

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
@@ -124,6 +124,29 @@ describe('UserChecklistComponent', () => {
     expectComponentToBeInvisible(find);
   });
 
+  it('should hide itself and save account property when clicking the dismiss button', async () => {
+    const { find, fixture } = await shallow.render();
+
+    find('.dont-show-again').triggerEventHandler('click');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expectComponentToBeInvisible(find);
+
+    expect(DummyChecklistApi.savedAccount).toBeTrue();
+  });
+
+  it('should fail silently if the account save fails', async () => {
+    const { instance, inject } = await shallow.render();
+
+    DummyChecklistApi.error = true;
+
+    await expectAsync(
+      inject(CHECKLIST_API).setChecklistHidden(),
+    ).toBeRejected();
+    await expectAsync(instance.hideChecklistForever()).not.toBeRejected();
+  });
+
   describe('Percentage completion', () => {
     async function expectPercentage(
       completed: number,

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
@@ -1,6 +1,5 @@
 /* @format */
 import { Component, Inject, OnInit } from '@angular/core';
-import { AccountService } from '@shared/services/account/account.service';
 import { CHECKLIST_API, ChecklistApi } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 
@@ -15,13 +14,10 @@ export class UserChecklistComponent implements OnInit {
   public isOpen: boolean = true;
   public isDisplayed: boolean = true;
 
-  constructor(
-    @Inject(CHECKLIST_API) private api: ChecklistApi,
-    private account: AccountService,
-  ) {}
+  constructor(@Inject(CHECKLIST_API) private api: ChecklistApi) {}
 
   public ngOnInit(): void {
-    if (this.account.getAccount().hideChecklist) {
+    if (this.api.isAccountHidingChecklist()) {
       this.isDisplayed = false;
       return;
     }

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
@@ -53,4 +53,13 @@ export class UserChecklistComponent implements OnInit {
   public open(): void {
     this.isOpen = true;
   }
+
+  public async hideChecklistForever(): Promise<void> {
+    this.isDisplayed = false;
+    try {
+      await this.api.setChecklistHidden();
+    } catch {
+      // Fail silently
+    }
+  }
 }

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
@@ -17,7 +17,10 @@ export class UserChecklistComponent implements OnInit {
   constructor(@Inject(CHECKLIST_API) private api: ChecklistApi) {}
 
   public ngOnInit(): void {
-    if (this.api.isAccountHidingChecklist()) {
+    if (
+      this.api.isAccountHidingChecklist() ||
+      !this.api.isArchiveOwnedByAccount()
+    ) {
       this.isDisplayed = false;
       return;
     }

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
@@ -1,5 +1,6 @@
 /* @format */
 import { Component, Inject, OnInit } from '@angular/core';
+import { AccountService } from '@shared/services/account/account.service';
 import { CHECKLIST_API, ChecklistApi } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 
@@ -14,9 +15,17 @@ export class UserChecklistComponent implements OnInit {
   public isOpen: boolean = true;
   public isDisplayed: boolean = true;
 
-  constructor(@Inject(CHECKLIST_API) private api: ChecklistApi) {}
+  constructor(
+    @Inject(CHECKLIST_API) private api: ChecklistApi,
+    private account: AccountService,
+  ) {}
 
   public ngOnInit(): void {
+    if (this.account.getAccount().hideChecklist) {
+      this.isDisplayed = false;
+      return;
+    }
+
     this.api
       .getChecklistItems()
       .then((items) => {

--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -6,20 +6,25 @@ import {
 } from '@angular/common/http/testing';
 import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
 import { environment } from '@root/environments/environment';
+import { AccountService } from '@shared/services/account/account.service';
+import { AccountVO } from '@models/account-vo';
 import { ChecklistItem } from '../types/checklist-item';
 import { UserChecklistService } from './user-checklist.service';
 
 describe('UserChecklistService', () => {
   let service: UserChecklistService;
   let http: HttpTestingController;
+  let account: AccountService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [HttpV2Service],
+      providers: [HttpV2Service, AccountService],
     });
     service = TestBed.inject(UserChecklistService);
     http = TestBed.inject(HttpTestingController);
+    account = TestBed.inject(AccountService);
+    account.clear();
     TestBed.inject(HttpV2Service).setAuthToken('test');
   });
 
@@ -53,5 +58,21 @@ describe('UserChecklistService', () => {
     expect(req.request.headers.get('Request-Version')).toBe('2');
     expect(req.request.headers.get('Authorization')).not.toBeNull();
     req.flush(expected);
+  });
+
+  it('can check if the user is hiding the checklist', () => {
+    account.setAccount(new AccountVO({ hideChecklist: false }));
+
+    expect(service.isAccountHidingChecklist()).toBeFalse();
+
+    account.setAccount(new AccountVO({ hideChecklist: true }));
+
+    expect(service.isAccountHidingChecklist()).toBeTrue();
+  });
+
+  it('will hide the checklist if the account is not set', () => {
+    account.clear();
+
+    expect(service.isAccountHidingChecklist()).toBeTrue();
   });
 });

--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -8,6 +8,7 @@ import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
 import { environment } from '@root/environments/environment';
 import { AccountService } from '@shared/services/account/account.service';
 import { AccountVO } from '@models/account-vo';
+import { ArchiveVO } from '@models/index';
 import { ChecklistItem } from '../types/checklist-item';
 import { UserChecklistService } from './user-checklist.service';
 
@@ -74,5 +75,17 @@ describe('UserChecklistService', () => {
     account.clear();
 
     expect(service.isAccountHidingChecklist()).toBeTrue();
+  });
+
+  it('can check if the current account has Owner access to the current archive', () => {
+    account.setAccount(new AccountVO({ hideChecklist: false }));
+
+    account.setArchive(new ArchiveVO({ accessRole: 'access.role.viewer' }));
+
+    expect(service.isArchiveOwnedByAccount()).toBeFalse();
+
+    account.setArchive(new ArchiveVO({ accessRole: 'access.role.owner' }));
+
+    expect(service.isArchiveOwnedByAccount()).toBeTrue();
   });
 });

--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -88,4 +88,38 @@ describe('UserChecklistService', () => {
 
     expect(service.isArchiveOwnedByAccount()).toBeTrue();
   });
+
+  it('can update the current account to hide the checklist', (done) => {
+    account.setAccount(new AccountVO({ hideChecklist: false }));
+
+    service
+      .setChecklistHidden()
+      .catch(() => {
+        done.fail();
+      })
+      .finally(() => {
+        done();
+      });
+
+    const req = http.expectOne(`${environment.apiUrl}/account/update`);
+
+    expect(req.request.method).toBe('POST');
+    expect(
+      req.request.body.RequestVO.data[0].AccountVO.hideChecklist,
+    ).toBeTrue();
+    req.flush({
+      Results: [
+        {
+          data: [
+            {
+              AccountVO: {
+                hideChecklist: true,
+              },
+            },
+          ],
+        },
+      ],
+      isSuccessful: true,
+    });
+  });
 });

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -23,4 +23,6 @@ export class UserChecklistService implements ChecklistApi {
   public isArchiveOwnedByAccount(): boolean {
     return false;
   }
+
+  public async setChecklistHidden(): Promise<void> {}
 }

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
 import { AccountService } from '@shared/services/account/account.service';
+import { AccessRole } from '@models/access-role';
 import { ChecklistApi } from '../types/checklist-api';
 import { ChecklistItem } from '../types/checklist-item';
 
@@ -25,7 +26,7 @@ export class UserChecklistService implements ChecklistApi {
   }
 
   public isArchiveOwnedByAccount(): boolean {
-    return false;
+    return this.account.checkMinimumArchiveAccess(AccessRole.Owner);
   }
 
   public async setChecklistHidden(): Promise<void> {}

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -19,4 +19,8 @@ export class UserChecklistService implements ChecklistApi {
   public isAccountHidingChecklist(): boolean {
     return true;
   }
+
+  public isArchiveOwnedByAccount(): boolean {
+    return false;
+  }
 }

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -29,5 +29,9 @@ export class UserChecklistService implements ChecklistApi {
     return this.account.checkMinimumArchiveAccess(AccessRole.Owner);
   }
 
-  public async setChecklistHidden(): Promise<void> {}
+  public async setChecklistHidden(): Promise<void> {
+    const updatedAccount = this.account.getAccount();
+    updatedAccount.hideChecklist = true;
+    await this.account.updateAccount(updatedAccount);
+  }
 }

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
+import { AccountService } from '@shared/services/account/account.service';
 import { ChecklistApi } from '../types/checklist-api';
 import { ChecklistItem } from '../types/checklist-item';
 
@@ -8,7 +9,10 @@ import { ChecklistItem } from '../types/checklist-item';
   providedIn: 'root',
 })
 export class UserChecklistService implements ChecklistApi {
-  constructor(private httpv2: HttpV2Service) {}
+  constructor(
+    private httpv2: HttpV2Service,
+    private account: AccountService,
+  ) {}
 
   public getChecklistItems(): Promise<ChecklistItem[]> {
     return firstValueFrom(
@@ -17,7 +21,7 @@ export class UserChecklistService implements ChecklistApi {
   }
 
   public isAccountHidingChecklist(): boolean {
-    return true;
+    return this.account.getAccount()?.hideChecklist ?? true;
   }
 
   public isArchiveOwnedByAccount(): boolean {

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -15,4 +15,8 @@ export class UserChecklistService implements ChecklistApi {
       this.httpv2.get<ChecklistItem>('/v2/event/checklist'),
     );
   }
+
+  public isAccountHidingChecklist(): boolean {
+    return true;
+  }
 }

--- a/src/app/user-checklist/types/checklist-api.ts
+++ b/src/app/user-checklist/types/checklist-api.ts
@@ -5,6 +5,7 @@ import { ChecklistItem } from './checklist-item';
 export interface ChecklistApi {
   getChecklistItems(): Promise<ChecklistItem[]>;
   isAccountHidingChecklist(): boolean;
+  isArchiveOwnedByAccount(): boolean;
 }
 
 export const CHECKLIST_API = new InjectionToken<ChecklistApi>('ChecklistApi');

--- a/src/app/user-checklist/types/checklist-api.ts
+++ b/src/app/user-checklist/types/checklist-api.ts
@@ -6,6 +6,7 @@ export interface ChecklistApi {
   getChecklistItems(): Promise<ChecklistItem[]>;
   isAccountHidingChecklist(): boolean;
   isArchiveOwnedByAccount(): boolean;
+  setChecklistHidden(): Promise<void>;
 }
 
 export const CHECKLIST_API = new InjectionToken<ChecklistApi>('ChecklistApi');

--- a/src/app/user-checklist/types/checklist-api.ts
+++ b/src/app/user-checklist/types/checklist-api.ts
@@ -4,6 +4,7 @@ import { ChecklistItem } from './checklist-item';
 
 export interface ChecklistApi {
   getChecklistItems(): Promise<ChecklistItem[]>;
+  isAccountHidingChecklist(): boolean;
 }
 
 export const CHECKLIST_API = new InjectionToken<ChecklistApi>('ChecklistApi');

--- a/src/app/user-checklist/user-checklist.module.ts
+++ b/src/app/user-checklist/user-checklist.module.ts
@@ -1,6 +1,7 @@
 /* @format */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { SharedModule } from '@shared/shared.module';
 import { UserChecklistComponent } from './components/user-checklist/user-checklist.component';
 import { ChecklistIconComponent } from './components/checklist-icon/checklist-icon.component';
 import { TaskIconComponent } from './components/task-icon/task-icon.component';
@@ -16,7 +17,7 @@ import { UserChecklistService } from './services/user-checklist.service';
     MinimizeIconComponent,
   ],
   exports: [UserChecklistComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, SharedModule],
   providers: [
     {
       provide: CHECKLIST_API,


### PR DESCRIPTION
This PR combines some related "hide the checklist" functionality. It includes: checking for the `hideChecklist` property on accounts, checking for the current archive's access role, and setting the `hideChecklist` value when clicking the "Don't show me this again" button.

I decided to keep things consistent and use an interface to control how much the component can do on its own; as a result it is not passed the `AccountService` directly, but instead controls it through the `ChecklistApi` interface. I think all of the usage of the AccountService could have been included directly in the component, but considering I didn't want to import the whole ApiService earlier, I thought it was only fair to not import the whole AccountService (does this component really need access to most of the AccountService methods?).

Since the component is still not fully integrated into the UI, manual testing is still a bit limited. You can view the automated tests for some testing input, and do some limited manual testing in Storybook (mainly verifying that the "Don't show me this again" button actually hides the component).