### PR TITLE
Call v2 version of `account/update` endpoint

### DIFF
--- a/src/app/core/components/account-settings/account-settings.component.spec.ts
+++ b/src/app/core/components/account-settings/account-settings.component.spec.ts
@@ -1,0 +1,92 @@
+import { Shallow } from 'shallow-render';
+import { NgModule } from '@angular/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AccountService } from '@shared/services/account/account.service';
+import { ActivatedRoute } from '@angular/router';
+import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
+import { AccountVO } from '@models/account-vo';
+import { AccountSettingsComponent } from './account-settings.component';
+
+@NgModule()
+class DummyModule {}
+
+class MockAccountService {
+  public account = new AccountVO({ accountId: 1, fullName: 'Test User' });
+
+  public getAccount(): AccountVO {
+    return this.account;
+  }
+
+  public setAccount(account: AccountVO): void {
+    this.account = account;
+  }
+}
+
+describe('AccountSettingsComponent', () => {
+  let shallow: Shallow<AccountSettingsComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(AccountSettingsComponent, DummyModule)
+      .provide(HttpClientTestingModule)
+      .provideMock(
+        { provide: AccountService, useClass: MockAccountService },
+        { provide: ActivatedRoute, useValue: {} },
+        {
+          provide: ApiService,
+          useValue: { account: { update: async () => new AccountVO({}) } },
+        },
+        {
+          provide: MessageService,
+          useValue: { showMessage(_: any) {}, showError(_: any) {} },
+        },
+      );
+  });
+
+  it('exists', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance).toBeTruthy();
+  });
+
+  it('can save an account property', async (done) => {
+    const { instance, inject } = await shallow.render();
+
+    const accountService = inject(AccountService);
+    const setAccountSpy = spyOn(accountService, 'setAccount').and.callThrough();
+    const accountUpdateSpy = spyOn(inject(ApiService).account, 'update');
+    const successfulMessageSpy = spyOn(inject(MessageService), 'showMessage');
+    const errorMessageSpy = spyOn(inject(MessageService), 'showError');
+
+    instance.onSaveProfileInfo('fullName', 'New Name').finally(() => {
+      expect(setAccountSpy).toHaveBeenCalled();
+      expect(accountUpdateSpy).toHaveBeenCalled();
+      expect(successfulMessageSpy).toHaveBeenCalled();
+      expect(errorMessageSpy).not.toHaveBeenCalled();
+      expect(accountService.getAccount().fullName).toBe('New Name');
+      done();
+    });
+  });
+
+  it('should reset an account property if an error occurs', async (done) => {
+    const { instance, inject } = await shallow.render();
+
+    const accountService = inject(AccountService);
+    const setAccountSpy = spyOn(accountService, 'setAccount').and.callThrough();
+    const accountUpdateSpy = spyOn(
+      inject(ApiService).account,
+      'update',
+    ).and.rejectWith({});
+    const successfulMessageSpy = spyOn(inject(MessageService), 'showMessage');
+    const errorMessageSpy = spyOn(inject(MessageService), 'showError');
+
+    instance.onSaveProfileInfo('fullName', 'New Name').finally(() => {
+      expect(setAccountSpy).not.toHaveBeenCalled();
+      expect(accountUpdateSpy).toHaveBeenCalled();
+      expect(successfulMessageSpy).not.toHaveBeenCalled();
+      expect(errorMessageSpy).toHaveBeenCalled();
+      expect(accountService.getAccount().fullName).toBe('Test User');
+      done();
+    });
+  });
+});

--- a/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
+++ b/src/app/core/components/advanced-settings/advanced-settings.component.spec.ts
@@ -4,7 +4,6 @@ import { AccountVO } from '@root/app/models';
 import { CoreModule } from '@core/core.module';
 import { MessageService } from '@shared/services/message/message.service';
 import { Shallow } from 'shallow-render';
-import { AccountResponse } from '../../../shared/services/api/account.repo';
 import { ApiService } from '../../../shared/services/api/api.service';
 import { AdvancedSettingsComponent } from './advanced-settings.component';
 
@@ -18,14 +17,13 @@ const mockAccountService = {
 const mockApiService = {
   account: {
     update: (account: AccountVO) => {
-      return Promise.resolve(new AccountResponse({}));
+      return Promise.resolve(account);
     },
   },
 };
 
 describe('AdvancedSettingsComponent', () => {
   let shallow: Shallow<AdvancedSettingsComponent>;
-  let component: AdvancedSettingsComponent;
   let messageShown = false;
 
   beforeEach(async () => {
@@ -54,8 +52,8 @@ describe('AdvancedSettingsComponent', () => {
   it('updates account on calling onAllowSFTPDeletion', async () => {
     const { instance, inject } = await shallow.render();
     const apiService = inject(ApiService);
-    const spy = spyOn(apiService.account, 'update').and.returnValue(
-      Promise.resolve(new AccountResponse({})),
+    const spy = spyOn(apiService.account, 'update').and.resolveTo(
+      new AccountVO({}),
     );
 
     await instance.onAllowSFTPDeletion();
@@ -65,7 +63,6 @@ describe('AdvancedSettingsComponent', () => {
 
   it('handles errors in onAllowSFTPDeletion', async () => {
     const { instance, inject } = await shallow.render();
-    const messageService = inject(MessageService);
 
     spyOn(inject(ApiService).account, 'update').and.throwError('test error');
 

--- a/src/app/core/components/billing-settings/billing-settings.component.spec.ts
+++ b/src/app/core/components/billing-settings/billing-settings.component.spec.ts
@@ -1,0 +1,99 @@
+import { Shallow } from 'shallow-render';
+import { NgModule } from '@angular/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AccountVO } from '@models/account-vo';
+import { AccountService } from '@shared/services/account/account.service';
+import { ActivatedRoute } from '@angular/router';
+import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
+import { BillingSettingsComponent } from './billing-settings.component';
+
+@NgModule()
+class DummyModule {}
+
+class MockAccountService {
+  public account = new AccountVO({
+    accountId: 1,
+    fullName: 'Test User',
+    zip: '12345',
+  });
+
+  public getAccount(): AccountVO {
+    return this.account;
+  }
+
+  public setAccount(account: AccountVO): void {
+    this.account = account;
+  }
+}
+
+describe('BillingSettingsComponent', () => {
+  let shallow: Shallow<BillingSettingsComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(BillingSettingsComponent, DummyModule)
+      .provide(HttpClientTestingModule)
+      .provideMock(
+        { provide: AccountService, useClass: MockAccountService },
+        {
+          provide: ApiService,
+          useValue: { account: { update: async () => new AccountVO({}) } },
+        },
+        {
+          provide: MessageService,
+          useValue: { showMessage(_: any) {}, showError(_: any) {} },
+        },
+      );
+  });
+
+  it('exists', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance).toBeTruthy();
+  });
+
+  it('can save an account property', async (done) => {
+    const { instance, inject } = await shallow.render();
+
+    const accountService = inject(AccountService);
+    const setAccountSpy = spyOn(accountService, 'setAccount').and.callThrough();
+    const accountUpdateSpy = spyOn(
+      inject(ApiService).account,
+      'update',
+    ).and.resolveTo(new AccountVO({ zip: null }));
+    const successfulMessageSpy = spyOn(inject(MessageService), 'showMessage');
+    const errorMessageSpy = spyOn(inject(MessageService), 'showError');
+
+    instance.onSaveInfo('fullName', 'New Name').finally(() => {
+      expect(setAccountSpy).toHaveBeenCalled();
+      expect(accountUpdateSpy).toHaveBeenCalled();
+      expect(successfulMessageSpy).toHaveBeenCalled();
+      expect(errorMessageSpy).not.toHaveBeenCalled();
+      expect(accountService.getAccount().fullName).toBe('New Name');
+      expect(accountService.getAccount().zip).toBe('12345');
+      done();
+    });
+  });
+
+  it('should reset an account property if an error occurs', async (done) => {
+    const { instance, inject } = await shallow.render();
+
+    const accountService = inject(AccountService);
+    const setAccountSpy = spyOn(accountService, 'setAccount').and.callThrough();
+    const accountUpdateSpy = spyOn(
+      inject(ApiService).account,
+      'update',
+    ).and.rejectWith({});
+    const successfulMessageSpy = spyOn(inject(MessageService), 'showMessage');
+    const errorMessageSpy = spyOn(inject(MessageService), 'showError');
+
+    instance.onSaveInfo('fullName', 'New Name').finally(() => {
+      expect(setAccountSpy).not.toHaveBeenCalled();
+      expect(accountUpdateSpy).toHaveBeenCalled();
+      expect(successfulMessageSpy).not.toHaveBeenCalled();
+      expect(errorMessageSpy).toHaveBeenCalled();
+      expect(accountService.getAccount().fullName).toBe('Test User');
+      done();
+    });
+  });
+});

--- a/src/app/core/components/billing-settings/billing-settings.component.ts
+++ b/src/app/core/components/billing-settings/billing-settings.component.ts
@@ -1,17 +1,14 @@
 /* @format */
 import { Component, OnInit } from '@angular/core';
 import { AccountService } from '@shared/services/account/account.service';
-import { DataService } from '@shared/services/data/data.service';
 import { AccountVO } from '@models';
 import { ApiService } from '@shared/services/api/api.service';
 import { AccountVOData } from '@models/account-vo';
 import { MessageService } from '@shared/services/message/message.service';
-import {
-  PrConstantsService,
-  Country,
-} from '@shared/services/pr-constants/pr-constants.service';
+import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
 import { FormInputSelectOption } from '@shared/components/form-input/form-input.component';
 import { EventService } from '@shared/services/event/event.service';
+import { savePropertyOnAccount } from '@shared/services/account/account.service.helpers';
 
 @Component({
   selector: 'pr-billing-settings',
@@ -25,7 +22,6 @@ export class BillingSettingsComponent implements OnInit {
 
   constructor(
     private accountService: AccountService,
-    private dataService: DataService,
     private prConstants: PrConstantsService,
     private api: ApiService,
     private message: MessageService,
@@ -56,25 +52,14 @@ export class BillingSettingsComponent implements OnInit {
   }
 
   async onSaveInfo(prop: keyof AccountVO, value: string) {
-    const originalValue = this.account[prop];
-    const data: AccountVOData = new AccountVO(this.account);
-    data[prop] = value;
-    delete data.notificationPreferences;
-    const updateAccountVo = new AccountVO(data);
-    this.account.update(data);
-    const response = await this.api.account.update(updateAccountVo);
-    if (!response.isSuccessful) {
-      const revertData: AccountVOData = {};
-      revertData[prop] = originalValue;
-      this.account.update(revertData);
-      this.message.showError({
-        message: 'There was a problem saving your account changes',
-      });
-    } else {
-      this.message.showMessage({
-        message: 'Account information saved.',
-        style: 'success',
-      });
-    }
+    savePropertyOnAccount(
+      this.account,
+      { prop, value },
+      {
+        accountService: this.accountService,
+        messageService: this.message,
+        apiService: this.api,
+      },
+    );
   }
 }

--- a/src/app/shared/services/account/account.service.helpers.ts
+++ b/src/app/shared/services/account/account.service.helpers.ts
@@ -1,0 +1,48 @@
+import { AccountVO } from '@models/account-vo';
+import { isNull, omitBy } from 'lodash';
+import { MessageService } from '../message/message.service';
+import { ApiService } from '../api/api.service';
+import { AccountService } from './account.service';
+
+interface SavePropertyOnAccountServices {
+  messageService: MessageService;
+  accountService: AccountService;
+  apiService: ApiService;
+}
+
+interface AccountChange {
+  prop: keyof AccountVO;
+  value: string;
+}
+
+export async function savePropertyOnAccount(
+  account: AccountVO,
+  change: AccountChange,
+  services: SavePropertyOnAccountServices,
+) {
+  const originalValue = account[change.prop];
+  const updateData = {
+    primaryEmail: account.primaryEmail,
+    [change.prop]: change.value,
+  };
+  account.update(updateData);
+  try {
+    const response = omitBy(
+      await services.apiService.account.update(updateData),
+      isNull,
+    );
+    account.update(response);
+    services.accountService.setAccount(account);
+    services.messageService.showMessage({
+      message: 'Account information saved.',
+      style: 'success',
+    });
+  } catch (err) {
+    account.update({
+      [change.prop]: originalValue,
+    });
+    services.messageService.showError({
+      message: 'There was a problem saving your account changes',
+    });
+  }
+}

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -288,13 +288,10 @@ export class AccountService {
     const updated = new AccountVO(this.account);
     updated.update(accountChanges);
 
-    return this.api.account
-      .update(updated)
-      .then((response: AccountResponse) => {
-        const newAccount = response.getAccountVO();
-        this.account.update(newAccount);
-        this.storage.local.set(ACCOUNT_KEY, this.account);
-      });
+    return this.api.account.update(updated).then((newAccount: AccountVO) => {
+      this.account.update(newAccount);
+      this.storage.local.set(ACCOUNT_KEY, this.account);
+    });
   }
 
   public changeArchive(archive: ArchiveVO) {

--- a/src/app/shared/services/api/account.repo.spec.ts
+++ b/src/app/shared/services/api/account.repo.spec.ts
@@ -1,11 +1,10 @@
 /* @format */
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { environment } from '@root/environments/environment';
-
 import { HttpService } from '@shared/services/http/http.service';
 import { AccountRepo } from '@shared/services/api/account.repo';
 import { AccountVO } from '@root/app/models';
@@ -56,5 +55,46 @@ describe('AccountRepo', () => {
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Request-Version')).toBe('2');
     req.flush(expected);
+  });
+
+  it('update should call v2 of /account/update', (done) => {
+    const update = {
+      primaryEmail: 'test@example.com',
+      fullName: 'Dr. Test User',
+    };
+
+    repo
+      .update(update)
+      .then((account) => {
+        expect(account).toBeInstanceOf(AccountVO);
+        expect(account.fullName).toBe(update.fullName);
+      })
+      .catch(() => {
+        done.fail();
+      })
+      .finally(() => done());
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/account/update`);
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
+    req.flush(update);
+  });
+
+  it('should map the `zip` propety to `postalCode` when calling /account/update', (done) => {
+    const update = {
+      primaryEmail: 'test@example.com',
+      zip: '12345',
+    };
+
+    repo.update(update).finally(() => done());
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/account/update`);
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
+    expect(req.request.body.zip).toBeUndefined();
+    expect(req.request.body.postalCode).toBe('12345');
+    req.flush(update);
   });
 });

--- a/src/app/user-checklist/services/user-checklist.service.spec.ts
+++ b/src/app/user-checklist/services/user-checklist.service.spec.ts
@@ -125,22 +125,9 @@ describe('UserChecklistService', () => {
     const req = http.expectOne(`${environment.apiUrl}/account/update`);
 
     expect(req.request.method).toBe('POST');
-    expect(
-      req.request.body.RequestVO.data[0].AccountVO.hideChecklist,
-    ).toBeTrue();
+    expect(req.request.body.hideChecklist).toBeTrue();
     req.flush({
-      Results: [
-        {
-          data: [
-            {
-              AccountVO: {
-                hideChecklist: true,
-              },
-            },
-          ],
-        },
-      ],
-      isSuccessful: true,
+      hideChecklist: true,
     });
   });
 


### PR DESCRIPTION
Call the v2 version of the `account/update` endpoint instead of the v1 version. This changes the signature of the account.update method of the ApiService, since it no longer returns a ResponseVO. Update calls to `account.update` and also do some slight refactoring.

Both the BillingSettingsComponent and the AccountSettingsComponent have identical logic when it comes to saving account properties. Extract this logic into a helper function so we can deduplicate this logic but still operate on our component properties and services directly.

PER-9747: Use a v2 request when updating hideChecklist

**Steps to test:**
1. Test updating accounts still works:
    * Verify that a user can change their e-mail address
    * Verify that a user can update their address (including Postal Code which had a special case here)
    * Verify that a user can update their SFTP settings
    * Verify that a user can hide the checklist
2. See if it's a v2 endpoint call