### PR TITLE
Upgrade codecov action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,4 +37,6 @@ jobs:
         run: npm run coverage:ci
 
       - name: Upload report to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Upgrade the codecov action to version 4. This version requires an access token, which has been added to the web-app repo's Github Actions secrets. This should hopefully allow us to see the codecov bot on all PRs again.