### PR TITLE
Fix GLAM onboarding integration bugs

### DIFF
--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
@@ -188,6 +188,6 @@
     </button>
   </div>
 </div>
-<div *ngIf="!isGlam">
+<div *ngIf="!isGlam && screen !== 'create' && screen !== 'name-archive'">
   <button (click)="skipStep()" class="btn btn-link">Skip this step</button>
 </div>

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
@@ -47,36 +47,36 @@
           </div>
           <div *ngIf="!selectedValue" class="disabled-overlay"></div>
         </div>
-        <div class="buttons">
-          <button
-            *ngIf="!pendingArchives.length"
-            (click)="makeMyArchive()"
-            class="btn btn-link"
-          >
-            Make my archive for me
-          </button>
-          <button
-            *ngIf="pendingArchives.length"
-            (click)="goToInvitations()"
-            class="btn btn-link"
-          >
-            Go back
-          </button>
-          <button
-            [class.btn-disabled]="!name"
-            (click)="setScreen('goals')"
-            [disabled]="!name"
-            class="btn btn-primary chart-path"
-          >
-            Next: Chart your path
-          </button>
-        </div>
+      </div>
+      <div class="buttons">
+        <button
+          *ngIf="!pendingArchives.length"
+          (click)="makeMyArchive()"
+          class="btn btn-link"
+        >
+          Make my archive for me
+        </button>
+        <button
+          *ngIf="pendingArchives.length"
+          (click)="goToInvitations()"
+          class="btn btn-link"
+        >
+          Go back
+        </button>
         <button
           *ngIf="pendingArchives.length"
           (click)="makeMyArchive()"
           class="btn btn-link"
         >
           Make my archive for me
+        </button>
+        <button
+          [class.btn-disabled]="!name"
+          (click)="setScreen('goals')"
+          [disabled]="!name"
+          class="btn btn-primary chart-path"
+        >
+          Next: Chart your path
         </button>
       </div>
     </div>


### PR DESCRIPTION
There are a few broken inconsistencies I initially missed in review for the GLAM onboarding integration pull requests:
* A "skip this step" link appears on the archive creation step of onboarding. This is not supposed  to show up here, and clicking on it does nothing because it was not programmed to have functionality when clicked on this screen.
* The "create archive for me" link is visibly greyed out until the user has selected an archive type. This should not be the case since the whole point of that link is to skip picking an archive type.

This may cause some errors to pop up on the GLAM side of the application, but I believe restoring the live onboarding experience takes priority over that.

Bugs like this are why I've been trying to advocate for us using [Branch By Abstraction](https://martinfowler.com/bliki/BranchByAbstraction.html) when it comes to big redesigns like this. If we implement future redesigns like this, the old logic will be completely untouched and so there are much lower odds of bugs like this popping up. (Though care still has to be taken in making sure new code is properly isolated! Because we didn't fully isolate the checklist, some of its functionality ended up causing the bug that was fixed in #427)