### PR TITLE
Set date picker to be Sunday-Saturday

### DIFF
--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
@@ -225,6 +225,7 @@
         [weekdays]="true"
         (dateSelect)="onDateChange($event)"
         [footerTemplate]="!dateOnly ? timePicker : null"
+        [firstDayOfWeek]="7"
       ></ngb-datepicker>
       <ng-template #timePicker>
         <div class="datepicker-footer">


### PR DESCRIPTION
Right now the date picker is set to start weeks on Mondays. This is a bit unintuitive for our primarily US-based audience. Change it so weeks start on Sunday.

This PR and #408 can be reviewed/merged in any order.

**Stepz to test:**
1. Open the date picker on a record/folder
2. Verify that the first day in the calendar column is a sunday instead of a monday.