### PR TITLE
Run deployment after dev build is complete

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -99,3 +99,10 @@ jobs:
 
       - name: Copy package to S3
         run: aws s3 cp ../mdot.tar.gz s3://permanent-repos/dev/mdot.tar.gz
+
+  deploy:
+    needs: [upload-code, upload-sourcemaps]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger dev deploy
+        run: curl -X POST -H 'Accept:application/vnd.github.v3+json' -H 'Authorization:Bearer ${{ secrets.PERMANENT_DEPLOY_PAT }}' https://api.github.com/repos/PermanentOrg/infrastructure/actions/workflows/deploy-dev.yml/dispatches -d '{"ref":"main"}'


### PR DESCRIPTION
We would like to enable continuous deployment to the dev environment for all of our repositories. To enable this, run a dev deployment after the build and upload steps are completed for dev.

I created an organization-wide secret called `PERMANENT_DEPLOY_PAT` that is authorized to trigger workflows on the infrastructure repo. It expires a year from now and is registered to my account, but since it is organization wide, we can use this token for all repos we want to set up continuous deployment for, in any environment and replace it only in one place.

Resolves PER-9720.

**Steps to test:**
1. Run a build of this branch
2. Verify it triggers a deploy after all other workflows are complete