### PR TITLE
Hide checklist on mobile (or when printing)

### DIFF
--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.scss
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.scss
@@ -2,6 +2,13 @@
 :host {
   position: absolute;
   bottom: 0;
+
+  @media only screen and (max-width: 900px) {
+    display: none;
+  }
+  @media print {
+    display: none;
+  }
 }
 
 .user-checklist {


### PR DESCRIPTION
The checklist should not be visible on mobile devices. Also if users want to print out a view of Permanent, they probably don't want to include personal account elements such as the new member checklist, so hide it from printing as well.

**Steps to test:**
1. Shrink your browser until it's in the mobile view and verify the checklist goes away
2. Hit the shortcut for printing in your browser and verify the checklist is gone in the preview

~~(i almost took a screenshot of this one before i realized i'd be taking a screenshot of nothing...)~~