### PR TITLE
Only show new member checklist on default archives

### DIFF
--- a/src/app/user-checklist/components/user-checklist/shared-mocks.ts
+++ b/src/app/user-checklist/components/user-checklist/shared-mocks.ts
@@ -36,7 +36,7 @@ export class DummyChecklistApi implements ChecklistApi {
     return DummyChecklistApi.accountHidden;
   }
 
-  public isArchiveOwnedByAccount(): boolean {
+  public isDefaultArchiveOwnedByAccount(): boolean {
     return DummyChecklistApi.archiveAccess === 'access.role.owner';
   }
 }

--- a/src/app/user-checklist/components/user-checklist/shared-mocks.ts
+++ b/src/app/user-checklist/components/user-checklist/shared-mocks.ts
@@ -1,5 +1,6 @@
 /* @format */
 import { AccessRoleType } from '@models/access-role';
+import { Subject } from 'rxjs';
 import { ChecklistApi } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 
@@ -8,7 +9,10 @@ export class DummyChecklistApi implements ChecklistApi {
   public static items: ChecklistItem[] = [];
   public static accountHidden: boolean = false;
   public static archiveAccess: AccessRoleType = 'access.role.owner';
+  public static defaultArchive: boolean = true;
   public static savedAccount: boolean = false;
+
+  private recheckArchive = new Subject<void>();
 
   public static reset(): void {
     this.items = [];
@@ -38,5 +42,13 @@ export class DummyChecklistApi implements ChecklistApi {
 
   public isDefaultArchiveOwnedByAccount(): boolean {
     return DummyChecklistApi.archiveAccess === 'access.role.owner';
+  }
+
+  public getArchiveChangedEvent(): Subject<void> {
+    return this.recheckArchive;
+  }
+
+  public sendArchiveChangeEvent(): void {
+    this.recheckArchive.next();
   }
 }

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
@@ -1,5 +1,6 @@
 /* @format */
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { CHECKLIST_API, ChecklistApi } from '../../types/checklist-api';
 import { ChecklistItem } from '../../types/checklist-item';
 
@@ -8,20 +9,24 @@ import { ChecklistItem } from '../../types/checklist-item';
   templateUrl: './user-checklist.component.html',
   styleUrl: './user-checklist.component.scss',
 })
-export class UserChecklistComponent implements OnInit {
+export class UserChecklistComponent implements OnInit, OnDestroy {
   public items: ChecklistItem[] = [];
   public percentage: number = 0;
   public isOpen: boolean = true;
   public isDisplayed: boolean = true;
 
+  private archiveSubscription: Subscription;
+
   constructor(@Inject(CHECKLIST_API) private api: ChecklistApi) {}
 
   public ngOnInit(): void {
-    if (
-      this.api.isAccountHidingChecklist() ||
-      !this.api.isDefaultArchiveOwnedByAccount()
-    ) {
-      this.isDisplayed = false;
+    this.archiveSubscription = this.api
+      .getArchiveChangedEvent()
+      .subscribe(() => {
+        this.hideChecklistIfNotOwnedOrDefault();
+      });
+
+    if (this.hideChecklistIfNotOwnedOrDefault()) {
       return;
     }
 
@@ -46,6 +51,10 @@ export class UserChecklistComponent implements OnInit {
       });
   }
 
+  public ngOnDestroy(): void {
+    this.archiveSubscription.unsubscribe();
+  }
+
   public minimize(): void {
     this.isOpen = false;
   }
@@ -61,5 +70,17 @@ export class UserChecklistComponent implements OnInit {
     } catch {
       // Fail silently
     }
+  }
+
+  private hideChecklistIfNotOwnedOrDefault(): boolean {
+    if (
+      this.api.isAccountHidingChecklist() ||
+      !this.api.isDefaultArchiveOwnedByAccount()
+    ) {
+      this.isDisplayed = false;
+      return true;
+    }
+    this.isDisplayed = true;
+    return false;
   }
 }

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
@@ -19,7 +19,7 @@ export class UserChecklistComponent implements OnInit {
   public ngOnInit(): void {
     if (
       this.api.isAccountHidingChecklist() ||
-      !this.api.isArchiveOwnedByAccount()
+      !this.api.isDefaultArchiveOwnedByAccount()
     ) {
       this.isDisplayed = false;
       return;

--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -80,15 +80,33 @@ describe('UserChecklistService', () => {
   });
 
   it('can check if the current account has Owner access to the current archive', () => {
-    account.setAccount(new AccountVO({ hideChecklist: false }));
+    account.setAccount(
+      new AccountVO({ hideChecklist: false, defaultArchiveId: 1 }),
+    );
 
-    account.setArchive(new ArchiveVO({ accessRole: 'access.role.viewer' }));
+    account.setArchive(
+      new ArchiveVO({ accessRole: 'access.role.viewer', archiveId: 1 }),
+    );
 
-    expect(service.isArchiveOwnedByAccount()).toBeFalse();
+    expect(service.isDefaultArchiveOwnedByAccount()).toBeFalse();
 
-    account.setArchive(new ArchiveVO({ accessRole: 'access.role.owner' }));
+    account.setArchive(
+      new ArchiveVO({ accessRole: 'access.role.owner', archiveId: 1 }),
+    );
 
-    expect(service.isArchiveOwnedByAccount()).toBeTrue();
+    expect(service.isDefaultArchiveOwnedByAccount()).toBeTrue();
+  });
+
+  it('will also check if the current account has the current archive as its default', () => {
+    account.setAccount(
+      new AccountVO({ hideChecklist: false, defaultArchiveId: 12345 }),
+    );
+
+    account.setArchive(
+      new ArchiveVO({ accessRole: 'access.role.owner', archiveId: 98765 }),
+    );
+
+    expect(service.isDefaultArchiveOwnedByAccount()).toBeFalse();
   });
 
   it('can update the current account to hide the checklist', (done) => {

--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -142,4 +142,26 @@ describe('UserChecklistService', () => {
       isSuccessful: true,
     });
   });
+
+  it('binds its recheck archive event to the accountservice', (done) => {
+    service.getArchiveChangedEvent().subscribe(() => {
+      service.getArchiveChangedEvent().unsubscribe();
+      done();
+    });
+
+    account.archiveChange.next(new ArchiveVO({}));
+  });
+
+  it('unsubscribes from the accountservice when it is destroyed', (done) => {
+    service.getArchiveChangedEvent().subscribe(() => {
+      done.fail('Service is still subscribed to AccountService');
+    });
+
+    service.ngOnDestroy();
+
+    account.archiveChange.next(new ArchiveVO({}));
+    setTimeout(() => {
+      done();
+    }, 1);
+  });
 });

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -27,13 +27,23 @@ export class UserChecklistService implements ChecklistApi {
     return this.account.getAccount()?.hideChecklist ?? true;
   }
 
-  public isArchiveOwnedByAccount(): boolean {
-    return this.account.checkMinimumArchiveAccess(AccessRole.Owner);
+  public isDefaultArchiveOwnedByAccount(): boolean {
+    return (
+      this.account.checkMinimumArchiveAccess(AccessRole.Owner) &&
+      this.isDefaultArchive()
+    );
   }
 
   public async setChecklistHidden(): Promise<void> {
     const updatedAccount = this.account.getAccount();
     updatedAccount.hideChecklist = true;
     await this.account.updateAccount(updatedAccount);
+  }
+
+  private isDefaultArchive(): boolean {
+    return (
+      this.account.getAccount().defaultArchiveId ===
+      this.account.getArchive().archiveId
+    );
   }
 }

--- a/src/app/user-checklist/services/user-checklist.service.ts
+++ b/src/app/user-checklist/services/user-checklist.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
+import { Injectable, OnDestroy } from '@angular/core';
+import { Subject, Subscription, firstValueFrom } from 'rxjs';
 import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { AccessRole } from '@models/access-role';
@@ -9,11 +9,22 @@ import { ChecklistApiResponse, ChecklistItem } from '../types/checklist-item';
 @Injectable({
   providedIn: 'root',
 })
-export class UserChecklistService implements ChecklistApi {
+export class UserChecklistService implements ChecklistApi, OnDestroy {
+  private recheckArchive = new Subject<void>();
+  private accountSubscription: Subscription;
+
   constructor(
     private httpv2: HttpV2Service,
     private account: AccountService,
-  ) {}
+  ) {
+    this.accountSubscription = account.archiveChange.subscribe(() => {
+      this.recheckArchive.next();
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.accountSubscription.unsubscribe();
+  }
 
   public async getChecklistItems(): Promise<ChecklistItem[]> {
     return (
@@ -38,6 +49,10 @@ export class UserChecklistService implements ChecklistApi {
     const updatedAccount = this.account.getAccount();
     updatedAccount.hideChecklist = true;
     await this.account.updateAccount(updatedAccount);
+  }
+
+  public getArchiveChangedEvent(): Subject<void> {
+    return this.recheckArchive;
   }
 
   private isDefaultArchive(): boolean {

--- a/src/app/user-checklist/types/checklist-api.ts
+++ b/src/app/user-checklist/types/checklist-api.ts
@@ -5,7 +5,7 @@ import { ChecklistItem } from './checklist-item';
 export interface ChecklistApi {
   getChecklistItems(): Promise<ChecklistItem[]>;
   isAccountHidingChecklist(): boolean;
-  isArchiveOwnedByAccount(): boolean;
+  isDefaultArchiveOwnedByAccount(): boolean;
   setChecklistHidden(): Promise<void>;
 }
 

--- a/src/app/user-checklist/types/checklist-api.ts
+++ b/src/app/user-checklist/types/checklist-api.ts
@@ -1,5 +1,6 @@
 /* @format */
 import { InjectionToken } from '@angular/core';
+import { Subject } from 'rxjs';
 import { ChecklistItem } from './checklist-item';
 
 export interface ChecklistApi {
@@ -7,6 +8,7 @@ export interface ChecklistApi {
   isAccountHidingChecklist(): boolean;
   isDefaultArchiveOwnedByAccount(): boolean;
   setChecklistHidden(): Promise<void>;
+  getArchiveChangedEvent(): Subject<void>;
 }
 
 export const CHECKLIST_API = new InjectionToken<ChecklistApi>('ChecklistApi');


### PR DESCRIPTION
Previously the checklist showed up on any archives the user owned. Now only show on the user's default archive. This PR also includes a light refactoring by renaming the `isArchiveOwnedbyAccount` method to `isDefaultArchiveOwnedByAccount` to match the new criteria.