### PR TITLE
Remove old custom dialog service import from stories

### DIFF
--- a/src/app/file-browser/components/sharing-dialog/sharing-dialog.stories.ts
+++ b/src/app/file-browser/components/sharing-dialog/sharing-dialog.stories.ts
@@ -1,5 +1,5 @@
 import { Meta, moduleMetadata, Story } from '@storybook/angular';
-import { DialogRef, DIALOG_DATA } from '@root/app/dialog/dialog.service';
+import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 
 import { AccountService } from '@shared/services/account/account.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';


### PR DESCRIPTION
This import was left over in our Storybook stories, probably missed since it isn't executed in production builds or tests. Get rid of it so Storybook compiles again.