### PR TITLE
Handle new thumbnail sizes

### DIFF
--- a/src/app/core/components/left-menu/left-menu.component.ts
+++ b/src/app/core/components/left-menu/left-menu.component.ts
@@ -29,8 +29,7 @@ import { ApiService } from '@shared/services/api/api.service';
 import { ProfileService } from '@shared/services/profile/profile.service';
 import { PayerService } from '@shared/services/payer/payer.service';
 import { EventService } from '@shared/services/event/event.service';
-import { DeviceService } from '@shared/services/device/device.service';
-import { AnalyticsService } from '@shared/services/analytics/analytics.service';
+import { GetThumbnail } from '@models/get-thumbnail';
 import { ConnectionsDialogComponent } from '../connections-dialog/connections-dialog.component';
 import { ProfileEditComponent } from '../profile-edit/profile-edit.component';
 import { MyArchivesDialogComponent } from '../my-archives-dialog/my-archives-dialog.component';
@@ -110,7 +109,7 @@ export class LeftMenuComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   checkArchiveThumbnail() {
-    if (!this.archive.thumbURL500) {
+    if (!GetThumbnail(this.archive, 500)) {
       setTimeout(async () => {
         await this.accountService.refreshArchive();
         this.checkArchiveThumbnail();

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -1,3 +1,4 @@
+/* @format */
 import {
   Component,
   OnInit,
@@ -13,12 +14,8 @@ import {
   ViewChild,
   AfterViewInit,
 } from '@angular/core';
-import { Router, ActivatedRoute, RouterState } from '@angular/router';
-
+import { Router, ActivatedRoute } from '@angular/router';
 import { getFormattedDate } from '@shared/utilities/dateTime';
-
-import { clone, find } from 'lodash';
-
 import { DataService } from '@shared/services/data/data.service';
 import {
   PromptService,
@@ -26,7 +23,6 @@ import {
   PromptField,
   FOLDER_VIEW_FIELD_INIIAL,
 } from '@shared/services/prompt/prompt.service';
-
 import {
   FolderVO,
   RecordVO,
@@ -50,11 +46,10 @@ import { FolderPickerService } from '@core/services/folder-picker/folder-picker.
 import { Deferred } from '@root/vendor/deferred';
 import { FolderView } from '@shared/services/folder-view/folder-view.enum';
 import { ApiService } from '@shared/services/api/api.service';
-import { checkMinimumAccess, AccessRole } from '@models/access-role';
+import { AccessRole } from '@models/access-role';
 import { DeviceService } from '@shared/services/device/device.service';
 import { StorageService } from '@shared/services/storage/storage.service';
 import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
-
 import {
   DragService,
   DragServiceEvent,
@@ -70,8 +65,8 @@ import { Subscription } from 'rxjs';
 import { DOCUMENT } from '@angular/common';
 import { ngIfFadeInAnimation } from '@shared/animations';
 import { RouteData } from '@root/app/app.routes';
-
 import { ThumbnailCache } from '@shared/utilities/thumbnail-cache/thumbnail-cache';
+import { GetThumbnail } from '@models/get-thumbnail';
 import { ItemClickEvent } from '../file-list/file-list.component';
 import { SharingComponent } from '../sharing/sharing.component';
 import { PublishComponent } from '../publish/publish.component';
@@ -1058,9 +1053,12 @@ export class FileListItemComponent
             const thumbnailItem = sortedItems.shift();
             if (thumbnailItem) {
               if (sortPriorities.includes(thumbnailItem.type)) {
-                if (thumbnailItem.thumbURL200 && thumbnailItem.thumbURL500) {
-                  this.folderThumb200 = thumbnailItem.thumbURL200;
-                  this.folderThumb500 = thumbnailItem.thumbURL500;
+                if (
+                  GetThumbnail(thumbnailItem, 200) &&
+                  GetThumbnail(thumbnailItem, 500)
+                ) {
+                  this.folderThumb200 = GetThumbnail(thumbnailItem, 200);
+                  this.folderThumb500 = GetThumbnail(thumbnailItem, 500);
                 } else {
                   this.folderContentsType =
                     FolderContentsType.BROKEN_THUMBNAILS;
@@ -1104,7 +1102,7 @@ export class FileListItemComponent
         return '';
       }
     } else {
-      return this.inGridView ? this.item.thumbURL500 : this.item.thumbURL200;
+      return GetThumbnail(this.item, 500);
     }
   }
 

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -42,8 +42,6 @@
           "
         ></pr-zooming-image-viewer>
         <pr-thumbnail
-          (disableSwipe)="toggleSwipe($event)"
-          (isFullScreen)="toggleFullscreen($event)"
           [item]="currentRecord"
           *ngIf="
             showThumbnail &&

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -29,12 +29,29 @@
         *ngIf="isQueued(i)"
       ></div>
       <div *ngIf="currentRecord === record" class="full" [ngSwitch]="">
+        <pr-zooming-image-viewer
+          [item]="currentRecord"
+          (disableSwipe)="toggleSwipe($event)"
+          (isFullScreen)="toggleFullscreen($event)"
+          *ngIf="
+            showThumbnail &&
+            isZoomableImage &&
+            !isDocument &&
+            !isVideo &&
+            !isAudio
+          "
+        ></pr-zooming-image-viewer>
         <pr-thumbnail
           (disableSwipe)="toggleSwipe($event)"
           (isFullScreen)="toggleFullscreen($event)"
           [item]="currentRecord"
-          *ngIf="showThumbnail && !isDocument && !isVideo && !isAudio"
-          [hideResizableImage]="false"
+          *ngIf="
+            showThumbnail &&
+            !isZoomableImage &&
+            !isDocument &&
+            !isVideo &&
+            !isAudio
+          "
         ></pr-thumbnail>
         <pr-video [item]="currentRecord" *ngIf="isVideo"></pr-video>
         <pr-audio [item]="currentRecord" *ngIf="isAudio"></pr-audio>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.scss
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.scss
@@ -85,6 +85,7 @@ $button-size: 2rem;
 }
 
 .file-viewer-image,
+pr-zooming-image-viewer,
 pr-thumbnail,
 pr-video,
 pr-audio .thumb-preview,

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -24,6 +24,7 @@ import { PublicProfileService } from '@public/services/public-profile/public-pro
 import type { KeysOfType } from '@shared/utilities/keysoftype';
 import { Subscription } from 'rxjs';
 import { SearchService } from '@search/services/search.service';
+import { ZoomingImageViewerComponent } from '@shared/components/zooming-image-viewer/zooming-image-viewer.component';
 import { TagsService } from '../../../core/services/tags/tags.service';
 
 @Component({
@@ -39,6 +40,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   public nextRecord: RecordVO;
   public records: RecordVO[];
   public currentIndex: number;
+  public isZoomableImage = false;
   public isVideo = false;
   public isAudio = false;
   public isDocument = false;
@@ -189,6 +191,10 @@ export class FileViewerComponent implements OnInit, OnDestroy {
   initRecord() {
     this.isAudio = this.currentRecord.type.includes('audio');
     this.isVideo = this.currentRecord.type.includes('video');
+    this.isZoomableImage =
+      this.currentRecord.type.includes('image') &&
+      this.currentRecord.FileVOs?.length &&
+      ZoomingImageViewerComponent.chooseFullSizeImage(this.currentRecord);
     this.isDocument = this.currentRecord.FileVOs?.some(
       (obj: ItemVO) => obj.type.includes('pdf') || obj.type.includes('txt'),
     );

--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -36,11 +36,7 @@
   <ng-container *ngIf="selectedItem && !isRootFolder">
     <div class="sidebar-item" *ngIf="selectedItem">
       <div class="sidebar-thumbnail">
-        <pr-thumbnail
-          [item]="selectedItem"
-          [hideResizableImage]="true"
-          [maxWidth]="500"
-        ></pr-thumbnail>
+        <pr-thumbnail [item]="selectedItem" [maxWidth]="500"></pr-thumbnail>
       </div>
     </div>
     <div class="sidebar-item">

--- a/src/app/models/archive-vo.ts
+++ b/src/app/models/archive-vo.ts
@@ -33,10 +33,10 @@ export class ArchiveVO extends BaseVO implements DynamicListChild {
   public birthDay;
   public company;
   public description;
-  public thumbURL200;
-  public thumbURL500;
-  public thumbURL1000;
-  public thumbURL2000;
+  public thumbURL200: string;
+  public thumbURL500: string;
+  public thumbURL1000: string;
+  public thumbURL2000: string;
   public thumbArchiveNbr: string;
   public type: ArchiveType;
   public isPendingAction: boolean;

--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -10,6 +10,7 @@ import { TimezoneVOData } from './timezone-vo';
 import { FolderType, SortType, FolderLinkType } from './vo-types';
 import { LocnVOData } from './locn-vo';
 import { TagVOData } from './tag-vo';
+import { HasThumbnails } from './get-thumbnail';
 import { ItemVO, ArchiveVO } from '.';
 
 export interface HasParentFolder {
@@ -30,7 +31,7 @@ export interface ChildItemData {
 
 export class FolderVO
   extends BaseVO
-  implements ChildItemData, HasParentFolder, DynamicListChild
+  implements ChildItemData, HasParentFolder, DynamicListChild, HasThumbnails
 {
   public isFolder = true;
   public isRecord = false;
@@ -66,11 +67,15 @@ export class FolderVO
 
   // Thumbnails
   public thumbStatus;
-  public thumbURL200;
-  public thumbURL500;
-  public thumbURL1000;
-  public thumbURL2000;
+  public thumbURL200: string;
+  public thumbURL500: string;
+  public thumbURL1000: string;
+  public thumbURL2000: string;
   public thumbDT;
+
+  // New thumbnails
+  public thumbnail256: string;
+  public thumbnail256CloudPath: string;
 
   public status;
   public publicDT;
@@ -190,11 +195,13 @@ export interface FolderVOData extends BaseVOData {
   imageRatio?: any;
   type?: any;
   thumbStatus?: any;
-  thumbURL200?: any;
-  thumbURL500?: any;
-  thumbURL1000?: any;
-  thumbURL2000?: any;
+  thumbURL200?: string;
+  thumbURL500?: string;
+  thumbURL1000?: string;
+  thumbURL2000?: string;
   thumbDT?: any;
+  thumbnail256?: string;
+  thumbnail256CloudPath?: string;
   status?: any;
   publicDT?: any;
   parentFolderId?: any;

--- a/src/app/models/get-thumbnail.spec.ts
+++ b/src/app/models/get-thumbnail.spec.ts
@@ -50,4 +50,16 @@ describe('GetThumbnail', () => {
 
     expect(GetThumbnail(folder, 1000)).toBe('https://example.com/correct');
   });
+
+  it('can handle a 256x256 thumbnail size', () => {
+    expect(
+      GetThumbnail(
+        {
+          thumbURL200: 'https://example.com/invalid',
+          thumbnail256: 'https://example.com/correct',
+        },
+        225,
+      ),
+    ).toBe('https://example.com/correct');
+  });
 });

--- a/src/app/models/get-thumbnail.spec.ts
+++ b/src/app/models/get-thumbnail.spec.ts
@@ -62,4 +62,16 @@ describe('GetThumbnail', () => {
       ),
     ).toBe('https://example.com/correct');
   });
+
+  it('should return the maximum size if a size bigger than all thumb sizes is requested', () => {
+    expect(
+      GetThumbnail(
+        {
+          thumbURL200: 'https://example.com/invalid',
+          thumbURL2000: 'https://example.com/correct',
+        },
+        100000,
+      ),
+    ).toBe('https://example.com/correct');
+  });
 });

--- a/src/app/models/get-thumbnail.spec.ts
+++ b/src/app/models/get-thumbnail.spec.ts
@@ -1,0 +1,53 @@
+import { GetThumbnail } from './get-thumbnail';
+import { FolderVO, RecordVO } from '.';
+
+describe('GetThumbnail', () => {
+  it('returns undefined if no thumbnails are defined', () => {
+    const record = new RecordVO({});
+
+    expect(GetThumbnail(record, 256)).toBeUndefined();
+  });
+
+  it('should return the thumbnail if only one is defined', () => {
+    const record = new RecordVO({ thumbURL200: 'https://example.com' });
+
+    expect(GetThumbnail(record, 1000)).toBe('https://example.com');
+  });
+
+  it('should return the thumbnail if the only one defined is not the minimum size', () => {
+    const record = { thumbURL2000: 'https://example.com' };
+
+    expect(GetThumbnail(record, Infinity)).toBe('https://example.com');
+  });
+
+  it('should return the correct thumbnail if two are defined', () => {
+    const record = new RecordVO({
+      thumbURL200: 'https://example.com/invalid',
+      thumbURL500: 'https://example.com/correct',
+    });
+
+    expect(GetThumbnail(record, 300)).toBe('https://example.com/correct');
+  });
+
+  it('should identify the correct thumbnail if all are defined', () => {
+    const record = new RecordVO({
+      thumbURL200: 'https://example.com/invalid',
+      thumbURL500: 'https://example.com/invalid',
+      thumbURL1000: 'https://example.com/correct',
+      thumbURL2000: 'https://example.com/invalid',
+    });
+
+    expect(GetThumbnail(record, 1000)).toBe('https://example.com/correct');
+  });
+
+  it('can take in a folder as well', () => {
+    const folder = new FolderVO({
+      thumbURL200: 'https://example.com/invalid',
+      thumbURL500: 'https://example.com/invalid',
+      thumbURL1000: 'https://example.com/correct',
+      thumbURL2000: 'https://example.com/invalid',
+    });
+
+    expect(GetThumbnail(folder, 1000)).toBe('https://example.com/correct');
+  });
+});

--- a/src/app/models/get-thumbnail.ts
+++ b/src/app/models/get-thumbnail.ts
@@ -4,6 +4,7 @@ interface ThumbnailData {
 }
 export interface HasThumbnails {
   thumbURL200?: string;
+  thumbnail256?: string;
   thumbURL500?: string;
   thumbURL1000?: string;
   thumbURL2000?: string;
@@ -15,6 +16,7 @@ export function GetThumbnail(
 ): string | undefined {
   const thumbnails: ThumbnailData[] = [
     { size: 200, url: item.thumbURL200 },
+    { size: 256, url: item.thumbnail256 },
     { size: 500, url: item.thumbURL500 },
     { size: 1000, url: item.thumbURL1000 },
     { size: 2000, url: item.thumbURL2000 },

--- a/src/app/models/get-thumbnail.ts
+++ b/src/app/models/get-thumbnail.ts
@@ -1,0 +1,26 @@
+interface ThumbnailData {
+  size: number;
+  url: string;
+}
+export interface HasThumbnails {
+  thumbURL200?: string;
+  thumbURL500?: string;
+  thumbURL1000?: string;
+  thumbURL2000?: string;
+}
+
+export function GetThumbnail(
+  item: HasThumbnails,
+  minimumSize: number,
+): string | undefined {
+  const thumbnails: ThumbnailData[] = [
+    { size: 200, url: item.thumbURL200 },
+    { size: 500, url: item.thumbURL500 },
+    { size: 1000, url: item.thumbURL1000 },
+    { size: 2000, url: item.thumbURL2000 },
+  ].filter((thumb) => thumb.url);
+  return (
+    thumbnails.find((thumb) => thumb.size >= minimumSize)?.url ||
+    thumbnails[0]?.url
+  );
+}

--- a/src/app/models/get-thumbnail.ts
+++ b/src/app/models/get-thumbnail.ts
@@ -10,10 +10,10 @@ export interface HasThumbnails {
   thumbURL2000?: string;
 }
 
-export function GetThumbnail(
+export function GetThumbnailInfo(
   item: HasThumbnails,
   minimumSize: number,
-): string | undefined {
+): ThumbnailData | undefined {
   const thumbnails: ThumbnailData[] = [
     { size: 200, url: item.thumbURL200 },
     { size: 256, url: item.thumbnail256 },
@@ -21,8 +21,16 @@ export function GetThumbnail(
     { size: 1000, url: item.thumbURL1000 },
     { size: 2000, url: item.thumbURL2000 },
   ].filter((thumb) => thumb.url);
-  return (
-    thumbnails.find((thumb) => thumb.size >= minimumSize)?.url ||
-    thumbnails[0]?.url
-  );
+  const biggestAvailableThumbnail = thumbnails[thumbnails.length - 1];
+  if (minimumSize > biggestAvailableThumbnail?.size) {
+    return biggestAvailableThumbnail;
+  }
+  return thumbnails.find((thumb) => thumb.size >= minimumSize) || thumbnails[0];
+}
+
+export function GetThumbnail(
+  item: HasThumbnails,
+  minimumSize: number,
+): string | undefined {
+  return GetThumbnailInfo(item, minimumSize)?.url;
 }

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -3,7 +3,6 @@ import { BaseVO, BaseVOData, DynamicListChild } from '@models/base-vo';
 import { DataStatus } from '@models/data-status.enum';
 import { ShareVO, sortShareVOs } from '@models/share-vo';
 import { formatDateISOString } from '@shared/utilities/dateTime';
-import { orderBy } from 'lodash';
 import { AccessRoleType } from './access-role';
 import { TimezoneVOData } from './timezone-vo';
 import { ChildItemData, HasParentFolder } from './folder-vo';
@@ -11,6 +10,7 @@ import { RecordType, FolderLinkType } from './vo-types';
 import { LocnVOData } from './locn-vo';
 import { TagVOData } from './tag-vo';
 import { ArchiveVO } from './archive-vo';
+import { HasThumbnails } from './get-thumbnail';
 
 interface RecordVoOptions {
   dataStatus: DataStatus;
@@ -18,7 +18,7 @@ interface RecordVoOptions {
 
 export class RecordVO
   extends BaseVO
-  implements ChildItemData, HasParentFolder, DynamicListChild
+  implements ChildItemData, HasParentFolder, DynamicListChild, HasThumbnails
 {
   public cleanParams = [
     'recordId',
@@ -68,12 +68,16 @@ export class RecordVO
   public type: RecordType;
 
   // Thumbnails
-  public thumbStatus;
-  public thumbURL200;
-  public thumbURL500;
-  public thumbURL1000;
-  public thumbURL2000;
+  public thumbStatus: string;
+  public thumbURL200: string;
+  public thumbURL500: string;
+  public thumbURL1000: string;
+  public thumbURL2000: string;
   public thumbDT;
+
+  // New thumbnails
+  public thumbnail256: string;
+  public thumbnail256CloudPath: string;
 
   // Statuses
   public fileStatus;
@@ -179,10 +183,12 @@ export interface RecordVOData extends BaseVOData {
   refArchiveNbr?: any;
   type?: any;
   thumbStatus?: any;
-  thumbURL200?: any;
-  thumbURL500?: any;
-  thumbURL1000?: any;
-  thumbURL2000?: any;
+  thumbURL200?: string;
+  thumbURL500?: string;
+  thumbURL1000?: string;
+  thumbURL2000?: string;
+  thumbnail256?: string;
+  thumbnail256CloudPath?: string;
   thumbDT?: any;
   fileStatus?: any;
   status?: any;

--- a/src/app/shared/components/archive-small/archive-small.component.ts
+++ b/src/app/shared/components/archive-small/archive-small.component.ts
@@ -1,14 +1,25 @@
-import { Component, OnInit, OnChanges, Input, SimpleChanges, HostBinding, Output, EventEmitter, ElementRef } from '@angular/core';
-
+/* @format */
+import {
+  Component,
+  OnInit,
+  OnChanges,
+  Input,
+  SimpleChanges,
+  HostBinding,
+  Output,
+  EventEmitter,
+  ElementRef,
+} from '@angular/core';
 import { ArchiveVO } from '@root/app/models';
 import { AccountService } from '@shared/services/account/account.service';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
 import { ApiService } from '@shared/services/api/api.service';
+import { GetThumbnail } from '@models/get-thumbnail';
 
 @Component({
   selector: 'pr-archive-small',
   templateUrl: './archive-small.component.html',
-  styleUrls: ['./archive-small.component.scss']
+  styleUrls: ['./archive-small.component.scss'],
 })
 export class ArchiveSmallComponent implements OnInit, OnChanges {
   @Input() archive: ArchiveVO = null;
@@ -46,13 +57,14 @@ export class ArchiveSmallComponent implements OnInit, OnChanges {
     private account: AccountService,
     private api: ApiService,
     private prConstants: PrConstantsService,
-    public element: ElementRef
-  ) { }
+    public element: ElementRef,
+  ) {}
 
   ngOnInit() {
     const currentArchive = this.account.getArchive();
     if (currentArchive) {
-      this.isCurrent = this.account.getArchive().archiveId === this.archive.archiveId;
+      this.isCurrent =
+        this.account.getArchive().archiveId === this.archive.archiveId;
     } else {
       this.isCurrent = false;
     }
@@ -86,7 +98,10 @@ export class ArchiveSmallComponent implements OnInit, OnChanges {
   }
 
   checkArchiveThumbnail() {
-    if (!this.archive.thumbURL200 && this.archive.status === 'status.archive.gen_avatar') {
+    if (
+      !GetThumbnail(this.archive, 200) &&
+      this.archive.status === 'status.archive.gen_avatar'
+    ) {
       setTimeout(async () => {
         const response = await this.api.archive.get([this.archive]);
         const updated = response.getArchiveVO();
@@ -97,7 +112,8 @@ export class ArchiveSmallComponent implements OnInit, OnChanges {
   }
 
   isDefaultArchive() {
-    return this.account.getAccount()?.defaultArchiveId === this.archive.archiveId;
+    return (
+      this.account.getAccount()?.defaultArchiveId === this.archive.archiveId
+    );
   }
-
 }

--- a/src/app/shared/components/thumbnail/thumbnail.component.html
+++ b/src/app/shared/components/thumbnail/thumbnail.component.html
@@ -1,21 +1,11 @@
 <!-- @format -->
 <div
-  [attr.aria-label]="item | getAltText"
-  [attr.role]="'img'"
-  [hidden]="hideResizableImage && item?.type === 'type.record.image'"
-  id="openseadragon"
-></div>
-<div
   class="pr-thumbnail-image"
   [attr.aria-label]="item | getAltText"
   [attr.role]="'img'"
   [ngClass]="{ loaded: thumbLoaded }"
   [style.backgroundImage]="imageUrl ? 'url(\'' + imageUrl + '\')' : undefined"
-  [hidden]="
-    (!hideResizableImage && item?.type === 'type.record.image') ||
-    item?.isFolder ||
-    isZip
-  "
+  [hidden]="item?.isFolder || isZip"
 ></div>
 <div class="pr-thumbnail-icon" [hidden]="!item?.isFolder">
   <i class="ion-md-folder"></i>

--- a/src/app/shared/components/thumbnail/thumbnail.component.html
+++ b/src/app/shared/components/thumbnail/thumbnail.component.html
@@ -10,6 +10,7 @@
   [attr.aria-label]="item | getAltText"
   [attr.role]="'img'"
   [ngClass]="{ loaded: thumbLoaded }"
+  [style.backgroundImage]="imageUrl ? 'url(\'' + imageUrl + '\')' : undefined"
   [hidden]="
     (!hideResizableImage && item?.type === 'type.record.image') ||
     item?.isFolder ||

--- a/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -25,9 +25,6 @@ export class ThumbnailComponent implements OnInit, DoCheck {
   @Input() public item: ItemVO;
   @Input() public maxWidth: number | undefined;
 
-  @Output() public disableSwipe = new EventEmitter<boolean>(false);
-  @Output() public isFullScreen = new EventEmitter<boolean>(false);
-
   public thumbLoaded = false;
   public isZip = false;
   public imageUrl: string | undefined;

--- a/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.html
+++ b/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.html
@@ -1,0 +1,7 @@
+<!-- @format -->
+<div
+  [attr.aria-label]="item | getAltText"
+  [attr.role]="'img'"
+  id="openseadragon"
+  #viewer
+></div>

--- a/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.scss
+++ b/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.scss
@@ -1,0 +1,20 @@
+/* @format */
+:host {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+#openseadragon {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  opacity: 1;
+}

--- a/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.spec.ts
+++ b/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.spec.ts
@@ -1,0 +1,188 @@
+/* @format */
+import { Shallow } from 'shallow-render';
+import OpenSeadragon from 'openseadragon';
+import { NgModule } from '@angular/core';
+import { GetAltTextPipe } from '@shared/pipes/get-alt-text.pipe';
+import { RecordVO } from '@models/index';
+import { ZoomingImageViewerComponent } from './zooming-image-viewer.component';
+
+@NgModule()
+class DummyModule {}
+
+class MockOpenSeaDragon {
+  private handlers = new Map<string, (any) => void>();
+
+  constructor(public options: OpenSeadragon.Options) {}
+
+  public addHandler(eventName: string, handler: (any) => void) {
+    this.handlers.set(eventName, handler);
+  }
+
+  public raiseEvent(eventName: string, event: any) {
+    this.handlers.get(eventName)(event);
+  }
+
+  public destroy(): void {
+    // do nothing
+  }
+}
+
+function createMockOpenSeaDragon(options: OpenSeadragon.Options) {
+  return new MockOpenSeaDragon(options);
+}
+
+describe('ZoomingImageViewerComponent', () => {
+  let shallow: Shallow<ZoomingImageViewerComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(ZoomingImageViewerComponent, DummyModule)
+      .declare(GetAltTextPipe)
+      .provideMock({
+        provide: 'openseadragon',
+        useValue: createMockOpenSeaDragon,
+      });
+  });
+
+  async function renderWithRecord(record: RecordVO) {
+    return await shallow.render({ bind: { item: record } });
+  }
+
+  function getValidTestRecord(): RecordVO {
+    return new RecordVO({
+      FileVOs: [{ fileURL: 'https://invalid-url' }],
+      type: 'type.record.image',
+    });
+  }
+
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance).toBeTruthy();
+  });
+
+  describe('Choose full size image', async () => {
+    it('will return undefined if no FileVOs are defined', () => {
+      expect(
+        ZoomingImageViewerComponent.chooseFullSizeImage(
+          new RecordVO({ FileVOs: [] }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it('will return the only FileVO url if it exists', () => {
+      expect(
+        ZoomingImageViewerComponent.chooseFullSizeImage(
+          new RecordVO({ FileVOs: [{ fileURL: 'test' }] }),
+        ),
+      ).toBe('test');
+    });
+
+    it('will return the converted FileVO url', () => {
+      expect(
+        ZoomingImageViewerComponent.chooseFullSizeImage(
+          new RecordVO({
+            FileVOs: [
+              { fileURL: 'invalid' },
+              { format: 'file.format.converted', fileURL: 'test' },
+            ],
+          }),
+        ),
+      ).toBe('test');
+    });
+
+    it('will return the first FileVO if there is no converted file', () => {
+      expect(
+        ZoomingImageViewerComponent.chooseFullSizeImage(
+          new RecordVO({
+            FileVOs: [{ fileURL: 'test' }, { fileURL: 'invalid' }],
+          }),
+        ),
+      ).toBe('test');
+    });
+  });
+
+  describe('Record formats that prevent openseadragon setup', () => {
+    async function expectNoViewerWithRecord(record: RecordVO) {
+      const { instance } = await renderWithRecord(record);
+
+      expect(instance.viewer).toBeUndefined();
+    }
+
+    it('needs an instance of RecordVO', async () => {
+      await expectNoViewerWithRecord({} as RecordVO);
+    });
+
+    it('needs FileVOs', async () => {
+      await expectNoViewerWithRecord(
+        new RecordVO({ type: 'type.record.image' }),
+      );
+    });
+
+    it('needs to be an image', async () => {
+      await expectNoViewerWithRecord(
+        new RecordVO({ FileVOs: [{ fileURL: 'test' }] }),
+      );
+    });
+
+    it('needs a valid image url', async () => {
+      await expectNoViewerWithRecord(
+        new RecordVO({
+          FileVOs: [{}],
+          type: 'type.record.image',
+        }),
+      );
+    });
+  });
+
+  it('sets up openseadragon with a record that is an image', async () => {
+    const { instance } = await renderWithRecord(getValidTestRecord());
+
+    expect(instance.viewer).toBeTruthy();
+  });
+
+  it('should output an event when going fullscreen', async () => {
+    const { instance, outputs } = await renderWithRecord(getValidTestRecord());
+    const viewer = instance.viewer;
+
+    viewer.raiseEvent('full-screen', { fullScreen: true });
+
+    expect(outputs.isFullScreen.emit).toHaveBeenCalledWith(true);
+
+    viewer.raiseEvent('full-screen', { fullScreen: false });
+
+    expect(outputs.isFullScreen.emit).toHaveBeenCalledWith(false);
+  });
+
+  it('should output an event if the user zooms in', async () => {
+    const { instance, outputs } = await renderWithRecord(getValidTestRecord());
+
+    const viewer = instance.viewer;
+    viewer.raiseEvent('zoom', { zoom: 2 });
+    viewer.raiseEvent('zoom', { zoom: 3 });
+
+    expect(outputs.disableSwipe.emit).toHaveBeenCalledWith(true);
+
+    viewer.raiseEvent('zoom', { zoom: 2 });
+
+    expect(outputs.disableSwipe.emit).toHaveBeenCalledWith(false);
+  });
+
+  it('should disable panning if the zoom level is lesss than 1', async () => {
+    const { instance } = await renderWithRecord(getValidTestRecord());
+    const viewer = instance.viewer;
+
+    const expectPanning = (enabled: boolean) => {
+      expect((viewer as OpenSeadragon.Options).panHorizontal).toBe(enabled);
+
+      expect((viewer as OpenSeadragon.Options).panVertical).toBe(enabled);
+    };
+
+    viewer.raiseEvent('zoom', { zoom: 1 });
+    viewer.raiseEvent('zoom', { zoom: 0.5 });
+
+    expectPanning(false);
+
+    viewer.raiseEvent('zoom', { zoom: 1.1 });
+    expectPanning(true);
+  });
+});

--- a/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.ts
+++ b/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.ts
@@ -1,0 +1,100 @@
+/* @format */
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnDestroy,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { RecordVO } from '@models/index';
+import * as OpenSeaDragon from 'openseadragon';
+import { ZoomEvent, FullScreenEvent } from 'openseadragon';
+
+@Component({
+  selector: 'pr-zooming-image-viewer',
+  templateUrl: './zooming-image-viewer.component.html',
+  styleUrl: './zooming-image-viewer.component.scss',
+})
+export class ZoomingImageViewerComponent implements AfterViewInit, OnDestroy {
+  @Input() public item: RecordVO;
+
+  @Output() public disableSwipe = new EventEmitter<boolean>(false);
+  @Output() public isFullScreen = new EventEmitter<boolean>(false);
+
+  public viewer: OpenSeaDragon.Viewer;
+
+  private initialZoom: number;
+
+  @ViewChild('viewer') element!: ElementRef<HTMLElement>;
+
+  constructor(
+    @Inject('openseadragon') private imageViewerFn: typeof OpenSeaDragon,
+  ) {}
+
+  public ngAfterViewInit() {
+    const viewerDiv = this.element.nativeElement;
+
+    if (
+      viewerDiv &&
+      this.item instanceof RecordVO &&
+      this.item.FileVOs &&
+      this.item.type === 'type.record.image'
+    ) {
+      const fullSizeImage = ZoomingImageViewerComponent.chooseFullSizeImage(
+        this.item,
+      );
+      if (fullSizeImage == null) {
+        return;
+      }
+      this.viewer = this.imageViewerFn({
+        element: viewerDiv,
+        prefixUrl: 'assets/openseadragon/images/',
+        tileSources: { type: 'image', url: fullSizeImage },
+        visibilityRatio: 1.0,
+        constrainDuringPan: true,
+        maxZoomLevel: 10,
+      });
+
+      this.viewer.addHandler('zoom', (event: ZoomEvent) => {
+        const zoom = event.zoom;
+        if (!this.initialZoom) {
+          this.initialZoom = zoom;
+        }
+
+        this.disableSwipe.emit(zoom > this.initialZoom);
+
+        this.enablePanning(zoom > 1);
+      });
+
+      this.viewer.addHandler('full-screen', (event: FullScreenEvent) => {
+        const { fullScreen } = event;
+        this.isFullScreen.emit(fullScreen);
+      });
+    }
+  }
+
+  public ngOnDestroy() {
+    if (this.viewer) {
+      this.viewer.destroy();
+    }
+  }
+
+  public static chooseFullSizeImage(record: RecordVO) {
+    if (record.FileVOs.length > 1) {
+      const convertedUrl = record.FileVOs.find(
+        (file) => file.format == 'file.format.converted',
+      )?.fileURL;
+      return convertedUrl ?? record.FileVOs[0]?.fileURL;
+    }
+    return record.FileVOs[0]?.fileURL;
+  }
+
+  private enablePanning(flag: boolean): void {
+    (this.viewer as OpenSeaDragon.Options).panHorizontal = flag;
+    (this.viewer as OpenSeaDragon.Options).panVertical = flag;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -193,6 +193,7 @@ import { MobileBannerComponent } from './components/mobile-banner/mobile-banner.
     PrLocationPipe,
     DatePipe,
     DialogCdkService,
+    {provide: 'Image', useValue: Image},
   ],
 })
 export class SharedModule {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -27,6 +27,7 @@ import {
   fas,
   faPenSquare,
 } from '@fortawesome/free-solid-svg-icons';
+import OpenSeadragon from 'openseadragon';
 import { DialogCdkService } from '../dialog-cdk/dialog-cdk.service';
 import { ArchivePickerComponent } from './components/archive-picker/archive-picker.component';
 import { BreadcrumbsComponent } from './components/breadcrumbs/breadcrumbs.component';
@@ -70,6 +71,7 @@ import { SwitcherComponent } from './components/switcher/switcher.component';
 import { GetAltTextPipe } from './pipes/get-alt-text.pipe';
 import { AccessRolePipe } from './pipes/access-role.pipe';
 import { MobileBannerComponent } from './components/mobile-banner/mobile-banner.component';
+import { ZoomingImageViewerComponent } from './components/zooming-image-viewer/zooming-image-viewer.component';
 
 @NgModule({
   imports: [
@@ -137,6 +139,7 @@ import { MobileBannerComponent } from './components/mobile-banner/mobile-banner.
     GetAltTextPipe,
     AccessRolePipe,
     MobileBannerComponent,
+    ZoomingImageViewerComponent,
   ],
   declarations: [
     ThumbnailComponent,
@@ -186,6 +189,7 @@ import { MobileBannerComponent } from './components/mobile-banner/mobile-banner.
     GetAltTextPipe,
     AccessRolePipe,
     MobileBannerComponent,
+    ZoomingImageViewerComponent,
   ],
   providers: [
     PublicLinkPipe,
@@ -193,7 +197,8 @@ import { MobileBannerComponent } from './components/mobile-banner/mobile-banner.
     PrLocationPipe,
     DatePipe,
     DialogCdkService,
-    {provide: 'Image', useValue: Image},
+    { provide: 'Image', useValue: Image },
+    { provide: 'openseadragon', useValue: OpenSeadragon },
   ],
 })
 export class SharedModule {


### PR DESCRIPTION
We will eventually be switching over to having Archivematica-generated thumbnails on records. Ideally we want this switchover to be pretty seamless from the web-app's perspective (in other words, we shouldn't need to make sure we merge code in parallel or have some kind of feature flag). This pull request creates a helper function called `GetThumbnail` that adds a layer of abstraction to fetching thumbnails on an item. This function takes in a minimum size, and it will try to pick the best thumbnail to match that size.

This functionality allows us to:
- Stop generating `thumbURL200`, `thumbURL500`, etc properties on objects without any web-app consequences.
- Introduce Archivematica 256x256 thumbnails and have them be used in the web-app
- Add new Archivematica-generated thumbnail sizes later with ease
- Centralize the logic originally contained in the `pr-thumbnail` component

This pull request also features some refactoring: the `pr-thumbnail` component has been refactored significantly and all OpenSeaDragon functionality has been extracted into its own component. Both components should have robust test coverage now.

**Testing Information**
Right now, we can't fully test this in a deployed environment until real Archivematica thumbnails are generated. In theory this could be simulated by modifying a record in the database to only have a 256x256 thumbnail. We do have unit tests in place to test the `GetThumbnail` functionality, but any manual testing should probably just check to see if thumbnails still load properly throughout the app and that the image viewer still works.