### PR TITLE
Add day labels to date picker

### DIFF
--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
@@ -205,14 +205,14 @@
         <ng-container *ngIf="!dateOnly">
           {{
             displayValue
-              ? (displayValue | prDate : item?.TimezoneVO)
+              ? (displayValue | prDate: item?.TimezoneVO)
               : (!canEdit ? readOnlyEmptyMessage : emptyMessage) || '&nbsp;'
           }}
         </ng-container>
         <ng-container *ngIf="dateOnly">
           {{
             displayValue
-              ? (displayValue | date : 'yyyy-MM-dd' : '+0000')
+              ? (displayValue | date: 'yyyy-MM-dd' : '+0000')
               : (!canEdit ? readOnlyEmptyMessage : emptyMessage) || '&nbsp;'
           }}
         </ng-container>
@@ -222,6 +222,7 @@
         [startDate]="ngbDate"
         [hidden]="!isEditing"
         [maxDate]="maxNgbDate"
+        [weekdays]="true"
         (dateSelect)="onDateChange($event)"
         [footerTemplate]="!dateOnly ? timePicker : null"
       ></ngb-datepicker>

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -219,7 +219,6 @@ export class SharedModule {
     library.addIcons(faFileArchive, faPenSquare);
     this.dialog.registerComponents(this.dialogComponents, this.resolver, true);
 
-    this.datePickerConfig.weekdays = false;
     this.datePickerConfig.minDate = {
       year: 1,
       day: 1,


### PR DESCRIPTION
Set the `weekdays` value to true in the ngb-datepicker component, and remove the config in the NgbDatePickerConfig service that removes them by default.

Resolves PER-9585.

**Steps to test:**
1. Open the date picker on a record/folder
2. Verify that day labels are visible