### PR TITLE
Enable @angular-eslint/no-empty-lifecycle-method lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,6 @@ module.exports = {
         ],
         // Below are rules we want to eventually enable:
         'import/no-cycle': 'off',
-        '@angular-eslint/no-empty-lifecycle-method': 'off',
         '@angular-eslint/no-output-native': 'off',
         '@angular-eslint/no-output-on-prefix': 'off',
         '@angular-eslint/use-lifecycle-interface': 'off',

--- a/src/app/announcement/components/android-app-notify/android-app-notify.component.ts
+++ b/src/app/announcement/components/android-app-notify/android-app-notify.component.ts
@@ -1,6 +1,5 @@
 /* @format */
-import { Component, OnInit, HostListener, ElementRef } from '@angular/core';
-
+import { Component, HostListener, ElementRef } from '@angular/core';
 import {
   adjustLayoutForAnnouncement,
   resetLayoutForAnnouncement,
@@ -16,7 +15,7 @@ export interface BeforeInstallPromptEvent extends Event {
   templateUrl: './android-app-notify.component.html',
   styleUrls: ['./android-app-notify.component.scss'],
 })
-export class AndroidAppNotifyComponent implements OnInit {
+export class AndroidAppNotifyComponent {
   public static readonly storageKey = 'androidAppNotificationDismissed';
   public active = false;
   public deferredPrompt: BeforeInstallPromptEvent;
@@ -31,8 +30,6 @@ export class AndroidAppNotifyComponent implements OnInit {
       adjustLayoutForAnnouncement(this);
     }
   }
-
-  ngOnInit(): void {}
 
   public showPrompt(): void {
     this.deferredPrompt.prompt();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, OnInit, HostBinding } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 declare var iosInnerHeight: Function;
 
@@ -8,7 +8,7 @@ declare var iosInnerHeight: Function;
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
   @HostBinding('class.mobile-safari') isMobileSafari = false;
   @HostBinding('class.mobile-safari-menu-bar-showing') isMenuBarShowing = false;
 
@@ -25,6 +25,4 @@ export class AppComponent implements OnInit {
       });
     }
   }
-
-  ngOnInit() {}
 }

--- a/src/app/apps/components/apps/apps.component.ts
+++ b/src/app/apps/components/apps/apps.component.ts
@@ -1,6 +1,12 @@
-import { Component, OnInit, OnDestroy, ViewChildren, QueryList, AfterViewInit } from '@angular/core';
+/* @format */
+import {
+  Component,
+  OnDestroy,
+  ViewChildren,
+  QueryList,
+  AfterViewInit,
+} from '@angular/core';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
-
 import { DataService } from '@shared/services/data/data.service';
 import { StorageService } from '@shared/services/storage/storage.service';
 import { ConnectorOverviewVO, FolderVO } from '@root/app/models';
@@ -9,22 +15,25 @@ import { AccountService } from '@shared/services/account/account.service';
 import { HasSubscriptions } from '@shared/utilities/hasSubscriptions';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { timeout } from '@shared/utilities/timeout';
 import { GuidedTourService } from '@shared/services/guided-tour/guided-tour.service';
-import { CreateArchivesComplete } from '@shared/services/guided-tour/tours/familysearch.tour';
-import { GuidedTourEvent } from '@shared/services/guided-tour/events';
-import { ConnectorComponent, FAMILYSEARCH_CONNECT_KEY } from '../connector/connector.component';
+import {
+  ConnectorComponent,
+  FAMILYSEARCH_CONNECT_KEY,
+} from '../connector/connector.component';
 
 @Component({
   selector: 'pr-apps',
   templateUrl: './apps.component.html',
-  styleUrls: ['./apps.component.scss']
+  styleUrls: ['./apps.component.scss'],
 })
-export class AppsComponent implements OnInit, AfterViewInit, OnDestroy, HasSubscriptions {
+export class AppsComponent
+  implements AfterViewInit, OnDestroy, HasSubscriptions
+{
   appsFolder: FolderVO;
   connectors: ConnectorOverviewVO[];
 
-  @ViewChildren(ConnectorComponent) connectorComponents: QueryList<ConnectorComponent>;
+  @ViewChildren(ConnectorComponent)
+  connectorComponents: QueryList<ConnectorComponent>;
 
   subscriptions: Subscription[] = [];
   constructor(
@@ -33,7 +42,7 @@ export class AppsComponent implements OnInit, AfterViewInit, OnDestroy, HasSubsc
     private accountService: AccountService,
     private dataService: DataService,
     private storage: StorageService,
-    private guidedTour: GuidedTourService
+    private guidedTour: GuidedTourService,
   ) {
     this.appsFolder = this.route.snapshot.data.appsFolder;
     this.connectors = this.route.snapshot.data.connectors;
@@ -44,49 +53,53 @@ export class AppsComponent implements OnInit, AfterViewInit, OnDestroy, HasSubsc
     this.registerRouterEventHandlers();
   }
 
-  ngOnInit() {
-  }
-
   registerArchiveChangeHandlers() {
     // register for archive change events to reload the root section
     this.subscriptions.push(
-      this.accountService.archiveChange.subscribe(async archive => {
+      this.accountService.archiveChange.subscribe(async (archive) => {
         this.router.navigate(['.'], { relativeTo: this.route });
-      })
+      }),
     );
   }
 
   registerRouterEventHandlers() {
     // register for navigation events to reinit page on folder changes
-    this.subscriptions.push(this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd ))
-      .subscribe((event: NavigationEnd) => {
-        if (event.url === '/app/apps') {
-          this.appsFolder = this.route.snapshot.data.appsFolder;
-          this.connectors = this.route.snapshot.data.connectors;
+    this.subscriptions.push(
+      this.router.events
+        .pipe(filter((event) => event instanceof NavigationEnd))
+        .subscribe((event: NavigationEnd) => {
+          if (event.url === '/app/apps') {
+            this.appsFolder = this.route.snapshot.data.appsFolder;
+            this.connectors = this.route.snapshot.data.connectors;
 
-          this.dataService.setCurrentFolder(this.appsFolder);
-        }
-      }));
+            this.dataService.setCurrentFolder(this.appsFolder);
+          }
+        }),
+    );
   }
-
 
   ngAfterViewInit() {
     const queryParams = this.route.snapshot.queryParams;
 
     if (queryParams.facebook !== undefined) {
       const connectorComponents = this.connectorComponents.toArray();
-      const fbConnectorComponent = find(connectorComponents, (comp: ConnectorComponent) => {
-        return comp.connector.type === 'type.connector.facebook';
-      });
+      const fbConnectorComponent = find(
+        connectorComponents,
+        (comp: ConnectorComponent) => {
+          return comp.connector.type === 'type.connector.facebook';
+        },
+      );
       fbConnectorComponent.connect();
     }
 
     if (queryParams.code && this.storage.local.get(FAMILYSEARCH_CONNECT_KEY)) {
       const connectorComponents = this.connectorComponents.toArray();
-      const fsConnectorComponent = find(connectorComponents, (comp: ConnectorComponent) => {
-        return comp.connector.type === 'type.connector.familysearch';
-      });
+      const fsConnectorComponent = find(
+        connectorComponents,
+        (comp: ConnectorComponent) => {
+          return comp.connector.type === 'type.connector.familysearch';
+        },
+      );
       setTimeout(() => {
         fsConnectorComponent.authorize(queryParams.code);
       });
@@ -96,5 +109,4 @@ export class AppsComponent implements OnInit, AfterViewInit, OnDestroy, HasSubsc
   ngOnDestroy() {
     this.dataService.setCurrentFolder();
   }
-
 }

--- a/src/app/apps/components/family-search-import/family-search-import.component.ts
+++ b/src/app/apps/components/family-search-import/family-search-import.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Inject } from '@angular/core';
+/* @format */
+import { Component, Inject } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
 import { filter } from 'lodash';
 import { ArchiveVO } from '@models';
@@ -31,7 +32,7 @@ interface FamilyMember {
   templateUrl: './family-search-import.component.html',
   styleUrls: ['./family-search-import.component.scss'],
 })
-export class FamilySearchImportComponent implements OnInit {
+export class FamilySearchImportComponent {
   public stage: 'people' | 'memories' | 'importing' = 'people';
   public importMemories = 'yes';
   public familyMembers: FamilySearchPersonI[] = [];
@@ -44,16 +45,14 @@ export class FamilySearchImportComponent implements OnInit {
     @Inject(DIALOG_DATA) public data: any,
     private api: ApiService,
     private message: MessageService,
-    private guidedTour: GuidedTourService
+    private guidedTour: GuidedTourService,
   ) {
     this.currentUser = data.currentUserData;
     this.familyMembers = filter(
       data.treeData,
-      (person) => person.id !== this.currentUser.id
+      (person) => person.id !== this.currentUser.id,
     );
   }
-
-  ngOnInit() {}
 
   cancel() {
     this.dialogRef.close(null, true);
@@ -71,7 +70,7 @@ export class FamilySearchImportComponent implements OnInit {
         fullName: person.display.name,
         type: 'type.archive.person',
         relationType: this.getRelationshipFromAncestryNumber(
-          person.display.ascendancyNumber
+          person.display.ascendancyNumber,
         ),
       });
     });
@@ -97,13 +96,13 @@ export class FamilySearchImportComponent implements OnInit {
 
       await this.api.connector.familysearchFactImportRequest(
         newArchives,
-        personIds
+        personIds,
       );
 
       if (this.importMemories === 'yes') {
         await this.api.connector.familysearchMemoryImportRequest(
           newArchives,
-          personIds
+          personIds,
         );
       }
 
@@ -131,7 +130,7 @@ export class FamilySearchImportComponent implements OnInit {
               show: () => {
                 this.guidedTour.markStepComplete(
                   'familysearch',
-                  'switchArchives'
+                  'switchArchives',
                 );
               },
             },

--- a/src/app/archive-settings/manage-metadata/subcomponents/category-add/add-new-category.component.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/category-add/add-new-category.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+/*@format */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TagVO } from '@models/tag-vo';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -13,17 +14,15 @@ import { Subject } from 'rxjs';
   templateUrl: './add-new-category.component.html',
   styleUrls: ['./add-new-category.component.scss'],
 })
-export class AddNewCategoryComponent implements OnInit {
+export class AddNewCategoryComponent {
   @Input() public dismissEvent: Subject<number>;
   @Output() public tagsUpdate = new EventEmitter<void>();
   @Output() public newCategory = new EventEmitter<string>();
   constructor(
     private prompt: PromptService,
     private api: ApiService,
-    private msg: MessageService
+    private msg: MessageService,
   ) {}
-
-  ngOnInit(): void {}
 
   public async createNewCategory(categoryName: string) {
     if (categoryName.includes(':')) {
@@ -44,7 +43,7 @@ export class AddNewCategoryComponent implements OnInit {
     try {
       ({ valueName } = await this.prompt.prompt(
         [promptField],
-        'Please create a default value to go into the new field'
+        'Please create a default value to go into the new field',
       ));
     } catch {
       // They canceled out of the prompt, return out of the error without throwing.

--- a/src/app/archive-settings/manage-metadata/subcomponents/category-edit/category-edit.component.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/category-edit/category-edit.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+/* @format */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { TagVO } from '@models/tag-vo';
@@ -11,7 +12,7 @@ import { PromptService } from '@shared/services/prompt/prompt.service';
   templateUrl: './category-edit.component.html',
   styleUrls: ['./category-edit.component.scss'],
 })
-export class CategoryEditComponent implements OnInit {
+export class CategoryEditComponent {
   @Input() public category: string;
   @Input() public tags: TagVO[];
   @Input() public dismissEvent: Subject<number>;
@@ -22,17 +23,15 @@ export class CategoryEditComponent implements OnInit {
   constructor(
     private api: ApiService,
     private msg: MessageService,
-    private prompt: PromptService
+    private prompt: PromptService,
   ) {}
-
-  ngOnInit(): void {}
 
   public async delete(): Promise<void> {
     const deleted = this.getMatchingMetadataTags();
     try {
       await this.prompt.confirm(
         'Delete',
-        `Are you sure you want to delete the "${this.category}" field? (This will remove ${deleted.length} metadata values)`
+        `Are you sure you want to delete the "${this.category}" field? (This will remove ${deleted.length} metadata values)`,
       );
     } catch {
       return;
@@ -46,7 +45,7 @@ export class CategoryEditComponent implements OnInit {
         message: 'There was an error deleting the field. Please try again.',
       });
       throw new Error(
-        'There was an error deleting the field. Please try again.'
+        'There was an error deleting the field. Please try again.',
       );
     }
   }
@@ -57,7 +56,7 @@ export class CategoryEditComponent implements OnInit {
         new TagVO({
           tagId: tag.tagId,
           name: [newCategory].concat(tag.name.split(':').slice(1)).join(':'),
-        })
+        }),
     );
     try {
       await this.api.tag.update(updated);
@@ -73,7 +72,7 @@ export class CategoryEditComponent implements OnInit {
   protected getMatchingMetadataTags(): TagVO[] {
     return this.tags.filter(
       (tag) =>
-        tag.isCustomMetadata() && tag.name.split(':')[0] === this.category
+        tag.isCustomMetadata() && tag.name.split(':')[0] === this.category,
     );
   }
 }

--- a/src/app/archive-settings/manage-metadata/subcomponents/value-add/add-new-value.component.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/value-add/add-new-value.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+/* @format */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
 import { Subject } from 'rxjs';
@@ -8,14 +9,15 @@ import { Subject } from 'rxjs';
   templateUrl: './add-new-value.component.html',
   styleUrls: ['./add-new-value.component.scss'],
 })
-export class AddNewValueComponent implements OnInit {
+export class AddNewValueComponent {
   @Input() public dismissEvent: Subject<number>;
   @Input() public category: string;
   @Output() public tagsUpdate: EventEmitter<void> = new EventEmitter<void>();
 
-  constructor(private api: ApiService, private msg: MessageService) {}
-
-  ngOnInit(): void {}
+  constructor(
+    private api: ApiService,
+    private msg: MessageService,
+  ) {}
 
   public async createNewTag(tagName: string) {
     try {
@@ -23,7 +25,7 @@ export class AddNewValueComponent implements OnInit {
         {
           name: this.category + ':' + tagName,
         },
-        {}
+        {},
       );
       this.tagsUpdate.emit();
     } catch {
@@ -32,7 +34,7 @@ export class AddNewValueComponent implements OnInit {
           'There was an error creating the custom value. Please try again.',
       });
       throw new Error(
-        'There was an error creating the custom value. Please try again.'
+        'There was an error creating the custom value. Please try again.',
       );
     }
   }

--- a/src/app/archive-settings/manage-metadata/subcomponents/value-edit/value-edit.component.ts
+++ b/src/app/archive-settings/manage-metadata/subcomponents/value-edit/value-edit.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+/* @format */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TagVO } from '@models/tag-vo';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -11,7 +12,7 @@ import { Subject } from 'rxjs';
   templateUrl: './value-edit.component.html',
   styleUrls: ['./value-edit.component.scss'],
 })
-export class EditValueComponent implements OnInit {
+export class EditValueComponent {
   @Input() public tag: TagVO;
   @Input() public dismissEvent: Subject<number>;
 
@@ -21,16 +22,14 @@ export class EditValueComponent implements OnInit {
   constructor(
     private api: ApiService,
     private msg: MessageService,
-    private prompt: PromptService
+    private prompt: PromptService,
   ) {}
-
-  ngOnInit(): void {}
 
   public async delete() {
     try {
       await this.prompt.confirm(
         'Delete',
-        `Are you sure you want to delete this metadata value? (${this.tag.name})`
+        `Are you sure you want to delete this metadata value? (${this.tag.name})`,
       );
     } catch {
       return;
@@ -46,7 +45,7 @@ export class EditValueComponent implements OnInit {
           'There was an error deleting the custom value. Please try again.',
       });
       throw new Error(
-        'There was an error deleting the custom value. Please try again.'
+        'There was an error deleting the custom value. Please try again.',
       );
     }
   }
@@ -67,7 +66,7 @@ export class EditValueComponent implements OnInit {
           'There was an error saving the custom value. Please try again.',
       });
       throw new Error(
-        'There was an error saving the custom value. Please try again.'
+        'There was an error saving the custom value. Please try again.',
       );
     }
   }

--- a/src/app/auth/components/auth/auth.component.ts
+++ b/src/app/auth/components/auth/auth.component.ts
@@ -1,15 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+/* @format */
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'pr-auth',
   templateUrl: './auth.component.html',
-  styleUrls: ['./auth.component.scss']
+  styleUrls: ['./auth.component.scss'],
 })
-export class AuthComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+export class AuthComponent {
+  constructor() {}
 }

--- a/src/app/auth/components/forgot-password/forgot-password.component.ts
+++ b/src/app/auth/components/forgot-password/forgot-password.component.ts
@@ -1,12 +1,10 @@
 /* @format */
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
   Validators,
 } from '@angular/forms';
-import { Router } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
 import { AuthResponse } from '@shared/services/api/auth.repo';
 import { MessageService } from '@shared/services/message/message.service';
 import { ApiService } from '@shared/services/api/api.service';
@@ -16,7 +14,7 @@ import { ApiService } from '@shared/services/api/api.service';
   templateUrl: './forgot-password.component.html',
   styleUrls: ['./forgot-password.component.scss'],
 })
-export class ForgotPasswordComponent implements OnInit {
+export class ForgotPasswordComponent {
   @HostBinding('class.pr-auth-form') classBinding = true;
   forgotForm: UntypedFormGroup;
   formErrors: any = {};
@@ -25,18 +23,14 @@ export class ForgotPasswordComponent implements OnInit {
   success: boolean;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private api: ApiService,
-    private router: Router,
     private message: MessageService,
-    private cookies: CookieService,
   ) {
     this.forgotForm = fb.group({
       email: ['', [Validators.required, Validators.email]],
     });
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
@@ -21,13 +21,13 @@ const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
 })
-export class LoginComponent implements OnInit {
+export class LoginComponent {
   @HostBinding('class.pr-auth-form') classBinding = true;
   loginForm: UntypedFormGroup;
   waiting: boolean;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private accountService: AccountService,
     private router: Router,
     private route: ActivatedRoute,
@@ -48,8 +48,6 @@ export class LoginComponent implements OnInit {
       keepLoggedIn: [true],
     });
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;

--- a/src/app/auth/components/logo/logo.component.ts
+++ b/src/app/auth/components/logo/logo.component.ts
@@ -1,15 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+/* @format */
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'pr-login-logo',
   templateUrl: './logo.component.html',
-  styleUrls: ['./logo.component.scss']
+  styleUrls: ['./logo.component.scss'],
 })
-export class LogoComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+export class LogoComponent {
+  constructor() {}
 }

--- a/src/app/auth/components/mfa/mfa.component.ts
+++ b/src/app/auth/components/mfa/mfa.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 import { UntypedFormGroup, UntypedFormBuilder } from '@angular/forms';
 import { AccountService } from '@shared/services/account/account.service';
 import {
@@ -16,13 +16,13 @@ import { DeviceService } from '@shared/services/device/device.service';
   templateUrl: './mfa.component.html',
   styleUrls: ['./mfa.component.scss'],
 })
-export class MfaComponent implements OnInit {
+export class MfaComponent {
   @HostBinding('class.pr-auth-form') classBinding = true;
   mfaForm: UntypedFormGroup;
   waiting: boolean;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private accountService: AccountService,
     private router: Router,
     private route: ActivatedRoute,
@@ -33,8 +33,6 @@ export class MfaComponent implements OnInit {
       token: [],
     });
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;

--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
@@ -32,7 +32,7 @@ const NEW_ONBOARDING_CHANCE = 1;
   templateUrl: './signup.component.html',
   styleUrls: ['./signup.component.scss'],
 })
-export class SignupComponent implements OnInit {
+export class SignupComponent {
   @HostBinding('class.pr-auth-form') classBinding = true;
   signupForm: UntypedFormGroup;
   waiting: boolean;
@@ -48,9 +48,8 @@ export class SignupComponent implements OnInit {
   shareItemIsRecord = false;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private accountService: AccountService,
-    private apiService: ApiService,
     private router: Router,
     private route: ActivatedRoute,
     private message: MessageService,
@@ -118,8 +117,6 @@ export class SignupComponent implements OnInit {
     ]);
     this.signupForm.addControl('confirm', confirmPasswordControl);
   }
-
-  ngOnInit() {}
 
   shouldCreateDefaultArchive() {
     if (window.location.search.includes('createArchive')) {

--- a/src/app/core/components/account-settings-dialog/account-settings-dialog.component.ts
+++ b/src/app/core/components/account-settings-dialog/account-settings-dialog.component.ts
@@ -1,11 +1,10 @@
 /* @format */
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@root/app/dialog/dialog.module';
 import { AccountService } from '@shared/services/account/account.service';
 import { AccountResponse } from '@shared/services/api/index.repo';
 import { MessageService } from '@shared/services/message/message.service';
 import { ApiService } from '@shared/services/api/api.service';
-import { Subscription } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 
 export type SettingsTab =
@@ -23,7 +22,7 @@ export type SettingsTab =
   templateUrl: './account-settings-dialog.component.html',
   styleUrls: ['./account-settings-dialog.component.scss'],
 })
-export class AccountSettingsDialogComponent implements OnInit {
+export class AccountSettingsDialogComponent {
   public activeTab: SettingsTab = 'account';
 
   public readonly verifyText = 'DELETE';
@@ -42,8 +41,6 @@ export class AccountSettingsDialogComponent implements OnInit {
       this.activeTab = data.tab;
     }
   }
-
-  ngOnInit(): void {}
 
   onDoneClick() {
     this.dialogRef.close();

--- a/src/app/core/components/all-archives/all-archives.component.ts
+++ b/src/app/core/components/all-archives/all-archives.component.ts
@@ -1,9 +1,7 @@
+/* @format */
 import {
   Component,
-  OnInit,
   AfterViewInit,
-  QueryList,
-  ViewChildren,
   Optional,
   OnDestroy,
   ViewChild,
@@ -37,7 +35,7 @@ import { CdkPortal } from '@angular/cdk/portal';
   templateUrl: './all-archives.component.html',
   styleUrls: ['./all-archives.component.scss'],
 })
-export class AllArchivesComponent implements OnInit, AfterViewInit, OnDestroy {
+export class AllArchivesComponent implements AfterViewInit, OnDestroy {
   public currentArchive: ArchiveVO;
   public archives: ArchiveVO[];
   public pendingArchives: ArchiveVO[];
@@ -53,14 +51,14 @@ export class AllArchivesComponent implements OnInit, AfterViewInit, OnDestroy {
     private prompt: PromptService,
     private message: MessageService,
     private router: Router,
-    @Optional() private portalService: SidebarActionPortalService
+    @Optional() private portalService: SidebarActionPortalService,
   ) {
     this.data.setCurrentFolder(
       new FolderVO({
         displayName: 'Archives',
         pathAsText: ['Archives'],
         type: 'page',
-      })
+      }),
     );
     this.currentArchive = accountService.getArchive();
 
@@ -69,7 +67,7 @@ export class AllArchivesComponent implements OnInit, AfterViewInit, OnDestroy {
       archivesData.map((archiveData) => {
         return new ArchiveVO(archiveData);
       }),
-      'fullName'
+      'fullName',
     );
     const currentArchiveFetched = remove(archives, {
       archiveId: this.currentArchive.archiveId,
@@ -80,11 +78,9 @@ export class AllArchivesComponent implements OnInit, AfterViewInit, OnDestroy {
 
     [this.pendingArchives, this.archives] = partition(
       archives as ArchiveVO[],
-      (a) => a.isPending()
+      (a) => a.isPending(),
     );
   }
-
-  ngOnInit() {}
 
   ngAfterViewInit() {
     if (this.portalService) {
@@ -121,7 +117,7 @@ export class AllArchivesComponent implements OnInit, AfterViewInit, OnDestroy {
       message = `You have been invited to collaborate on the ${
         archive.fullName
       } archive. Accept ${this.prConstants.translate(
-        archive.accessRole
+        archive.accessRole,
       )} access and switch?`;
     }
 

--- a/src/app/core/components/archive-switcher/archive-switcher.component.ts
+++ b/src/app/core/components/archive-switcher/archive-switcher.component.ts
@@ -1,10 +1,5 @@
-import {
-  Component,
-  OnInit,
-  AfterViewInit,
-  QueryList,
-  ViewChildren,
-} from '@angular/core';
+/* @format */
+import { Component, AfterViewInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Validators } from '@angular/forms';
 
@@ -24,7 +19,6 @@ import { ArchiveVO, FolderVO } from '@root/app/models';
 import { BaseResponse } from '@shared/services/api/base';
 import { ApiService } from '@shared/services/api/api.service';
 import { ArchiveResponse } from '@shared/services/api/index.repo';
-import { FormInputSelectOption } from '@shared/components/form-input/form-input.component';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
 import { RELATIONSHIP_FIELD } from '@shared/components/prompt/prompt-fields';
 import { DataService } from '@shared/services/data/data.service';
@@ -34,7 +28,7 @@ import { DataService } from '@shared/services/data/data.service';
   templateUrl: './archive-switcher.component.html',
   styleUrls: ['./archive-switcher.component.scss'],
 })
-export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
+export class ArchiveSwitcherComponent implements AfterViewInit {
   public currentArchive: ArchiveVO;
   public archives: ArchiveVO[];
   constructor(
@@ -45,14 +39,14 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
     private route: ActivatedRoute,
     private prompt: PromptService,
     private message: MessageService,
-    private router: Router
+    private router: Router,
   ) {
     this.data.setCurrentFolder(
       new FolderVO({
         displayName: 'Archives',
         pathAsText: ['Archives'],
         type: 'page',
-      })
+      }),
     );
     this.currentArchive = accountService.getArchive();
 
@@ -61,7 +55,7 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
       archivesData.map((archiveData) => {
         return new ArchiveVO(archiveData);
       }),
-      'fullName'
+      'fullName',
     );
     const currentArchiveFetched = remove(archives, {
       archiveId: this.currentArchive.archiveId,
@@ -73,11 +67,9 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
     this.archives = archives as ArchiveVO[];
   }
 
-  ngOnInit() {}
-
   ngAfterViewInit() {
     const targetElems = document.querySelectorAll(
-      '.archive-list pr-archive-small'
+      '.archive-list pr-archive-small',
     );
     gsap.from(targetElems, {
       duration: 0.75,
@@ -112,7 +104,7 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
       message = `You have been invited to collaborate on the ${
         archive.fullName
       } archive. Accept ${this.prConstants.translate(
-        archive.accessRole
+        archive.accessRole,
       )} access and switch?`;
     }
 

--- a/src/app/core/components/archive-type-change-dialog/archive-type-change-dialog.component.ts
+++ b/src/app/core/components/archive-type-change-dialog/archive-type-change-dialog.component.ts
@@ -1,6 +1,7 @@
+/* @format */
 import { Observable } from 'rxjs';
 import { ArchiveVO, ArchiveType } from '@models/archive-vo';
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -10,7 +11,7 @@ import { MessageService } from '@shared/services/message/message.service';
   templateUrl: './archive-type-change-dialog.component.html',
   styleUrls: ['./archive-type-change-dialog.component.scss'],
 })
-export class ArchiveTypeChangeDialogComponent implements OnInit {
+export class ArchiveTypeChangeDialogComponent {
   archive: ArchiveVO;
   archiveType: ArchiveType;
   archiveClose: Observable<void>;
@@ -20,14 +21,12 @@ export class ArchiveTypeChangeDialogComponent implements OnInit {
     private dialogRef: DialogRef,
     private api: ApiService,
     @Inject(DIALOG_DATA) public data: any,
-    private msg: MessageService
+    private msg: MessageService,
   ) {
     this.archive = this.data.archive;
     this.archiveType = this.data.archiveType;
     this.archiveClose = this.data.archiveClose;
   }
-
-  ngOnInit(): void {}
 
   public onDoneClick(): void {
     this.archiveClose.subscribe();

--- a/src/app/core/components/connections-dialog/connections-dialog.component.ts
+++ b/src/app/core/components/connections-dialog/connections-dialog.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import {
   Component,
   OnInit,
@@ -7,7 +8,6 @@ import {
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ApiService } from '@shared/services/api/api.service';
-import { DataService } from '@shared/services/data/data.service';
 import {
   PromptService,
   PromptButton,
@@ -60,7 +60,7 @@ export type ConnectionsTab = 'connections' | 'pending' | 'new';
   templateUrl: './connections-dialog.component.html',
   styleUrls: ['./connections-dialog.component.scss'],
 })
-export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
+export class ConnectionsDialogComponent implements IsTabbedDialog {
   connections: RelationVO[] = [];
   connectionRequests: RelationVO[] = [];
   sentConnectionsRequests: RelationVO[] = [];
@@ -73,7 +73,6 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
   constructor(
     private route: ActivatedRoute,
     private api: ApiService,
-    private dataService: DataService,
     private promptService: PromptService,
     private messageService: MessageService,
     private prConstants: PrConstantsService,
@@ -81,7 +80,7 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
     private relationService: RelationshipService,
     private dialog: Dialog,
     @Inject(DIALOG_DATA) public data: any,
-    private dialogRef: DialogRef
+    private dialogRef: DialogRef,
   ) {
     this.data.connections.map((relation: RelationVO) => {
       if (relation.status.includes('ok')) {
@@ -116,8 +115,6 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
     }
   }
 
-  ngOnInit(): void {}
-
   onDoneClick(): void {
     this.dialogRef.close();
   }
@@ -132,7 +129,7 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
     this.promptService
       .promptButtons(
         buttons,
-        `Relationship with ${relation.RelationArchiveVO.fullName}`
+        `Relationship with ${relation.RelationArchiveVO.fullName}`,
       )
       .then((value: string) => {
         switch (value) {
@@ -152,7 +149,7 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
     this.promptService
       .promptButtons(
         buttons,
-        `Relationship with ${relation.RelationArchiveVO.fullName}`
+        `Relationship with ${relation.RelationArchiveVO.fullName}`,
       )
       .then((value: string) => {
         switch (value) {
@@ -172,7 +169,7 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
         `Accept relationship with ${relation.ArchiveVO.fullName}?`,
         deferred.promise,
         'Accept',
-        skipDecline ? 'Cancel' : 'Decline'
+        skipDecline ? 'Cancel' : 'Decline',
       )
       .then((value) => {
         const relationMyVo = new RelationVO({
@@ -253,7 +250,7 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
         fields,
         `Relationship with ${relation.RelationArchiveVO.fullName}`,
         deferred.promise,
-        'Save'
+        'Save',
       )
       .then((value) => {
         updatedRelation = new RelationVO({
@@ -310,7 +307,7 @@ export class ConnectionsDialogComponent implements OnInit, IsTabbedDialog {
         confirmText,
         confirmTitle,
         deferred.promise,
-        'btn-danger'
+        'btn-danger',
       );
       const response = await this.relationService.remove(relation);
       this.messageService.showMessage({

--- a/src/app/core/components/folder-picker/folder-picker.component.ts
+++ b/src/app/core/components/folder-picker/folder-picker.component.ts
@@ -1,11 +1,8 @@
+/* @format */
 import { Component, OnInit, OnDestroy } from '@angular/core';
-
-import { find, remove } from 'lodash';
-
+import { remove } from 'lodash';
 import { Deferred } from '@root/vendor/deferred';
-
 import { DataService } from '@shared/services/data/data.service';
-
 import { FolderVO, ItemVO, RecordVO } from '@root/app/models/index';
 import { ApiService } from '@shared/services/api/api.service';
 import { FolderResponse } from '@shared/services/api/index.repo';
@@ -25,7 +22,7 @@ export enum FolderPickerOperations {
   templateUrl: './folder-picker.component.html',
   styleUrls: ['./folder-picker.component.scss'],
 })
-export class FolderPickerComponent implements OnInit, OnDestroy {
+export class FolderPickerComponent implements OnDestroy {
   public currentFolder: FolderVO;
   public chooseFolderDeferred: Deferred;
   public operation: FolderPickerOperations;
@@ -49,19 +46,17 @@ export class FolderPickerComponent implements OnInit, OnDestroy {
     private api: ApiService,
     private message: MessageService,
     private folderPickerService: FolderPickerService,
-    private prompt: PromptService
+    private prompt: PromptService,
   ) {
     this.folderPickerService.registerComponent(this);
   }
-
-  ngOnInit() {}
 
   show(
     startingFolder: FolderVO,
     operation: FolderPickerOperations,
     savePromise?: Promise<any>,
     filterFolderLinkIds: number[] = null,
-    allowRecords = false
+    allowRecords = false,
   ) {
     if (this.cancelResetTimeout) {
       clearTimeout(this.cancelResetTimeout);
@@ -126,26 +121,26 @@ export class FolderPickerComponent implements OnInit, OnDestroy {
             folder_linkId: folder.folder_linkId,
             folderId: folder.folderId,
             archiveNbr: folder.archiveNbr,
-          })
+          }),
         )
         .toPromise();
       this.currentFolder = folderResponse.getFolderVO(true);
       this.isRootFolder = this.currentFolder.type.includes(
-        'type.folder.root.root'
+        'type.folder.root.root',
       );
       if (!this.allowRecords) {
         remove(this.currentFolder.ChildItemVOs, 'isRecord');
       }
       if (this.filterFolderLinkIds && this.filterFolderLinkIds.length) {
         remove(this.currentFolder.ChildItemVOs, (f: ItemVO) =>
-          this.filterFolderLinkIds.includes(f.folder_linkId)
+          this.filterFolderLinkIds.includes(f.folder_linkId),
         );
       }
       remove(this.currentFolder.ChildItemVOs, (item) =>
-        item.type.includes('type.folder.root.app')
+        item.type.includes('type.folder.root.app'),
       );
       remove(this.currentFolder.ChildItemVOs, (item) =>
-        item.type.includes('type.folder.root.vault')
+        item.type.includes('type.folder.root.vault'),
       );
     } catch (err) {
       if (err instanceof FolderResponse) {
@@ -177,7 +172,7 @@ export class FolderPickerComponent implements OnInit, OnDestroy {
   loadCurrentFolderChildData() {
     return this.dataService.fetchLeanItems(
       this.currentFolder.ChildItemVOs,
-      this.currentFolder
+      this.currentFolder,
     );
   }
 
@@ -186,7 +181,7 @@ export class FolderPickerComponent implements OnInit, OnDestroy {
       this.prompt
         .confirm(
           'Yes',
-          `This folder is publicly accessible by others. Are you sure you would like to ${this.operationName.toLocaleLowerCase()} to this location?`
+          `This folder is publicly accessible by others. Are you sure you would like to ${this.operationName.toLocaleLowerCase()} to this location?`,
         )
         .then(() => {
           this.setChosenFolder();

--- a/src/app/core/components/main/main.component.ts
+++ b/src/app/core/components/main/main.component.ts
@@ -2,7 +2,6 @@
 import {
   Component,
   OnInit,
-  OnDestroy,
   AfterViewInit,
   ViewChild,
   ElementRef,
@@ -55,7 +54,6 @@ export class MainComponent
   implements
     OnInit,
     AfterViewInit,
-    OnDestroy,
     DraggableComponent,
     DragTargetDroppableComponent
 {
@@ -155,8 +153,6 @@ export class MainComponent
     }
     this.checkCta();
   }
-
-  ngOnDestroy() {}
 
   ngAfterViewInit() {
     this.checkShareByUrl();

--- a/src/app/core/components/manage-tags/manage-tags.component.ts
+++ b/src/app/core/components/manage-tags/manage-tags.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+/* @format */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TagVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
@@ -6,9 +7,9 @@ import { PromptService } from '@shared/services/prompt/prompt.service';
 @Component({
   selector: 'pr-manage-tags',
   templateUrl: './manage-tags.component.html',
-  styleUrls: ['./manage-tags.component.scss']
+  styleUrls: ['./manage-tags.component.scss'],
 })
-export class ManageTagsComponent implements OnInit {
+export class ManageTagsComponent {
   @Input() tags: TagVO[] = [];
   @Output() refreshTags = new EventEmitter<void>();
 
@@ -18,18 +19,19 @@ export class ManageTagsComponent implements OnInit {
 
   constructor(
     private api: ApiService,
-    private prompt: PromptService
-  ) { }
-
-  ngOnInit(): void {
-  }
+    private prompt: PromptService,
+  ) {}
 
   public getFilteredTags(): TagVO[] {
-    return this.tags.filter((t) =>
-      t.name.toLocaleLowerCase().includes(
-        this.filter.trim().toLocaleLowerCase()
-      ) && !t.isCustomMetadata()
-    ).sort((a, b) => a.name.localeCompare(b.name));
+    return this.tags
+      .filter(
+        (t) =>
+          t.name
+            .toLocaleLowerCase()
+            .includes(this.filter.trim().toLocaleLowerCase()) &&
+          !t.isCustomMetadata(),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   public getTagCount(): number {
@@ -48,28 +50,28 @@ export class ManageTagsComponent implements OnInit {
 
   public async deleteTag(tag: TagVO): Promise<void> {
     return this.prompt
-    .confirm(
-      'Delete',
-      'Are you sure you want to delete this tag from all items in the current archive?'
-    )
-    .then(async () => {
-      this.tags = this.tags.filter((t) => t.tagId !== tag.tagId);
-      return this.api.tag
-        .delete(tag)
-        .then(() => {
-          this.refreshTags.emit();
-        })
-        .catch(() => {
-          // Let's add the tag back to UI to show it isn't deleted.
-          this.tags.push(tag);
-          throw new Error('Manage Tags: Error accessing delete endpoint');
-        });
-    })
-    .catch((e: Error) => {
-      if (e) {
-        throw new Error(e.message);
-      }
-    });
+      .confirm(
+        'Delete',
+        'Are you sure you want to delete this tag from all items in the current archive?',
+      )
+      .then(async () => {
+        this.tags = this.tags.filter((t) => t.tagId !== tag.tagId);
+        return this.api.tag
+          .delete(tag)
+          .then(() => {
+            this.refreshTags.emit();
+          })
+          .catch(() => {
+            // Let's add the tag back to UI to show it isn't deleted.
+            this.tags.push(tag);
+            throw new Error('Manage Tags: Error accessing delete endpoint');
+          });
+      })
+      .catch((e: Error) => {
+        if (e) {
+          throw new Error(e.message);
+        }
+      });
   }
 
   public isEditingTag(tag: TagVO): boolean {

--- a/src/app/core/components/members-dialog/members-dialog.component.ts
+++ b/src/app/core/components/members-dialog/members-dialog.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Inject } from '@angular/core';
+/* @format */
+import { Component, Inject } from '@angular/core';
 import {
   DIALOG_DATA,
   DialogRef,
@@ -43,7 +44,7 @@ type MembersTab = 'members' | 'pending' | 'add';
   templateUrl: './members-dialog.component.html',
   styleUrls: ['./members-dialog.component.scss'],
 })
-export class MembersDialogComponent implements OnInit, IsTabbedDialog {
+export class MembersDialogComponent implements IsTabbedDialog {
   members: AccountVO[];
   pendingMembers: AccountVO[];
   canEdit: boolean;
@@ -57,17 +58,15 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
     private message: MessageService,
     private api: ApiService,
     private accountService: AccountService,
-    private payerService: PayerService
+    private payerService: PayerService,
   ) {
     [this.members, this.pendingMembers] = partition(this.data.members, {
       status: 'status.generic.ok',
     });
     this.canEdit = this.accountService.checkMinimumArchiveAccess(
-      AccessRole.Manager
+      AccessRole.Manager,
     );
   }
-
-  ngOnInit(): void {}
 
   setTab(tab: MembersTab) {
     this.activeTab = tab;
@@ -103,7 +102,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
     const value: any = await this.promptService.prompt(
       fields,
       `Edit access for ${member.fullName}`,
-      deferred.promise
+      deferred.promise,
     );
     const updatedMember = clone(member);
     updatedMember.accessRole = value.accessRole as AccessRoleType;
@@ -113,7 +112,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
         await this.confirmOwnershipTransfer();
         const response = await this.api.archive.transferOwnership(
           updatedMember,
-          this.accountService.getArchive()
+          this.accountService.getArchive(),
         );
         this.message.showMessage({
           message: 'Ownership transfer request sent.',
@@ -125,7 +124,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
       } else {
         const response = await this.api.archive.updateMember(
           updatedMember,
-          this.accountService.getArchive()
+          this.accountService.getArchive(),
         );
         this.message.showMessage({
           message: 'Member access saved successfully.',
@@ -153,7 +152,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
       .then(() => {
         return this.api.archive.removeMember(
           member,
-          this.accountService.getArchive()
+          this.accountService.getArchive(),
         );
       })
       .then((response: ArchiveResponse) => {
@@ -194,10 +193,10 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
           'Add Member',
           null,
           null,
-          `You do not have permission to add members to this archive.`
+          `You do not have permission to add members to this archive.`,
         );
         window.open(
-          'https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing'
+          'https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing',
         );
       } catch {
         // Catch PromptService rejection, but do nothing on "Cancel" button press
@@ -225,7 +224,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
     const value = await this.promptService.prompt(
       fields,
       'Add member',
-      deferred.promise
+      deferred.promise,
     );
     member = value as AccountVO;
 
@@ -273,7 +272,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
   confirmOwnershipTransfer() {
     return this.promptService.confirm(
       'Transfer ownership',
-      'Permanent Archives can only have one owner at a time. Once this is complete, your role will be changed to Manager'
+      'Permanent Archives can only have one owner at a time. Once this is complete, your role will be changed to Manager',
     );
   }
 
@@ -300,7 +299,7 @@ export class MembersDialogComponent implements OnInit, IsTabbedDialog {
         member.fullName = value.fullName;
         return this.api.invite.sendMemberInvite(
           member,
-          this.accountService.getArchive()
+          this.accountService.getArchive(),
         );
       })
       .then((response: InviteResponse) => {

--- a/src/app/core/components/multi-select-status/multi-select-status.component.ts
+++ b/src/app/core/components/multi-select-status/multi-select-status.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, HostBinding, OnDestroy } from '@angular/core';
+/* @format */
+import { Component, HostBinding, OnDestroy } from '@angular/core';
 import { DataService } from '@shared/services/data/data.service';
 import { Subscription } from 'rxjs';
 import { ItemVO } from '@models';
@@ -8,9 +9,9 @@ import { PromptButton } from '@shared/services/prompt/prompt.service';
 @Component({
   selector: 'pr-multi-select-status',
   templateUrl: './multi-select-status.component.html',
-  styleUrls: ['./multi-select-status.component.scss']
+  styleUrls: ['./multi-select-status.component.scss'],
 })
-export class MultiSelectStatusComponent implements OnInit, OnDestroy {
+export class MultiSelectStatusComponent implements OnDestroy {
   @HostBinding('class.visible') isMultiSelectEnabled = false;
   isMultiSelectEnabledSubscription: Subscription;
 
@@ -18,15 +19,13 @@ export class MultiSelectStatusComponent implements OnInit, OnDestroy {
 
   constructor(
     private data: DataService,
-    private edit: EditService
+    private edit: EditService,
   ) {
     this.multiclickItems = this.data.multiclickItems;
-    this.isMultiSelectEnabledSubscription = this.data.multiSelectChange.subscribe(enabled => {
-      this.isMultiSelectEnabled = enabled;
-    });
-  }
-
-  ngOnInit() {
+    this.isMultiSelectEnabledSubscription =
+      this.data.multiSelectChange.subscribe((enabled) => {
+        this.isMultiSelectEnabled = enabled;
+      });
   }
 
   ngOnDestroy() {
@@ -35,7 +34,7 @@ export class MultiSelectStatusComponent implements OnInit, OnDestroy {
 
   onDoneClick() {
     const items: ItemVO[] = [];
-    this.multiclickItems.forEach(i => items.push(i));
+    this.multiclickItems.forEach((i) => items.push(i));
     this.data.setMultiSelect(false);
 
     const actions: PromptButton[] = [
@@ -45,11 +44,10 @@ export class MultiSelectStatusComponent implements OnInit, OnDestroy {
       {
         buttonName: 'cancel',
         buttonText: 'Cancel',
-        class: 'btn-secondary'
-      }
+        class: 'btn-secondary',
+      },
     ];
 
     this.edit.promptForAction(items, actions);
   }
-
 }

--- a/src/app/core/components/nav/nav.component.ts
+++ b/src/app/core/components/nav/nav.component.ts
@@ -1,7 +1,6 @@
 /* @format */
 import {
   Component,
-  OnInit,
   AfterViewInit,
   ViewChild,
   Optional,
@@ -11,8 +10,6 @@ import { SidebarActionPortalService } from '@core/services/sidebar-action-portal
 import { CdkPortalOutlet } from '@angular/cdk/portal';
 import { NotificationService } from '@root/app/notifications/services/notification.service';
 import { Dialog } from '@root/app/dialog/dialog.module';
-import { DeviceService } from '@shared/services/device/device.service';
-import { AccountService } from '@shared/services/account/account.service';
 import { EventService } from '@shared/services/event/event.service';
 
 @Component({
@@ -20,7 +17,7 @@ import { EventService } from '@shared/services/event/event.service';
   templateUrl: './nav.component.html',
   styleUrls: ['./nav.component.scss'],
 })
-export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
+export class NavComponent implements AfterViewInit, OnDestroy {
   hambugerMenuVisible: boolean;
   rightMenuVisible: boolean;
 
@@ -32,8 +29,6 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
     @Optional() public notificationService: NotificationService,
     @Optional() private dialog: Dialog,
   ) {}
-
-  ngOnInit() {}
 
   ngAfterViewInit() {
     if (this.portalService) {

--- a/src/app/core/components/notification-preferences/notification-preferences.component.ts
+++ b/src/app/core/components/notification-preferences/notification-preferences.component.ts
@@ -1,7 +1,8 @@
+/* @format */
 import { Component, OnInit } from '@angular/core';
 import { AccountService } from '@shared/services/account/account.service';
 import { DataService } from '@shared/services/data/data.service';
-import { FolderVO, AccountVO, NotificationPreferencesI } from '@models';
+import { AccountVO, NotificationPreferencesI } from '@models';
 import { cloneDeep } from 'lodash';
 import { ApiService } from '@shared/services/api/api.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -9,29 +10,27 @@ import { MessageService } from '@shared/services/message/message.service';
 @Component({
   selector: 'pr-notification-preferences',
   templateUrl: './notification-preferences.component.html',
-  styleUrls: ['./notification-preferences.component.scss']
+  styleUrls: ['./notification-preferences.component.scss'],
 })
-export class NotificationPreferencesComponent implements OnInit {
+export class NotificationPreferencesComponent {
   public account: AccountVO;
   public preferences: NotificationPreferencesI;
   constructor(
     private accountService: AccountService,
     private dataService: DataService,
     private api: ApiService,
-    private message: MessageService
+    private message: MessageService,
   ) {
     this.account = this.accountService.getAccount();
     this.preferences = cloneDeep(this.account.notificationPreferences);
   }
 
-  ngOnInit(): void {
-  }
-
   async onPreferenceChange(path: string[], value: boolean) {
-    const response = await this.api.account.updateNotificationPreference(path.join('.'), value);
+    const response = await this.api.account.updateNotificationPreference(
+      path.join('.'),
+      value,
+    );
     if (response.isSuccessful) {
-
     }
   }
-
 }

--- a/src/app/core/components/upload-button/upload-button.component.ts
+++ b/src/app/core/components/upload-button/upload-button.component.ts
@@ -1,12 +1,10 @@
 /* @format */
 import {
   Component,
-  OnInit,
   OnDestroy,
   ViewChild,
   ElementRef,
   Input,
-  Optional,
   HostBinding,
 } from '@angular/core';
 import { UploadService } from '@core/services/upload/upload.service';
@@ -30,9 +28,7 @@ import { EventService } from '@shared/services/event/event.service';
   templateUrl: './upload-button.component.html',
   styleUrls: ['./upload-button.component.scss'],
 })
-export class UploadButtonComponent
-  implements OnInit, OnDestroy, HasSubscriptions
-{
+export class UploadButtonComponent implements OnDestroy, HasSubscriptions {
   private files: File[];
   @Input() fullWidth: boolean;
 
@@ -63,8 +59,6 @@ export class UploadButtonComponent
 
     this.upload.registerButtonComponent(this);
   }
-
-  ngOnInit() {}
 
   ngOnDestroy() {
     this.upload.unregisterButtonComponent(this);

--- a/src/app/dialog/dialog.component.ts
+++ b/src/app/dialog/dialog.component.ts
@@ -4,7 +4,6 @@ import {
   ViewContainerRef,
   ViewChild,
   ElementRef,
-  AfterViewInit,
 } from '@angular/core';
 import { DeviceService } from '@shared/services/device/device.service';
 import { DialogOptions, DialogRef } from './dialog.service';
@@ -14,7 +13,7 @@ import { DialogOptions, DialogRef } from './dialog.service';
   templateUrl: './dialog.component.html',
   styleUrls: ['./dialog.component.scss'],
 })
-export class DialogComponent implements AfterViewInit {
+export class DialogComponent {
   public isVisible = false;
   public height = 'fullscreen';
   public width = 'fullscreen';
@@ -31,8 +30,6 @@ export class DialogComponent implements AfterViewInit {
   menuWrapperElement: ElementRef;
 
   constructor(private device: DeviceService) {}
-
-  ngAfterViewInit() {}
 
   bindDialogRef(dialogRef: DialogRef) {
     if (!this.dialogRef) {

--- a/src/app/embed/components/forgot-password-embed/forgot-password-embed.component.ts
+++ b/src/app/embed/components/forgot-password-embed/forgot-password-embed.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
@@ -13,7 +13,7 @@ import { AuthResponse } from '@shared/services/api/auth.repo';
   templateUrl: './forgot-password-embed.component.html',
   styleUrls: ['./forgot-password-embed.component.scss'],
 })
-export class ForgotPasswordEmbedComponent implements OnInit {
+export class ForgotPasswordEmbedComponent {
   forgotForm: UntypedFormGroup;
   formErrors: any = {};
 
@@ -21,16 +21,14 @@ export class ForgotPasswordEmbedComponent implements OnInit {
   success: boolean;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private api: ApiService,
-    private message: MessageService
+    private message: MessageService,
   ) {
     this.forgotForm = fb.group({
       email: ['', [Validators.required, Validators.email]],
     });
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;

--- a/src/app/embed/components/login-embed/login-embed.component.ts
+++ b/src/app/embed/components/login-embed/login-embed.component.ts
@@ -1,21 +1,15 @@
 /* @format */
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
   Validators,
-  FormControl,
 } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-
 import { APP_CONFIG } from '@root/app/app.config';
-import { matchControlValidator } from '@shared/utilities/forms';
-
 import { AccountService } from '@shared/services/account/account.service';
 import { AuthResponse } from '@shared/services/api/auth.repo';
 import { MessageService } from '@shared/services/message/message.service';
-import { AccountResponse } from '@shared/services/api/index.repo';
-
 import * as FormUtilities from '@shared/utilities/forms';
 import { IFrameService } from '@shared/services/iframe/iframe.service';
 
@@ -26,7 +20,7 @@ const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
   templateUrl: './login-embed.component.html',
   styleUrls: ['./login-embed.component.scss'],
 })
-export class LoginEmbedComponent implements OnInit {
+export class LoginEmbedComponent {
   @HostBinding('class.pr-auth-form') classBinding = true;
   loginForm: UntypedFormGroup;
   waiting: boolean;
@@ -68,8 +62,6 @@ export class LoginEmbedComponent implements OnInit {
       this.iFrame.setParentUrl('/app');
     }
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;

--- a/src/app/embed/components/mfa-embed/mfa-embed.component.ts
+++ b/src/app/embed/components/mfa-embed/mfa-embed.component.ts
@@ -1,11 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+/* @format */
+import { Component } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
   Validators,
 } from '@angular/forms';
-import { Router } from '@angular/router';
-
 import { AccountService } from '@shared/services/account/account.service';
 import { MessageService } from '@shared/services/message/message.service';
 import {
@@ -20,23 +19,20 @@ import { IFrameService } from '@shared/services/iframe/iframe.service';
   templateUrl: './mfa-embed.component.html',
   styleUrls: ['./mfa-embed.component.scss'],
 })
-export class MfaEmbedComponent implements OnInit {
+export class MfaEmbedComponent {
   verifyForm: UntypedFormGroup;
   waiting: boolean;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private accountService: AccountService,
-    private router: Router,
     private message: MessageService,
-    private iFrame: IFrameService
+    private iFrame: IFrameService,
   ) {
     this.verifyForm = fb.group({
       token: ['', Validators.required],
     });
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;
@@ -46,7 +42,7 @@ export class MfaEmbedComponent implements OnInit {
       .then(() => {
         return this.accountService.switchToDefaultArchive();
       })
-      .then((response: ArchiveResponse) => {
+      .then((_: ArchiveResponse) => {
         this.waiting = false;
         this.iFrame.setParentUrl('/app');
       })

--- a/src/app/embed/components/signup-embed/signup-embed.component.ts
+++ b/src/app/embed/components/signup-embed/signup-embed.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
@@ -7,15 +7,11 @@ import {
   UntypedFormControl,
 } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-
 import { APP_CONFIG } from '@root/app/app.config';
 import { AccountVO } from '@root/app/models';
 import { matchControlValidator, trimWhitespace } from '@shared/utilities/forms';
-
 import { AccountService } from '@shared/services/account/account.service';
 import { MessageService } from '@shared/services/message/message.service';
-
-import * as FormUtilities from '@shared/utilities/forms';
 
 const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
 
@@ -24,7 +20,7 @@ const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
   templateUrl: './signup-embed.component.html',
   styleUrls: ['./signup-embed.component.scss'],
 })
-export class SignupEmbedComponent implements OnInit {
+export class SignupEmbedComponent {
   @HostBinding('class.pr-auth-form') classBinding = true;
   signupForm: UntypedFormGroup;
   waiting: boolean;
@@ -39,7 +35,7 @@ export class SignupEmbedComponent implements OnInit {
   };
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private accountService: AccountService,
     private router: Router,
     private route: ActivatedRoute,
@@ -68,8 +64,6 @@ export class SignupEmbedComponent implements OnInit {
     ]);
     this.signupForm.addControl('confirm', confirmPasswordControl);
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;

--- a/src/app/embed/components/verify-embed/verify-embed.component.ts
+++ b/src/app/embed/components/verify-embed/verify-embed.component.ts
@@ -1,15 +1,13 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
   Validators,
 } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-
 import { AccountService } from '@shared/services/account/account.service';
 import { MessageService } from '@shared/services/message/message.service';
 import {
-  AuthResponse,
   ArchiveResponse,
   AccountResponse,
 } from '@shared/services/api/index.repo';
@@ -19,23 +17,21 @@ import {
   templateUrl: './verify-embed.component.html',
   styleUrls: ['./verify-embed.component.scss'],
 })
-export class VerifyEmbedComponent implements OnInit {
+export class VerifyEmbedComponent {
   verifyForm: UntypedFormGroup;
   waiting: boolean;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private accountService: AccountService,
     private router: Router,
     private message: MessageService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) {
     this.verifyForm = fb.group({
       token: ['', Validators.required],
     });
   }
-
-  ngOnInit() {}
 
   onSubmit(formValue: any) {
     this.waiting = true;
@@ -45,7 +41,7 @@ export class VerifyEmbedComponent implements OnInit {
       .then(() => {
         return this.accountService.switchToDefaultArchive();
       })
-      .then((response: ArchiveResponse) => {
+      .then((_: ArchiveResponse) => {
         this.waiting = false;
         this.router.navigate(['..', 'done'], { relativeTo: this.route });
       })

--- a/src/app/file-browser/components/download-button/download-button.component.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.ts
@@ -2,7 +2,6 @@
 import {
   Component,
   Input,
-  OnInit,
   ElementRef,
   ViewChild,
   HostListener,
@@ -21,7 +20,7 @@ interface Format {
   templateUrl: './download-button.component.html',
   styleUrls: ['./download-button.component.scss'],
 })
-export class DownloadButtonComponent implements OnInit {
+export class DownloadButtonComponent {
   @Input() selectedItem;
 
   displayDownloadDropdown = false;
@@ -36,8 +35,6 @@ export class DownloadButtonComponent implements OnInit {
     private data: DataService,
     private message: MessageService,
   ) {}
-
-  ngOnInit(): void {}
 
   @HostListener('document:click', ['$event'])
   handleClickOutside(event) {

--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
@@ -1,7 +1,6 @@
 /* @format */
 import {
   Component,
-  OnInit,
   OnDestroy,
   EventEmitter,
   Output,
@@ -17,15 +16,11 @@ import {
   unsubscribeAll,
 } from '@shared/utilities/hasSubscriptions';
 import { Subscription, Subject } from 'rxjs';
-import { min, get } from 'lodash';
+import { min } from 'lodash';
 import { AccountService } from '@shared/services/account/account.service';
 import { ItemVO, AccessRole, SortType, FolderVO, RecordVO } from '@models';
 import { getAccessAsEnum } from '@models/access-role';
-import { fadeAnimation, ngIfFadeInAnimation } from '@shared/animations';
-import {
-  FolderResponse,
-  RecordResponse,
-} from '@shared/services/api/index.repo';
+import { ngIfFadeInAnimation } from '@shared/animations';
 import { EditService } from '@core/services/edit/edit.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
@@ -60,9 +55,7 @@ type FileListColumn = 'name' | 'date' | 'type';
   styleUrls: ['./file-list-controls.component.scss'],
   animations: [ngIfFadeInAnimation],
 })
-export class FileListControlsComponent
-  implements OnInit, OnDestroy, HasSubscriptions
-{
+export class FileListControlsComponent implements OnDestroy, HasSubscriptions {
   public isSorting$ = new Subject<boolean>();
 
   @Input() allowSort = true;
@@ -138,8 +131,6 @@ export class FileListControlsComponent
       }),
     );
   }
-
-  ngOnInit(): void {}
 
   ngOnDestroy() {
     unsubscribeAll(this.subscriptions);

--- a/src/app/file-browser/components/folder-description/folder-description.component.ts
+++ b/src/app/file-browser/components/folder-description/folder-description.component.ts
@@ -1,17 +1,14 @@
-import { Component, OnInit, Input } from '@angular/core';
+/* @format */
+import { Component, Input } from '@angular/core';
 import { FolderVO } from '@models';
 
 @Component({
   selector: 'pr-folder-description',
   templateUrl: './folder-description.component.html',
-  styleUrls: ['./folder-description.component.scss']
+  styleUrls: ['./folder-description.component.scss'],
 })
-export class FolderDescriptionComponent implements OnInit {
+export class FolderDescriptionComponent {
   @Input() folder: FolderVO;
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  constructor() {}
 }

--- a/src/app/file-browser/components/folder-view/folder-view.component.ts
+++ b/src/app/file-browser/components/folder-view/folder-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+/* @format */
+import { Component, OnDestroy } from '@angular/core';
 import { DataService } from '@shared/services/data/data.service';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
 import { Subscription } from 'rxjs';
@@ -6,27 +7,23 @@ import { Subscription } from 'rxjs';
 @Component({
   selector: 'pr-folder-view',
   templateUrl: './folder-view.component.html',
-  styleUrls: ['./folder-view.component.scss']
+  styleUrls: ['./folder-view.component.scss'],
 })
-export class FolderViewComponent implements OnInit, OnDestroy {
+export class FolderViewComponent implements OnDestroy {
   public currentView: FolderView;
   private dataServiceSubscription: Subscription;
-  constructor(
-    private data: DataService
-  ) {
+  constructor(private data: DataService) {
     if (this.data.currentFolder) {
       this.currentView = data.currentFolder.view;
     }
-    this.dataServiceSubscription = this.data.currentFolderChange.subscribe(folder => {
-      this.currentView = folder.view;
-    });
-  }
-
-  ngOnInit() {
+    this.dataServiceSubscription = this.data.currentFolderChange.subscribe(
+      (folder) => {
+        this.currentView = folder.view;
+      },
+    );
   }
 
   ngOnDestroy() {
     this.dataServiceSubscription.unsubscribe();
   }
-
 }

--- a/src/app/file-browser/components/publish/publish.component.ts
+++ b/src/app/file-browser/components/publish/publish.component.ts
@@ -1,11 +1,5 @@
 /* @format */
-import {
-  Component,
-  OnInit,
-  ViewChild,
-  ElementRef,
-  Inject,
-} from '@angular/core';
+import { Component, ViewChild, ElementRef, Inject } from '@angular/core';
 import { RecordVO, FolderVO } from '@models';
 import { DIALOG_DATA, DialogRef } from '@root/app/dialog/dialog.module';
 import { ApiService } from '@shared/services/api/api.service';
@@ -27,7 +21,7 @@ import { EventService } from '@shared/services/event/event.service';
   templateUrl: './publish.component.html',
   styleUrls: ['./publish.component.scss'],
 })
-export class PublishComponent implements OnInit {
+export class PublishComponent {
   public sourceItem: RecordVO | FolderVO = null;
   public publicItem: RecordVO | FolderVO = null;
 
@@ -66,8 +60,6 @@ export class PublishComponent implements OnInit {
       this.checkInternetArchiveLink();
     }
   }
-
-  ngOnInit() {}
 
   async publishItem() {
     if (this.sourceItem.type.includes('public')) {

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import { RecordVO } from '@root/app/models';
 import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { DataService } from '@shared/services/data/data.service';
@@ -20,7 +21,7 @@ type SidebarTab = 'info' | 'details' | 'sharing' | 'views';
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss'],
 })
-export class SidebarComponent implements OnInit, OnDestroy, HasSubscriptions {
+export class SidebarComponent implements OnDestroy, HasSubscriptions {
   currentTab: SidebarTab = 'info';
   selectedItem: ItemVO = this.dataService.currentFolder;
   selectedItems: ItemVO[];
@@ -44,7 +45,7 @@ export class SidebarComponent implements OnInit, OnDestroy, HasSubscriptions {
     private dataService: DataService,
     private editService: EditService,
     private accountService: AccountService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
   ) {
     this.currentArchive = this.accountService.getArchive();
 
@@ -95,14 +96,14 @@ export class SidebarComponent implements OnInit, OnDestroy, HasSubscriptions {
           this.selectedItem.FileVOs[0]
         ) {
           this.originalFileExtension = this.selectedItem.FileVOs.find(
-            (item) => item.format === 'file.format.original'
+            (item) => item.format === 'file.format.original',
           )
             ?.type.split('.')
             .pop();
 
           this.permanentFileExtension =
             this.selectedItem.FileVOs.find(
-              (item) => item.format === 'file.format.converted'
+              (item) => item.format === 'file.format.converted',
             )
               ?.type.split('.')
               .pop() || this.originalFileExtension;
@@ -110,11 +111,9 @@ export class SidebarComponent implements OnInit, OnDestroy, HasSubscriptions {
           this.originalFileExtension = '';
           this.permanentFileExtension = '';
         }
-      })
+      }),
     );
   }
-
-  ngOnInit() {}
 
   ngOnDestroy() {
     unsubscribeAll(this.subscriptions);
@@ -126,7 +125,7 @@ export class SidebarComponent implements OnInit, OnDestroy, HasSubscriptions {
       items,
       (i) =>
         i.accessRole === 'access.role.viewer' ||
-        i.accessRole === 'access.role.contributor'
+        i.accessRole === 'access.role.contributor',
     );
 
     this.canEdit =
@@ -141,7 +140,7 @@ export class SidebarComponent implements OnInit, OnDestroy, HasSubscriptions {
         !this.isRootFolder &&
         this.accountService.checkMinimumAccess(
           this.selectedItem.accessRole,
-          AccessRole.Owner
+          AccessRole.Owner,
         );
     }
   }

--- a/src/app/gallery/components/gallery-header/gallery-header.component.ts
+++ b/src/app/gallery/components/gallery-header/gallery-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { AccountService } from '@shared/services/account/account.service';
 
 @Component({
@@ -6,12 +6,10 @@ import { AccountService } from '@shared/services/account/account.service';
   templateUrl: './gallery-header.component.html',
   styleUrls: ['./gallery-header.component.scss'],
 })
-export class GalleryHeaderComponent implements OnInit {
+export class GalleryHeaderComponent {
   public isLoggedIn: boolean;
 
   constructor(protected account: AccountService) {
     this.isLoggedIn = this.account.isLoggedIn();
   }
-
-  ngOnInit(): void {}
 }

--- a/src/app/notifications/components/notification-dialog/notification-dialog.component.ts
+++ b/src/app/notifications/components/notification-dialog/notification-dialog.component.ts
@@ -1,6 +1,17 @@
-import { Component, OnInit, Inject, ViewChildren, AfterViewInit, OnDestroy, ElementRef, QueryList } from '@angular/core';
+/* @format */
+import {
+  Component,
+  Inject,
+  ViewChildren,
+  AfterViewInit,
+  OnDestroy,
+  QueryList,
+} from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@root/app/dialog/dialog.module';
-import { HasSubscriptions, unsubscribeAll } from '@shared/utilities/hasSubscriptions';
+import {
+  HasSubscriptions,
+  unsubscribeAll,
+} from '@shared/utilities/hasSubscriptions';
 import { Subscription } from 'rxjs';
 import { NotificationVOData } from '@models/notification-vo';
 import { NotificationComponent } from '../notification/notification.component';
@@ -9,21 +20,20 @@ import { NotificationService } from '../../services/notification.service';
 @Component({
   selector: 'pr-notification-dialog',
   templateUrl: './notification-dialog.component.html',
-  styleUrls: ['./notification-dialog.component.scss']
+  styleUrls: ['./notification-dialog.component.scss'],
 })
-export class NotificationDialogComponent implements OnInit, AfterViewInit, OnDestroy, HasSubscriptions {
-  @ViewChildren(NotificationComponent) notificationComponents: QueryList<NotificationComponent>;
+export class NotificationDialogComponent
+  implements AfterViewInit, OnDestroy, HasSubscriptions
+{
+  @ViewChildren(NotificationComponent)
+  notificationComponents: QueryList<NotificationComponent>;
 
   subscriptions: Subscription[] = [];
   constructor(
     @Inject(DIALOG_DATA) public data: any,
     private dialogRef: DialogRef,
-    public notificationService: NotificationService
-  ) {
-  }
-
-  ngOnInit(): void {
-  }
+    public notificationService: NotificationService,
+  ) {}
 
   ngAfterViewInit(): void {
     this.markNewAsSeen();

--- a/src/app/onboarding/components/welcome-screen/welcome-screen.component.ts
+++ b/src/app/onboarding/components/welcome-screen/welcome-screen.component.ts
@@ -1,6 +1,5 @@
 /* @format */
-import { Dialog } from '@root/app/dialog/dialog.module';
-import { Component, EventEmitter, OnInit, Output, Input } from '@angular/core';
+import { Component, EventEmitter, Output, Input } from '@angular/core';
 import { OnboardingScreen } from '@onboarding/shared/onboarding-screen';
 import { ArchiveVO } from '@models/archive-vo';
 
@@ -9,7 +8,7 @@ import { ArchiveVO } from '@models/archive-vo';
   templateUrl: './welcome-screen.component.html',
   styleUrls: ['./welcome-screen.component.scss'],
 })
-export class WelcomeScreenComponent implements OnInit {
+export class WelcomeScreenComponent {
   @Input() pendingArchives: ArchiveVO[] = [];
   @Output() nextScreen = new EventEmitter<OnboardingScreen>();
   @Output() selectInvitation = new EventEmitter<ArchiveVO>();
@@ -20,8 +19,6 @@ export class WelcomeScreenComponent implements OnInit {
   public OnboardingScreen: typeof OnboardingScreen = OnboardingScreen;
 
   constructor() {}
-
-  ngOnInit(): void {}
 
   public goToScreen(screen: OnboardingScreen): void {
     this.nextScreen.emit(screen);

--- a/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts
+++ b/src/app/pledge/components/claim-storage-login/claim-storage-login.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { AccountService } from '@shared/services/account/account.service';
 import { Router, ActivatedRoute } from '@angular/router';
 import {
@@ -8,10 +8,8 @@ import {
   Validators,
 } from '@angular/forms';
 import { CookieService } from 'ngx-cookie-service';
-
 import { ApiService } from '@shared/services/api/api.service';
 import { PledgeService } from '@pledge/services/pledge.service';
-
 import { APP_CONFIG } from '@root/app/app.config';
 import {
   AuthResponse,
@@ -25,7 +23,7 @@ import { MessageService } from '@shared/services/message/message.service';
   templateUrl: './claim-storage-login.component.html',
   styleUrls: ['./claim-storage-login.component.scss'],
 })
-export class ClaimStorageLoginComponent implements OnInit {
+export class ClaimStorageLoginComponent {
   public waiting = false;
   public loggedIn = false;
   public needsMfa = false;
@@ -39,7 +37,7 @@ export class ClaimStorageLoginComponent implements OnInit {
     private pledgeService: PledgeService,
     private router: Router,
     private route: ActivatedRoute,
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private message: MessageService,
     private cookies: CookieService,
   ) {
@@ -72,8 +70,6 @@ export class ClaimStorageLoginComponent implements OnInit {
       token: [],
     });
   }
-
-  ngOnInit() {}
 
   async logOut() {
     this.waiting = true;

--- a/src/app/pledge/components/claim-storage/claim-storage.component.ts
+++ b/src/app/pledge/components/claim-storage/claim-storage.component.ts
@@ -1,11 +1,10 @@
 /* @format */
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
   Validators,
 } from '@angular/forms';
-
 import { APP_CONFIG } from '@root/app/app.config';
 import { AccountVO } from '@root/app/models';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -21,7 +20,7 @@ const MIN_PASSWORD_LENGTH = APP_CONFIG.passwordMinLength;
   templateUrl: './claim-storage.component.html',
   styleUrls: ['./claim-storage.component.scss'],
 })
-export class ClaimStorageComponent implements OnInit {
+export class ClaimStorageComponent {
   public signupForm: UntypedFormGroup;
   public pledge: PledgeData = this.pledgeService.currentPledgeData;
 
@@ -29,7 +28,7 @@ export class ClaimStorageComponent implements OnInit {
   public storageAmount: number;
 
   constructor(
-    private fb: UntypedFormBuilder,
+    fb: UntypedFormBuilder,
     private route: ActivatedRoute,
     private router: Router,
     private api: ApiService,
@@ -57,8 +56,6 @@ export class ClaimStorageComponent implements OnInit {
       optIn: [true],
     });
   }
-
-  ngOnInit() {}
 
   async onSubmit(formValue: any) {
     this.waiting = true;

--- a/src/app/pledge/components/missing-pledge/missing-pledge.component.ts
+++ b/src/app/pledge/components/missing-pledge/missing-pledge.component.ts
@@ -1,15 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+/* @format */
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'pr-missing-pledge',
   templateUrl: './missing-pledge.component.html',
-  styleUrls: ['./missing-pledge.component.scss']
+  styleUrls: ['./missing-pledge.component.scss'],
 })
-export class MissingPledgeComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+export class MissingPledgeComponent {
+  constructor() {}
 }

--- a/src/app/pledge/components/new-pledge/new-pledge.component.ts
+++ b/src/app/pledge/components/new-pledge/new-pledge.component.ts
@@ -5,7 +5,6 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  OnDestroy,
   Input,
 } from '@angular/core';
 import {
@@ -32,7 +31,7 @@ const elements = stripe.elements();
   templateUrl: './new-pledge.component.html',
   styleUrls: ['./new-pledge.component.scss'],
 })
-export class NewPledgeComponent implements OnInit, AfterViewInit, OnDestroy {
+export class NewPledgeComponent implements OnInit, AfterViewInit {
   @Input() inlineFlow: boolean = false;
   public waiting: boolean;
   public pledgeForm: UntypedFormGroup;
@@ -298,8 +297,6 @@ export class NewPledgeComponent implements OnInit, AfterViewInit, OnDestroy {
     const bytesInGiB = 1073741824;
     return Math.floor(amount / 10) * bytesInGiB;
   }
-
-  ngOnDestroy() {}
 }
 
 export interface PledgeData {

--- a/src/app/pledge/components/pledge/pledge.component.ts
+++ b/src/app/pledge/components/pledge/pledge.component.ts
@@ -1,15 +1,14 @@
+/* @format */
 import { Component, OnInit, HostBinding, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-
 import { IFrameService } from '@shared/services/iframe/iframe.service';
-
 
 @Component({
   selector: 'pr-pledge',
   templateUrl: './pledge.component.html',
-  styleUrls: ['./pledge.component.scss']
+  styleUrls: ['./pledge.component.scss'],
 })
-export class PledgeComponent implements OnInit, OnDestroy {
+export class PledgeComponent implements OnInit {
   @HostBinding('class.for-light-bg') forLightBg = true;
   @HostBinding('class.for-dark-bg') forDarkBg = false;
   @HostBinding('class.visible') visible = false;
@@ -26,8 +25,5 @@ export class PledgeComponent implements OnInit, OnDestroy {
     setTimeout(() => {
       this.visible = true;
     });
-  }
-
-  ngOnDestroy() {
   }
 }

--- a/src/app/public/components/archive-search/archive-search.component.ts
+++ b/src/app/public/components/archive-search/archive-search.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+/* @format */
+import { Component, Output, EventEmitter } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 @Component({
@@ -6,9 +7,8 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
   templateUrl: './archive-search.component.html',
   styleUrls: ['./archive-search.component.scss'],
 })
-export class ArchiveSearchComponent implements OnInit {
-
-  @Output() search = new EventEmitter<string>()
+export class ArchiveSearchComponent {
+  @Output() search = new EventEmitter<string>();
 
   public searchForm: FormGroup;
 
@@ -16,16 +16,10 @@ export class ArchiveSearchComponent implements OnInit {
 
   public displayIcon: boolean = true;
 
-  constructor(
-    private fb: FormBuilder,
-  ) {
+  constructor(private fb: FormBuilder) {
     this.searchForm = this.fb.group({
       query: ['', [Validators.required]],
     });
-  }
-
-  ngOnInit(): void {
-    
   }
 
   public clearForm(): void {
@@ -35,6 +29,4 @@ export class ArchiveSearchComponent implements OnInit {
   public onHandleSearch(): void {
     this.search.emit(this.searchForm.value.query);
   }
-
- 
 }

--- a/src/app/public/components/public-archive-web-links/public-archive-web-links.component.ts
+++ b/src/app/public/components/public-archive-web-links/public-archive-web-links.component.ts
@@ -1,11 +1,12 @@
-import { Component, OnInit, Input } from '@angular/core';
+/* @format */
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'pr-public-archive-web-links',
   templateUrl: './public-archive-web-links.component.html',
   styleUrls: ['./public-archive-web-links.component.scss'],
 })
-export class PublicArchiveWebLinksComponent implements OnInit {
+export class PublicArchiveWebLinksComponent {
   componentName: string = 'public-archive-web-links';
 
   @Input() description: string = '';
@@ -13,6 +14,4 @@ export class PublicArchiveWebLinksComponent implements OnInit {
   @Input() websites: string[] = [];
 
   constructor() {}
-
-  ngOnInit(): void {}
 }

--- a/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.ts
+++ b/src/app/share-preview/components/create-account-dialog/create-account-dialog.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, OnInit, Input, Inject } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
 import { DeviceService } from '@shared/services/device/device.service';
 
@@ -8,7 +8,7 @@ import { DeviceService } from '@shared/services/device/device.service';
   templateUrl: './create-account-dialog.component.html',
   styleUrls: ['./create-account-dialog.component.scss'],
 })
-export class CreateAccountDialogComponent implements OnInit {
+export class CreateAccountDialogComponent {
   sharerName: string = this.data.sharerName;
 
   constructor(
@@ -16,8 +16,6 @@ export class CreateAccountDialogComponent implements OnInit {
     private device: DeviceService,
     @Inject(DIALOG_DATA) public data: any,
   ) {}
-
-  ngOnInit(): void {}
 
   isMobile(): boolean {
     return this.device.isMobileWidth();

--- a/src/app/share-preview/components/share-not-found/share-not-found.component.ts
+++ b/src/app/share-preview/components/share-not-found/share-not-found.component.ts
@@ -1,15 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+/* @format */
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'pr-share-not-found',
   templateUrl: './share-not-found.component.html',
-  styleUrls: ['./share-not-found.component.scss']
+  styleUrls: ['./share-not-found.component.scss'],
 })
-export class ShareNotFoundComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+export class ShareNotFoundComponent {
+  constructor() {}
 }

--- a/src/app/shared/components/archive-picker/archive-picker.component.ts
+++ b/src/app/shared/components/archive-picker/archive-picker.component.ts
@@ -1,17 +1,11 @@
-import { Component, OnInit, Inject } from '@angular/core';
+/* @format */
+import { Component, Inject } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
 import {
   PromptService,
   PromptField,
 } from '@shared/services/prompt/prompt.service';
-import {
-  RelationVO,
-  ArchiveVO,
-  InviteVO,
-  FolderVO,
-  RecordVO,
-  ItemVO,
-} from '@models';
+import { RelationVO, ArchiveVO, InviteVO, ItemVO } from '@models';
 import { Deferred } from '@root/vendor/deferred';
 import { ApiService } from '@shared/services/api/api.service';
 import {
@@ -43,7 +37,7 @@ export interface ArchivePickerComponentConfig {
   templateUrl: './archive-picker.component.html',
   styleUrls: ['./archive-picker.component.scss'],
 })
-export class ArchivePickerComponent implements OnInit {
+export class ArchivePickerComponent {
   relations: RelationVO[];
   relationOptions: FormInputSelectOption[];
   hideAccessRoleOnInvite = false;
@@ -58,7 +52,7 @@ export class ArchivePickerComponent implements OnInit {
     private accountService: AccountService,
     private message: MessageService,
     private prConstants: PrConstantsService,
-    private ga: GoogleAnalyticsService
+    private ga: GoogleAnalyticsService,
   ) {
     this.relations = this.dialogData.relations;
     this.hideAccessRoleOnInvite = this.dialogData.hideAccessRoleOnInvite;
@@ -69,8 +63,6 @@ export class ArchivePickerComponent implements OnInit {
       };
     });
   }
-
-  ngOnInit() {}
 
   searchByEmail() {
     const deferred = new Deferred();
@@ -120,7 +112,7 @@ export class ArchivePickerComponent implements OnInit {
         fields,
         forShare ? 'Invite to share' : 'Send invitation',
         deferred.promise,
-        'Send'
+        'Send',
       )
       .then((value) => {
         const invite = new InviteVO({
@@ -133,7 +125,7 @@ export class ArchivePickerComponent implements OnInit {
         if (this.dialogData.shareItem) {
           return this.api.invite.sendShareInvite(
             [invite],
-            this.dialogData.shareItem
+            this.dialogData.shareItem,
           );
         } else {
           return this.api.invite.send([invite]);

--- a/src/app/shared/components/archive-switcher-dialog/archive-switcher-dialog.component.ts
+++ b/src/app/shared/components/archive-switcher-dialog/archive-switcher-dialog.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, Inject } from '@angular/core';
-
+/* @format */
+import { Component, Inject } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
 import { AccountService } from '@shared/services/account/account.service';
 import { ArchiveVO } from '@models';
@@ -9,9 +9,9 @@ import { orderBy } from 'lodash';
 @Component({
   selector: 'pr-archive-switcher-dialog',
   templateUrl: './archive-switcher-dialog.component.html',
-  styleUrls: ['./archive-switcher-dialog.component.scss']
+  styleUrls: ['./archive-switcher-dialog.component.scss'],
 })
-export class ArchiveSwitcherDialogComponent implements OnInit {
+export class ArchiveSwitcherDialogComponent {
   public loadingArchives = false;
   public archives: ArchiveVO[] = [];
   public currentArchive: ArchiveVO;
@@ -23,14 +23,13 @@ export class ArchiveSwitcherDialogComponent implements OnInit {
   constructor(
     private dialogRef: DialogRef,
     @Inject(DIALOG_DATA) public data: any,
-    private account: AccountService
+    private account: AccountService,
   ) {
-    this.archives = orderBy(this.account.getArchives(), a => a.fullName.toLowerCase());
+    this.archives = orderBy(this.account.getArchives(), (a) =>
+      a.fullName.toLowerCase(),
+    );
 
     this.promptText = data.promptText;
-  }
-
-  ngOnInit() {
   }
 
   async onArchiveClick(archive: ArchiveVO) {
@@ -39,8 +38,8 @@ export class ArchiveSwitcherDialogComponent implements OnInit {
       try {
         await this.account.changeArchive(archive);
         this.close();
-      } catch (err) {}
-      finally {
+      } catch (err) {
+      } finally {
         this.waiting = false;
       }
     }
@@ -60,5 +59,4 @@ export class ArchiveSwitcherDialogComponent implements OnInit {
   cancel() {
     this.dialogRef.close(null, true);
   }
-
 }

--- a/src/app/shared/components/folder-view-toggle/folder-view-toggle.component.ts
+++ b/src/app/shared/components/folder-view-toggle/folder-view-toggle.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
 import { FolderViewService } from '@shared/services/folder-view/folder-view.service';
 
@@ -21,9 +21,7 @@ interface FolderViewToggleOption {
   templateUrl: './folder-view-toggle.component.html',
   styleUrls: ['./folder-view-toggle.component.scss'],
 })
-export class FolderViewToggleComponent
-  implements OnInit, OnDestroy, HasSubscriptions
-{
+export class FolderViewToggleComponent implements OnDestroy, HasSubscriptions {
   currentFolderView: FolderView;
   folderViews: FolderViewToggleOption[] = [
     {
@@ -52,8 +50,6 @@ export class FolderViewToggleComponent
       }),
     );
   }
-
-  ngOnInit(): void {}
 
   ngOnDestroy() {
     unsubscribeAll(this.subscriptions);

--- a/src/app/shared/components/message/message.component.ts
+++ b/src/app/shared/components/message/message.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   MessageService,
   MessageDisplayOptions,
@@ -21,7 +21,7 @@ interface Message {
   templateUrl: './message.component.html',
   styleUrls: ['./message.component.scss'],
 })
-export class MessageComponent implements OnInit {
+export class MessageComponent {
   displayText: string;
   navigateTo: string[];
   navigateParams: any;
@@ -41,8 +41,6 @@ export class MessageComponent implements OnInit {
   ) {
     this.service.registerComponent(this);
   }
-
-  ngOnInit() {}
 
   display(data: MessageDisplayOptions) {
     if (this.visible) {

--- a/src/app/shared/components/new-archive-form/new-archive-form.component.ts
+++ b/src/app/shared/components/new-archive-form/new-archive-form.component.ts
@@ -1,9 +1,9 @@
+/* @format */
 import {
   Component,
   ElementRef,
   EventEmitter,
   Input,
-  OnInit,
   Output,
   ViewChild,
 } from '@angular/core';
@@ -37,7 +37,7 @@ const ARCHIVE_TYPES: { text: string; value: ArchiveType }[] = [
   templateUrl: './new-archive-form.component.html',
   styleUrls: ['./new-archive-form.component.scss'],
 })
-export class NewArchiveFormComponent implements OnInit {
+export class NewArchiveFormComponent {
   @Input() showRelations: boolean = false;
   @Output() success = new EventEmitter<ArchiveVO>();
   @Output() error = new EventEmitter();
@@ -55,8 +55,6 @@ export class NewArchiveFormComponent implements OnInit {
     };
   }
 
-  ngOnInit(): void {}
-
   public isFormValid() {
     return (
       this.fullNameRef?.nativeElement.validity.valid &&
@@ -71,7 +69,7 @@ export class NewArchiveFormComponent implements OnInit {
     try {
       this.waiting = true;
       const response = await this.api.archive.create(
-        new ArchiveVO(this.formData)
+        new ArchiveVO(this.formData),
       );
       const newArchive = response.getArchiveVO();
       this.success.emit(newArchive);

--- a/src/app/shared/components/prompt/prompt.component.ts
+++ b/src/app/shared/components/prompt/prompt.component.ts
@@ -1,7 +1,19 @@
-import { Component, OnInit, EventEmitter, Input, Output, ElementRef, OnDestroy, ViewChildren, QueryList } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
-
-import { PromptService, PromptField, PromptButton, PromptConfig } from '@shared/services/prompt/prompt.service';
+/* @format */
+import {
+  Component,
+  Input,
+  ElementRef,
+  OnDestroy,
+  ViewChildren,
+  QueryList,
+} from '@angular/core';
+import { UntypedFormGroup, UntypedFormBuilder } from '@angular/forms';
+import {
+  PromptService,
+  PromptField,
+  PromptButton,
+  PromptConfig,
+} from '@shared/services/prompt/prompt.service';
 import { FormInputComponent } from '@shared/components/form-input/form-input.component';
 
 const DEFAULT_SAVE_TEXT = 'OK';
@@ -10,9 +22,9 @@ const DEFAULT_CANCEL_TEXT = 'Cancel';
 @Component({
   selector: 'pr-prompt',
   templateUrl: './prompt.component.html',
-  styleUrls: ['./prompt.component.scss']
+  styleUrls: ['./prompt.component.scss'],
 })
-export class PromptComponent implements OnInit, OnDestroy {
+export class PromptComponent implements OnDestroy {
   @Input() isVisible: boolean;
 
   @ViewChildren(FormInputComponent) inputQuery: QueryList<FormInputComponent>;
@@ -39,12 +51,13 @@ export class PromptComponent implements OnInit, OnDestroy {
 
   private promptQueue: PromptConfig[] = [];
 
-  constructor(private service: PromptService, private fb: UntypedFormBuilder, private element: ElementRef) {
+  constructor(
+    private service: PromptService,
+    private fb: UntypedFormBuilder,
+    private element: ElementRef,
+  ) {
     this.service.registerComponent(this);
     this.defaultForm = fb.group({});
-  }
-
-  ngOnInit() {
   }
 
   ngOnDestroy() {
@@ -69,7 +82,7 @@ export class PromptComponent implements OnInit, OnDestroy {
     donePromise?: Promise<any>,
     doneResolve?: Function,
     doneReject?: Function,
-    template?: string
+    template?: string,
   ) {
     if (this.donePromise) {
       let newDoneReject, newDoneResolve;
@@ -88,7 +101,7 @@ export class PromptComponent implements OnInit, OnDestroy {
         cancelText: cancelText,
         donePromise: newDonePromise,
         doneResolve: newDoneResolve,
-        doneReject: newDoneReject
+        doneReject: newDoneReject,
       });
 
       return newDonePromise;
@@ -157,9 +170,13 @@ export class PromptComponent implements OnInit, OnDestroy {
   }
 
   getInput(fieldName: string) {
-    const component = this.inputQuery.find(input => input.fieldName === fieldName);
+    const component = this.inputQuery.find(
+      (input) => input.fieldName === fieldName,
+    );
     if (component) {
-      return component.getElement().nativeElement.querySelector('.form-control');
+      return component
+        .getElement()
+        .nativeElement.querySelector('.form-control');
     } else {
       return null;
     }
@@ -172,7 +189,7 @@ export class PromptComponent implements OnInit, OnDestroy {
     donePromise?: Promise<any>,
     doneResolve?: Function,
     doneReject?: Function,
-    template?: string
+    template?: string,
   ) {
     if (this.donePromise) {
       let newDoneReject, newDoneResolve;
@@ -189,7 +206,7 @@ export class PromptComponent implements OnInit, OnDestroy {
         donePromise: newDonePromise,
         doneResolve: newDoneResolve,
         doneReject: newDoneReject,
-        template: template
+        template: template,
       });
 
       return newDonePromise;
@@ -238,14 +255,14 @@ export class PromptComponent implements OnInit, OnDestroy {
   }
 
   reset() {
-    this.editForm =  null;
+    this.editForm = null;
     this.editButtons = null;
     this.title = null;
     this.fields = null;
     this.donePromise = null;
     this.doneResolve = null;
     this.doneReject = null;
-    this.template =  null;
+    this.template = null;
     this.waiting = false;
 
     if (this.promptQueue.length) {
@@ -261,7 +278,7 @@ export class PromptComponent implements OnInit, OnDestroy {
           next.donePromise,
           next.doneResolve,
           next.doneReject,
-          next.template
+          next.template,
         );
       } else if (next.buttons) {
         this.promptButtons(
@@ -271,7 +288,7 @@ export class PromptComponent implements OnInit, OnDestroy {
           next.donePromise,
           next.doneResolve,
           next.doneReject,
-          next.template
+          next.template,
         );
       }
     }

--- a/src/app/shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component.ts
+++ b/src/app/shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component.ts
@@ -1,7 +1,6 @@
 /* @format */
 import {
   Component,
-  OnInit,
   OnDestroy,
   AfterViewInit,
   ViewChild,
@@ -34,7 +33,7 @@ import { slideUpAnimation } from '@shared/animations';
   animations: [slideUpAnimation],
 })
 export class RoutedDialogWrapperComponent
-  implements OnInit, AfterViewInit, HasSubscriptions, OnDestroy
+  implements AfterViewInit, HasSubscriptions, OnDestroy
 {
   private dialogToken: DialogComponentToken;
   private dialogOptions: DialogOptions;
@@ -52,8 +51,6 @@ export class RoutedDialogWrapperComponent
     private routeHistory: RouteHistoryService,
     private title: Title,
   ) {}
-
-  ngOnInit(): void {}
 
   ngAfterViewInit(): void {
     this.title.setTitle(`${this.route.snapshot.data.title} | Permanent.org`);

--- a/src/app/shared/components/static-map/static-map.component.ts
+++ b/src/app/shared/components/static-map/static-map.component.ts
@@ -1,18 +1,25 @@
-import { Component, OnInit, ElementRef, AfterViewInit, Input, SimpleChanges, OnChanges } from '@angular/core';
+/* @format */
+import {
+  Component,
+  ElementRef,
+  Input,
+  SimpleChanges,
+  OnChanges,
+} from '@angular/core';
 import { LocnVOData, ItemVO } from '@models';
-import { environment } from '@root/environments/environment';
 import { compact } from 'lodash';
 import { SecretsService } from '../../services/secrets/secrets.service';
-
 
 @Component({
   selector: 'pr-static-map',
   templateUrl: './static-map.component.html',
-  styleUrls: ['./static-map.component.scss']
+  styleUrls: ['./static-map.component.scss'],
 })
-export class StaticMapComponent implements OnInit, OnChanges, AfterViewInit {
+export class StaticMapComponent implements OnChanges {
   private dpiScale = 1;
-  private baseUrl = `https://maps.googleapis.com/maps/api/staticmap?key=${this.secrets.get('GOOGLE_API_KEY')}`;
+  private baseUrl = `https://maps.googleapis.com/maps/api/staticmap?key=${this.secrets.get(
+    'GOOGLE_API_KEY',
+  )}`;
 
   @Input() item: ItemVO;
   @Input() items: ItemVO[];
@@ -24,38 +31,32 @@ export class StaticMapComponent implements OnInit, OnChanges, AfterViewInit {
 
   constructor(
     private elementRef: ElementRef,
-    private secrets: SecretsService
+    private secrets: SecretsService,
   ) {
     this.dpiScale = (window ? window.devicePixelRatio > 1.75 : false) ? 2 : 1;
   }
 
-  ngOnInit(): void {
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(_: SimpleChanges): void {
     setTimeout(() => {
       this.buildUrl();
     });
-  }
-
-  ngAfterViewInit() {
   }
 
   buildUrl() {
     let locations: LocnVOData[];
 
     if (this.item) {
-      locations = [ this.item.LocnVO ];
+      locations = [this.item.LocnVO];
     } else if (this.items) {
-      locations = this.items.map(i => i.LocnVO);
+      locations = this.items.map((i) => i.LocnVO);
     } else if (this.location) {
-      locations = [ this.location ];
+      locations = [this.location];
     }
 
     locations = compact(locations);
 
     if (!locations.length) {
-      return this.imageUrl = null;
+      return (this.imageUrl = null);
     }
 
     const width = (this.elementRef.nativeElement as HTMLElement).clientWidth;

--- a/src/app/shared/components/tags/tags.component.ts
+++ b/src/app/shared/components/tags/tags.component.ts
@@ -1,11 +1,5 @@
 /* @format */
-import {
-  Component,
-  OnInit,
-  Input,
-  OnChanges,
-  HostBinding,
-} from '@angular/core';
+import { Component, Input, OnChanges, HostBinding } from '@angular/core';
 import { TagVOData } from '@models/tag-vo';
 import { orderBy } from 'lodash';
 import { ngIfScaleAnimationDynamic } from '@shared/animations';
@@ -16,7 +10,7 @@ import { ngIfScaleAnimationDynamic } from '@shared/animations';
   styleUrls: ['./tags.component.scss'],
   animations: [ngIfScaleAnimationDynamic],
 })
-export class TagsComponent implements OnInit, OnChanges {
+export class TagsComponent implements OnChanges {
   @Input() tags: TagVOData[];
   @HostBinding('class.read-only') @Input() readOnly = true;
   @Input() canEdit = false;
@@ -27,8 +21,6 @@ export class TagsComponent implements OnInit, OnChanges {
   orderedTags: TagVOData[] = [];
 
   constructor() {}
-
-  ngOnInit(): void {}
 
   ngOnChanges() {
     if (!this.tags?.length) {

--- a/src/app/shared/components/timeline-complete-dialog/timeline-complete-dialog.component.ts
+++ b/src/app/shared/components/timeline-complete-dialog/timeline-complete-dialog.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Inject, ViewChild, ElementRef } from '@angular/core';
+/* @format */
+import { Component, Inject, ViewChild, ElementRef } from '@angular/core';
 import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.module';
 import { FolderVO } from '@models';
 import { copyFromInputElement } from '@shared/utilities/forms';
@@ -9,9 +10,9 @@ import { GoogleAnalyticsService } from '@shared/services/google-analytics/google
 @Component({
   selector: 'pr-timeline-complete-dialog',
   templateUrl: './timeline-complete-dialog.component.html',
-  styleUrls: ['./timeline-complete-dialog.component.scss']
+  styleUrls: ['./timeline-complete-dialog.component.scss'],
 })
-export class TimelineCompleteDialogComponent implements OnInit {
+export class TimelineCompleteDialogComponent {
   public folder: FolderVO;
   public publicLink: string;
 
@@ -20,15 +21,12 @@ export class TimelineCompleteDialogComponent implements OnInit {
 
   constructor(
     private dialogRef: DialogRef,
-    private linkPipe: PublicLinkPipe,
+    linkPipe: PublicLinkPipe,
     private ga: GoogleAnalyticsService,
     @Inject(DIALOG_DATA) public data: any,
   ) {
     this.folder = this.data.folder;
     this.publicLink = linkPipe.transform(this.folder);
-  }
-
-  ngOnInit() {
   }
 
   copyPublicLink() {
@@ -47,5 +45,4 @@ export class TimelineCompleteDialogComponent implements OnInit {
   close() {
     this.dialogRef.close();
   }
-
 }

--- a/src/app/shares/components/shares/shares.component.ts
+++ b/src/app/shares/components/shares/shares.component.ts
@@ -1,20 +1,37 @@
-import { Component, OnInit, OnDestroy, AfterViewInit, ViewChildren, QueryList, ElementRef, Inject, HostBinding } from '@angular/core';
+/* @format */
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  Inject,
+  HostBinding,
+} from '@angular/core';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
-
 import { find, remove } from 'lodash';
-import { TweenLite, ScrollToPlugin } from 'gsap/all';
-import { DataService, SelectClickEvent, SelectedItemsSet } from '@shared/services/data/data.service';
-
-import { ConnectorOverviewVO, FolderVO, RecordVO, ArchiveVO, ShareVO, ItemVO } from '@root/app/models';
+import {
+  DataService,
+  SelectClickEvent,
+  SelectedItemsSet,
+} from '@shared/services/data/data.service';
+import { FolderVO, ArchiveVO, ItemVO } from '@root/app/models';
 import { AccountService } from '@shared/services/account/account.service';
 import { DOCUMENT } from '@angular/common';
-import { MessageService } from '@shared/services/message/message.service';
 import { DeviceService } from '@shared/services/device/device.service';
-import { slideUpAnimation, fadeAnimation, ngIfScaleAnimationDynamic } from '@shared/animations';
-import { FileListItemParent, ItemClickEvent } from '@fileBrowser/components/file-list/file-list.component';
+import {
+  slideUpAnimation,
+  fadeAnimation,
+  ngIfScaleAnimationDynamic,
+} from '@shared/animations';
+import {
+  FileListItemParent,
+  ItemClickEvent,
+} from '@fileBrowser/components/file-list/file-list.component';
 import { Subscription } from 'rxjs';
 import debug from 'debug';
-import { unsubscribeAll, HasSubscriptions } from '@shared/utilities/hasSubscriptions';
+import {
+  unsubscribeAll,
+  HasSubscriptions,
+} from '@shared/utilities/hasSubscriptions';
 import { EditService } from '@core/services/edit/edit.service';
 import { filter } from 'rxjs/operators';
 
@@ -22,9 +39,11 @@ import { filter } from 'rxjs/operators';
   selector: 'pr-shares',
   templateUrl: './shares.component.html',
   styleUrls: ['./shares.component.scss'],
-  animations: [ slideUpAnimation, fadeAnimation, ngIfScaleAnimationDynamic ]
+  animations: [slideUpAnimation, fadeAnimation, ngIfScaleAnimationDynamic],
 })
-export class SharesComponent implements OnInit, AfterViewInit, OnDestroy, FileListItemParent, HasSubscriptions {
+export class SharesComponent
+  implements OnInit, OnDestroy, FileListItemParent, HasSubscriptions
+{
   @HostBinding('class.show-sidebar') showSidebar = true;
 
   sharesFolder: FolderVO;
@@ -44,49 +63,55 @@ export class SharesComponent implements OnInit, AfterViewInit, OnDestroy, FileLi
     private editService: EditService,
     private accountService: AccountService,
     public device: DeviceService,
-    @Inject(DOCUMENT) private document: any
+    @Inject(DOCUMENT) private document: any,
   ) {
     this.sharesFolder = new FolderVO({
       displayName: 'Shares',
       pathAsText: ['Shares'],
       type: 'type.folder.root.share',
-      ChildItemVOs: []
+      ChildItemVOs: [],
     });
 
     this.dataService.setCurrentFolder(this.sharesFolder);
   }
 
   registerDataServiceHandlers() {
-    this.subscriptions.push(this.dataService.selectedItems$().subscribe(selectedItems => {
-      this.selectedItems = selectedItems;
-    }));
+    this.subscriptions.push(
+      this.dataService.selectedItems$().subscribe((selectedItems) => {
+        this.selectedItems = selectedItems;
+      }),
+    );
 
-    this.subscriptions.push(this.dataService.unsharedItem$().subscribe(item => {
-      item.isPendingAction = true;
-      this.dataService.clearSelectedItems();
-      remove(this.shareItems, item);
-    }));
+    this.subscriptions.push(
+      this.dataService.unsharedItem$().subscribe((item) => {
+        item.isPendingAction = true;
+        this.dataService.clearSelectedItems();
+        remove(this.shareItems, item);
+      }),
+    );
   }
 
   registerArchiveChangeHandlers() {
     // register for archive change events to reload the root section
     this.subscriptions.push(
-      this.accountService.archiveChange.subscribe(async archive => {
+      this.accountService.archiveChange.subscribe(async (archive) => {
         // may be in a record we don't have access to, reload just the 'root'
         this.router.navigate(['.'], { relativeTo: this.route });
-      })
+      }),
     );
   }
 
   registerRouterEventHandlers() {
     // register for navigation events to reinit page on folder changes
-    this.subscriptions.push(this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd ))
-      .subscribe((event: NavigationEnd) => {
-        if (event.url === '/app/shares') {
-          this.ngOnInit();
-        }
-      }));
+    this.subscriptions.push(
+      this.router.events
+        .pipe(filter((event) => event instanceof NavigationEnd))
+        .subscribe((event: NavigationEnd) => {
+          if (event.url === '/app/shares') {
+            this.ngOnInit();
+          }
+        }),
+    );
   }
 
   ngOnInit() {
@@ -94,7 +119,8 @@ export class SharesComponent implements OnInit, AfterViewInit, OnDestroy, FileLi
     this.allShareItems = [];
 
     const currentArchive = this.accountService.getArchive();
-    const shareArchives = this.route.snapshot.data.shares as ArchiveVO[] || [];
+    const shareArchives =
+      (this.route.snapshot.data.shares as ArchiveVO[]) || [];
     for (const archive of shareArchives) {
       for (const item of archive.ItemVOs) {
         item.ShareArchiveVO = archive;
@@ -111,7 +137,9 @@ export class SharesComponent implements OnInit, AfterViewInit, OnDestroy, FileLi
     const queryParams = this.route.snapshot.queryParams;
 
     if (queryParams.shareArchiveNbr) {
-      const targetItem = find(this.allShareItems, { archiveNbr: queryParams.shareArchiveNbr });
+      const targetItem = find(this.allShareItems, {
+        archiveNbr: queryParams.shareArchiveNbr,
+      });
       if (targetItem) {
         this.editService.openShareDialog(targetItem);
       }
@@ -122,9 +150,6 @@ export class SharesComponent implements OnInit, AfterViewInit, OnDestroy, FileLi
       this.registerArchiveChangeHandlers();
       this.registerRouterEventHandlers();
     }
-  }
-
-  ngAfterViewInit() {
   }
 
   ngOnDestroy() {
@@ -146,5 +171,4 @@ export class SharesComponent implements OnInit, AfterViewInit, OnDestroy, FileLi
 
     this.dataService.onSelectEvent(selectEvent);
   }
-
 }

--- a/src/app/views/components/timeline-view/timeline-breadcrumbs/timeline-breadcrumbs.component.ts
+++ b/src/app/views/components/timeline-view/timeline-breadcrumbs/timeline-breadcrumbs.component.ts
@@ -1,10 +1,26 @@
-import { Component, OnInit, Input, OnDestroy, ViewChild, ElementRef, Output, EventEmitter, AfterViewInit } from '@angular/core';
+/* @format */
+import {
+  Component,
+  OnInit,
+  Input,
+  OnDestroy,
+  ViewChild,
+  ElementRef,
+  Output,
+  EventEmitter,
+} from '@angular/core';
 import { DataService } from '@shared/services/data/data.service';
 import { Subscription } from 'rxjs';
 import { DataItem } from 'vis-timeline/standalone';
 import { debounce, minBy, remove } from 'lodash';
 import { Router, ActivatedRoute } from '@angular/router';
-import { TimelineGroupTimespan, GetTimespanFromRange, GroupByTimespan, TimelineGroup, TimelineItem, TimelineItemDataType, TimelineDataItem } from '../timeline-util';
+import {
+  TimelineGroupTimespan,
+  GetTimespanFromRange,
+  GroupByTimespan,
+  TimelineGroup,
+  TimelineItem,
+} from '../timeline-util';
 
 export interface TimelineBreadcrumb {
   text: string;
@@ -22,9 +38,9 @@ export interface TimelineBreadcrumb {
 @Component({
   selector: 'pr-timeline-breadcrumbs',
   templateUrl: './timeline-breadcrumbs.component.html',
-  styleUrls: ['./timeline-breadcrumbs.component.scss']
+  styleUrls: ['./timeline-breadcrumbs.component.scss'],
 })
-export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDestroy {
+export class TimelineBreadcrumbsComponent implements OnInit, OnDestroy {
   @Input() timelineGroups: Map<TimelineGroupTimespan, DataItem[]>;
   @Output() breadcrumbClicked = new EventEmitter<TimelineBreadcrumb>();
 
@@ -40,18 +56,17 @@ export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDe
   constructor(
     private data: DataService,
     private activatedRoute: ActivatedRoute,
-    private router: Router
+    private router: Router,
   ) {
-    this.dataServiceSubscription = this.data.currentFolderChange.subscribe(folder => {
-      this.setFolderBreadcrumbs();
-    });
+    this.dataServiceSubscription = this.data.currentFolderChange.subscribe(
+      (_) => {
+        this.setFolderBreadcrumbs();
+      },
+    );
   }
 
   ngOnInit() {
     this.setFolderBreadcrumbs();
-  }
-
-  ngAfterViewInit() {
   }
 
   ngOnDestroy() {
@@ -61,15 +76,22 @@ export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDe
   onTimelineZoom(event) {
     const start = event.start.getTime();
     const end = event.end.getTime();
-    const midpoint = (start + end ) / 2;
+    const midpoint = (start + end) / 2;
     let timespan = GetTimespanFromRange(start, end);
     let group: TimelineGroup;
 
     if (timespan > TimelineGroupTimespan.Year) {
       let bestMatch: TimelineItem | TimelineGroup;
 
-      while ((!bestMatch || bestMatch.dataType !== 'group') && timespan > TimelineGroupTimespan.Year) {
-        bestMatch = this.getBestMatchGroupForTimespan(midpoint, --timespan, true);
+      while (
+        (!bestMatch || bestMatch.dataType !== 'group') &&
+        timespan > TimelineGroupTimespan.Year
+      ) {
+        bestMatch = this.getBestMatchGroupForTimespan(
+          midpoint,
+          --timespan,
+          true,
+        );
       }
 
       if (bestMatch.dataType === 'group') {
@@ -78,7 +100,6 @@ export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDe
     }
 
     this.setTimeBreadcrumbs(group);
-
   }
 
   onGroupClick(group: TimelineGroup) {
@@ -98,7 +119,7 @@ export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDe
         type: 'folder',
         text: folder.pathAsText[i],
         archiveNbr: folder.pathAsArchiveNbr[i],
-        folder_linkId: folder.pathAsFolder_linkId[i]
+        folder_linkId: folder.pathAsFolder_linkId[i],
       });
     }
 
@@ -106,13 +127,19 @@ export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDe
   }
 
   setTimeBreadcrumbs(group?: TimelineGroup) {
-    remove(this.breadcrumbs, b => b.type === 'timespan');
+    remove(this.breadcrumbs, (b) => b.type === 'timespan');
     if (group) {
-      const midpoint = group.groupEnd ? (group.groupStart + group.groupEnd) / 2 : group.groupStart;
+      const midpoint = group.groupEnd
+        ? (group.groupStart + group.groupEnd) / 2
+        : group.groupStart;
       const groups: TimelineGroup[] = [];
       let timespan = TimelineGroupTimespan.Year;
       while (timespan < group.groupTimespan) {
-        const bestMatch = this.getBestMatchGroupForTimespan(midpoint, timespan, true);
+        const bestMatch = this.getBestMatchGroupForTimespan(
+          midpoint,
+          timespan,
+          true,
+        );
         if (bestMatch.dataType === 'group') {
           groups.push(bestMatch);
         }
@@ -125,52 +152,68 @@ export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDe
       // find only groups needed in breadcrumbs
       for (let i = groups.length - 1; i >= 0; i--) {
         const x = groups[i];
-        if (x.groupItems.length > lastGroupSize && x.groupItems.length > group.groupItems.length) {
+        if (
+          x.groupItems.length > lastGroupSize &&
+          x.groupItems.length > group.groupItems.length
+        ) {
           lastGroupSize = x.groupItems.length;
           bestFitGroups.unshift(x);
         }
       }
-      
-      this.breadcrumbs.push(...bestFitGroups.map(g => this.getBreadcrumbFromGroup(g)));
+
+      this.breadcrumbs.push(
+        ...bestFitGroups.map((g) => this.getBreadcrumbFromGroup(g)),
+      );
       this.breadcrumbs.push(this.getBreadcrumbFromGroup(group));
     }
   }
 
   scrollToEnd() {
     setTimeout(() => {
-      const elem = (this.scrollElem.nativeElement as HTMLDivElement);
+      const elem = this.scrollElem.nativeElement as HTMLDivElement;
       elem.scrollLeft = elem.scrollWidth - elem.clientWidth;
     });
   }
 
   onBreadcrumbClick(clickedBreadcrumb: TimelineBreadcrumb) {
     if (clickedBreadcrumb === this.breadcrumbs[0]) {
-      const publicArchiveNbr = this.activatedRoute.snapshot.params.publicArchiveNbr;
+      const publicArchiveNbr =
+        this.activatedRoute.snapshot.params.publicArchiveNbr;
       this.router.navigate(['p', 'archive', publicArchiveNbr]);
     } else {
       this.breadcrumbClicked.emit(clickedBreadcrumb);
     }
   }
 
-  getBestMatchGroupForTimespan(time: number, timespan: TimelineGroupTimespan, allowItems = false) {
+  getBestMatchGroupForTimespan(
+    time: number,
+    timespan: TimelineGroupTimespan,
+    allowItems = false,
+  ) {
     timespan = Math.min(timespan, TimelineGroupTimespan.Hour);
     let items = this.timelineGroups.get(timespan);
     if (!items) {
-      items = GroupByTimespan(this.data.currentFolder.ChildItemVOs, timespan).groupedItems;
+      items = GroupByTimespan(
+        this.data.currentFolder.ChildItemVOs,
+        timespan,
+      ).groupedItems;
       this.timelineGroups.set(timespan, items);
     }
 
     const diffs = items
-      .filter((i: TimelineGroup | TimelineItem) => allowItems || i.dataType === 'group')
+      .filter(
+        (i: TimelineGroup | TimelineItem) =>
+          allowItems || i.dataType === 'group',
+      )
       .map((i: TimelineGroup) => {
         const diff = time - (i.end ? (i.start + i.end) / 2 : i.start);
         return {
           item: i,
-          diff: Math.abs(diff)
+          diff: Math.abs(diff),
         };
       });
 
-    const bestMatch = minBy(diffs, d => d.diff).item;
+    const bestMatch = minBy(diffs, (d) => d.diff).item;
     return bestMatch;
   }
 
@@ -181,10 +224,9 @@ export class TimelineBreadcrumbsComponent implements OnInit, AfterViewInit, OnDe
       timespan: group.groupTimespan,
       timespanName: group.groupName,
       timespanStart: group.groupStart,
-      timespanEnd: group.groupEnd
+      timespanEnd: group.groupEnd,
     };
 
     return breadcrumb;
   }
-
 }


### PR DESCRIPTION
This linting rule prohibits empty lifecycle methods on components, services, etc. This PR enables that linting rule in the web app, and then fixes all new linting errors. It also includes Prettier formatting and some miscellaneous cleanup work.

Lint rule: @angular-eslint/no-empty-lifecycle-method