### PR TITLE
Fix error when destroying hidden checklist

### DIFF
--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.spec.ts
@@ -219,6 +219,14 @@ describe('UserChecklistComponent', () => {
     expect(instance.items[0].id).not.toBe('refresh');
   });
 
+  it('should not throw errors if subscriptions are undefined', async () => {
+    DummyChecklistApi.accountHidden = true;
+
+    const { instance } = await shallow.render();
+
+    expect(() => instance.ngOnDestroy()).not.toThrow();
+  });
+
   describe('Percentage completion', () => {
     async function expectPercentage(
       completed: number,

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.ts
@@ -27,22 +27,22 @@ export class UserChecklistComponent implements OnInit, OnDestroy {
         this.hideChecklistIfNotOwnedOrDefault();
       });
 
-    if (this.hideChecklistIfNotOwnedOrDefault()) {
-      return;
-    }
-
     this.refreshSubscription = this.api
       .getRefreshChecklistEvent()
       .subscribe(() => {
         this.refreshChecklist();
       });
 
+    if (this.hideChecklistIfNotOwnedOrDefault()) {
+      return;
+    }
+
     this.refreshChecklist();
   }
 
   public ngOnDestroy(): void {
-    this.archiveSubscription.unsubscribe();
-    this.refreshSubscription.unsubscribe();
+    this.archiveSubscription?.unsubscribe();
+    this.refreshSubscription?.unsubscribe();
   }
 
   public minimize(): void {


### PR DESCRIPTION
The checklist is designed to skip subscribing to refresh events if it is completely hidden in the current view since there's no point to refreshing the checklist if it is completely disabled. This causes an error to be thrown when we later unsubscribe from this undefined subscription. Do a check for undefined when unsubscribing and make the refresh subscription be defined even for hidden checklists, since the checklist could reappear if the user changes archives.

PER-9738: Navigating to Public Gallery from an archive is broken