### PR TITLE
Add codecov threshold configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1


### PR DESCRIPTION
The codecov/project action is failing since there seems to be some fluctuations in the coverage calculations either on Karma or CodeCov's side. Fix this by setting a threshold for codecov changes. I think 1% is good since the codebase is pretty big; a 1% decrease would be a serious oversight that should be addressed. But the threshold also allows the small coverage fluctuations to not block any pull requests. In general, the patch changes are more important than full project coverage anyway.