### PR TITLE
Add gift code result message to modal

### DIFF
--- a/src/app/core/components/redeem-gift/redeem-gift.component.html
+++ b/src/app/core/components/redeem-gift/redeem-gift.component.html
@@ -1,0 +1,33 @@
+<!-- @format -->
+<div class="panel-title">Redeem Gift</div>
+<p>
+  If you've been given a gift code, you can redeem it for free storage below.
+</p>
+<form
+  [formGroup]="promoForm"
+  class="dialog-form"
+  (submit)="onPromoFormSubmit(promoForm.value)"
+>
+  <div class="dialog-form-field">
+    <label for="promoCode">Gift code</label>
+    <input
+      type="text"
+      class="form-control"
+      id="promoCode"
+      name="name"
+      formControlName="code"
+    />
+  </div>
+  <div class="dialog-form-field">
+    <button class="btn btn-primary" [disabled]="promoForm.invalid || waiting">
+      Redeem
+    </button>
+  </div>
+  <div
+    class="results-message"
+    *ngIf="resultMessage"
+    [class.successful]="resultMessage?.successful"
+  >
+    {{ resultMessage.message | prConstants }}
+  </div>
+</form>

--- a/src/app/core/components/redeem-gift/redeem-gift.component.scss
+++ b/src/app/core/components/redeem-gift/redeem-gift.component.scss
@@ -1,0 +1,24 @@
+/* @format */
+@import 'variables';
+
+.panel-title {
+  @include tabbedDialogPanelTitle;
+}
+
+.btn {
+  margin: $grid-unit 0;
+  width: auto;
+}
+
+form {
+  @include tabbedDialogPanelForm;
+}
+
+.results-message {
+  &.successful {
+    color: green;
+  }
+  &:not(.successful) {
+    color: $form-error-red;
+  }
+}

--- a/src/app/core/components/redeem-gift/redeem-gift.component.spec.ts
+++ b/src/app/core/components/redeem-gift/redeem-gift.component.spec.ts
@@ -1,0 +1,110 @@
+/* @format */
+import { Shallow } from 'shallow-render';
+import { AccountService } from '@shared/services/account/account.service';
+import { CoreModule } from '@core/core.module';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { PromoVOData } from '../../../models/promo-vo';
+import { ApiService } from '../../../shared/services/api/api.service';
+import { MessageService } from '../../../shared/services/message/message.service';
+import { RedeemGiftComponent } from './redeem-gift.component';
+import {
+  MockAccountService,
+  MockApiService,
+  MockBillingRepo,
+} from './shared-mocks';
+
+describe('StorageDialogComponent', () => {
+  let shallow: Shallow<RedeemGiftComponent>;
+  let messageShown: boolean = false;
+  let mockAccountService: MockAccountService;
+  let mockApiService: MockApiService;
+  let mockActivatedRoute;
+  const paramMap = new BehaviorSubject(convertToParamMap({}));
+  const queryParamMap = new BehaviorSubject(convertToParamMap({}));
+
+  beforeEach(() => {
+    mockActivatedRoute = {
+      paramMap: paramMap.asObservable(),
+      queryParamMap: queryParamMap.asObservable(),
+    };
+    mockAccountService = new MockAccountService();
+    mockApiService = {
+      billing: new MockBillingRepo(),
+    };
+    shallow = new Shallow(RedeemGiftComponent, CoreModule)
+      .dontMock(AccountService)
+      .dontMock(ApiService)
+      .mock(MessageService, {
+        showError: () => {
+          messageShown = true;
+        },
+      })
+      .provide({ provide: AccountService, useValue: mockAccountService })
+      .provide({ provide: ApiService, useValue: mockApiService })
+      .provideMock([{ provide: ActivatedRoute, useValue: mockActivatedRoute }]);
+  });
+
+  it('should exist', async () => {
+    const { element } = await shallow.render();
+
+    expect(element).not.toBeNull();
+  });
+
+  it('has an input for a prefilled promo code', async () => {
+    const { find } = await shallow.render({
+      bind: {
+        promoCode: 'potato',
+      },
+    });
+
+    expect(find('input').nativeElement.value).toBe('potato');
+  });
+
+  it('should send an API request when submitting a promo code', async () => {
+    const { instance } = await shallow.render();
+    const promoData: PromoVOData = { code: 'promo' };
+    await instance.onPromoFormSubmit(promoData);
+
+    expect(mockApiService.billing.calledRedeemPromoCode).toBeTruthy();
+    expect(instance.resultMessage.successful).toBeTrue();
+  });
+
+  it('should update the account after redeeming a promo code', async () => {
+    const { instance } = await shallow.render();
+    const promoData: PromoVOData = { code: 'promo' };
+    await instance.onPromoFormSubmit(promoData);
+
+    expect(mockAccountService.addedStorage).toBe(5000 * 1024 * 1024);
+    expect(instance.resultMessage.successful).toBeTrue();
+  });
+
+  it('should enable the submit button after adding a promo code', async () => {
+    const { find, instance, fixture } = await shallow.render();
+    instance.promoForm.patchValue({
+      code: 'promo1',
+    });
+    instance.promoForm.updateValueAndValidity();
+    fixture.detectChanges();
+    const button = find('.btn-primary');
+
+    expect(button.nativeElement.disabled).toBeFalsy();
+  });
+
+  it('should handle an invalid promo code', async () => {
+    const { instance } = await shallow.render();
+    mockApiService.billing.isSuccessful = false;
+    await instance.onPromoFormSubmit({ code: 'potato' });
+
+    expect(instance.resultMessage.successful).toBeFalse();
+    expect(instance.resultMessage.message).toBe('warning.promo.not_found');
+  });
+
+  it('should handle any other unexpected errors when redeeming promo code', async () => {
+    const { instance } = await shallow.render();
+    mockAccountService.failRefresh = true;
+    await instance.onPromoFormSubmit({ code: 'potato' });
+
+    expect(instance.resultMessage.successful).toBeFalse();
+  });
+});

--- a/src/app/core/components/redeem-gift/redeem-gift.component.stories.ts
+++ b/src/app/core/components/redeem-gift/redeem-gift.component.stories.ts
@@ -1,0 +1,40 @@
+/* @format */
+import { moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { AccountService } from '@shared/services/account/account.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { PrConstantsPipe } from '@shared/pipes/pr-constants.pipe';
+import { RedeemGiftComponent } from './redeem-gift.component';
+import { MockAccountService, MockBillingRepo } from './shared-mocks';
+
+const meta: Meta<RedeemGiftComponent> = {
+  title: 'Redeem Gift Form',
+  component: RedeemGiftComponent,
+  tags: ['storage-dialog', 'dialog'],
+  decorators: [
+    moduleMetadata({
+      imports: [FormsModule, ReactiveFormsModule],
+      declarations: [PrConstantsPipe],
+      providers: [
+        { provide: AccountService, useClass: MockAccountService },
+        { provide: ApiService, useValue: { billing: new MockBillingRepo() } },
+      ],
+    }),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<RedeemGiftComponent>;
+
+export const Successful: Story = {};
+export const ForceError: Story = (() => {
+  const billing = new MockBillingRepo();
+  billing.isSuccessful = false;
+  return {
+    decorators: [
+      moduleMetadata({
+        providers: [{ provide: ApiService, useValue: { billing } }],
+      }),
+    ],
+  };
+})();

--- a/src/app/core/components/redeem-gift/redeem-gift.component.ts
+++ b/src/app/core/components/redeem-gift/redeem-gift.component.ts
@@ -1,0 +1,91 @@
+/* @format */
+import { Component, Input, OnInit } from '@angular/core';
+import {
+  UntypedFormGroup,
+  UntypedFormBuilder,
+  Validators,
+} from '@angular/forms';
+import { PromoVOData } from '@models';
+import { ApiService } from '@shared/services/api/api.service';
+import {
+  BillingResponse,
+  AccountResponse,
+} from '@shared/services/api/index.repo';
+import { FileSizePipe } from '@shared/pipes/filesize.pipe';
+import { AccountService } from '@shared/services/account/account.service';
+import { EventService } from '@shared/services/event/event.service';
+
+interface StorageRedemptionMessage {
+  successful: boolean;
+  message: string;
+}
+
+@Component({
+  selector: 'pr-redeem-gift',
+  templateUrl: './redeem-gift.component.html',
+  styleUrl: './redeem-gift.component.scss',
+})
+export class RedeemGiftComponent implements OnInit {
+  @Input() public promoCode: string = '';
+  public resultMessage: StorageRedemptionMessage | undefined;
+  public promoForm: UntypedFormGroup;
+  public waiting: boolean;
+
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private account: AccountService,
+    private api: ApiService,
+    private event: EventService,
+  ) {}
+
+  public ngOnInit(): void {
+    this.promoForm = this.formBuilder.group({
+      code: [this.promoCode, [Validators.required]],
+    });
+  }
+
+  public async onPromoFormSubmit(value: PromoVOData) {
+    try {
+      this.waiting = true;
+      const response = await this.api.billing.redeemPromoCode(value);
+      await this.handleValidPromoCode(response);
+    } catch (err: unknown) {
+      this.showPromoCodeError(err);
+    } finally {
+      this.waiting = false;
+    }
+  }
+
+  private showPromoCodeError(err: unknown) {
+    const message =
+      err instanceof BillingResponse || err instanceof AccountResponse
+        ? err.getMessage()
+        : 'There was an error redeeming your code.';
+    this.resultMessage = { message, successful: false };
+  }
+
+  private async handleValidPromoCode(response: BillingResponse) {
+    await this.updateAccountStorageBytes(response);
+    this.event.dispatch({
+      entity: 'account',
+      action: 'submit_promo',
+    });
+    this.promoForm.reset();
+  }
+
+  private async updateAccountStorageBytes(response: BillingResponse) {
+    await this.account.refreshAccount();
+    const promo = response.getPromoVO();
+    const bytes = promo.sizeInMB * (1024 * 1024);
+    this.account.addStorageBytes(bytes);
+    this.showPromoCodeSuccess(bytes);
+  }
+
+  private showPromoCodeSuccess(bytes: number) {
+    const pipe = new FileSizePipe();
+    this.resultMessage = {
+      message: `Gift code redeemed for ${pipe.transform(bytes)} of storage.`,
+      successful: true,
+    };
+  }
+}

--- a/src/app/core/components/redeem-gift/shared-mocks.ts
+++ b/src/app/core/components/redeem-gift/shared-mocks.ts
@@ -1,0 +1,58 @@
+import { AccountVO } from '@models/account-vo';
+import { PromoVOData } from '@models/promo-vo';
+import { BillingResponse } from '@shared/services/api/billing.repo';
+
+const mockPromoResponse = {
+  Results: [
+    {
+      data: [
+        {
+          PromoVO: {
+            promoId: 13,
+            code: 'promo9',
+            sizeInMB: 5000,
+          },
+        },
+      ],
+    },
+  ],
+  isSuccessful: true,
+};
+const failedPromoResponse = {
+  Results: [
+    {
+      data: null,
+      message: ['warning.promo.not_found'],
+      status: false,
+    },
+  ],
+  isSuccessful: false,
+};
+export class MockBillingRepo {
+  public calledRedeemPromoCode = false;
+  public isSuccessful = true;
+  public redeemPromoCode(_value: PromoVOData): Promise<BillingResponse> {
+    this.calledRedeemPromoCode = true;
+    if (this.isSuccessful) {
+      return Promise.resolve(new BillingResponse(mockPromoResponse));
+    }
+    return Promise.reject(new BillingResponse(failedPromoResponse));
+  }
+}
+export interface MockApiService {
+  billing: MockBillingRepo;
+}
+export class MockAccountService {
+  public addedStorage: number | undefined;
+  public failRefresh: boolean = false;
+  public refreshAccount(): Promise<void> {
+    if (this.failRefresh) {
+      return Promise.reject();
+    }
+    return Promise.resolve();
+  }
+  public setAccount(_account: AccountVO): void {}
+  public addStorageBytes(sizeInBytes: number): void {
+    this.addedStorage = sizeInBytes;
+  }
+}

--- a/src/app/core/components/storage-dialog/storage-dialog.component.html
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.html
@@ -66,42 +66,7 @@
           <pr-gift-storage></pr-gift-storage>
         </ng-container>
         <ng-container *ngSwitchCase="'promo'">
-          <div class="panel-title">Redeem Gift</div>
-          <p>
-            If you've been given a gift code, you can redeem it for free storage
-            below.
-          </p>
-          <form
-            [formGroup]="promoForm"
-            class="dialog-form"
-            (submit)="onPromoFormSubmit(promoForm.value)"
-          >
-            <div class="dialog-form-field">
-              <label for="promoCode">Gift code</label>
-              <input
-                type="text"
-                class="form-control"
-                id="promoCode"
-                name="name"
-                formControlName="code"
-              />
-            </div>
-            <div
-              class="results-message"
-              *ngIf="resultMessage"
-              [class.successful]="resultMessage?.successful"
-            >
-              {{ resultMessage.message }}
-            </div>
-            <div class="dialog-form-field">
-              <button
-                class="btn btn-primary"
-                [disabled]="promoForm.invalid || waiting"
-              >
-                Redeem
-              </button>
-            </div>
-          </form>
+          <pr-redeem-gift [promoCode]="promoCode"></pr-redeem-gift>
         </ng-container>
         <ng-container *ngSwitchCase="'transaction'">
           <div class="panel-title">Transaction History</div>

--- a/src/app/core/components/storage-dialog/storage-dialog.component.html
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.html
@@ -86,6 +86,13 @@
                 formControlName="code"
               />
             </div>
+            <div
+              class="results-message"
+              *ngIf="resultMessage"
+              [class.successful]="resultMessage?.successful"
+            >
+              {{ resultMessage.message }}
+            </div>
             <div class="dialog-form-field">
               <button
                 class="btn btn-primary"

--- a/src/app/core/components/storage-dialog/storage-dialog.component.ts
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.ts
@@ -1,62 +1,30 @@
 /* @format */
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-} from '@angular/forms';
-import { PromoVOData } from '@models';
 import { Subscription } from 'rxjs';
-import { ApiService } from '@shared/services/api/api.service';
-import {
-  BillingResponse,
-  AccountResponse,
-} from '@shared/services/api/index.repo';
 import { unsubscribeAll } from '@shared/utilities/hasSubscriptions';
-import { FileSizePipe } from '@shared/pipes/filesize.pipe';
-import { AccountService } from '@shared/services/account/account.service';
 import { EventService } from '@shared/services/event/event.service';
 import { DialogRef } from '@angular/cdk/dialog';
 
 type StorageDialogTab = 'add' | 'file' | 'transaction' | 'promo' | 'gift';
-
-interface StorageRedemptionMessage {
-  successful: boolean;
-  message: string;
-}
-
 @Component({
   selector: 'pr-storage-dialog',
   templateUrl: './storage-dialog.component.html',
   styleUrls: ['./storage-dialog.component.scss'],
 })
 export class StorageDialogComponent implements OnInit, OnDestroy {
-  activeTab: StorageDialogTab = 'add';
-
-  promoForm: UntypedFormGroup;
-
-  waiting: boolean;
-
-  tabs = ['add', 'gift', 'promo', 'transaction', 'file'];
-  subscriptions: Subscription[] = [];
-
-  public resultMessage: StorageRedemptionMessage | undefined;
+  public activeTab: StorageDialogTab = 'add';
+  public tabs = ['add', 'gift', 'promo', 'transaction', 'file'];
+  public subscriptions: Subscription[] = [];
+  public promoCode: string | undefined;
 
   constructor(
-    private fb: UntypedFormBuilder,
     private dialogRef: DialogRef,
-    private account: AccountService,
-    private api: ApiService,
     private route: ActivatedRoute,
     private event: EventService,
-  ) {
-    this.promoForm = this.fb.group({
-      code: ['', [Validators.required]],
-    });
-  }
+  ) {}
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.subscriptions.push(
       this.route.paramMap.subscribe((params: ParamMap) => {
         const path = params.get('path') as StorageDialogTab;
@@ -71,17 +39,17 @@ export class StorageDialogComponent implements OnInit, OnDestroy {
       this.route.queryParamMap.subscribe((params) => {
         const param = params.get('promoCode');
         if (this.activeTab === 'promo' && param) {
-          this.promoForm.setValue({ code: param });
+          this.promoCode = param;
         }
       }),
     );
   }
 
-  ngOnDestroy(): void {
+  public ngOnDestroy(): void {
     unsubscribeAll(this.subscriptions);
   }
 
-  setTab(tab: StorageDialogTab) {
+  public setTab(tab: StorageDialogTab) {
     this.activeTab = tab;
     if (tab === 'promo') {
       this.event.dispatch({
@@ -91,52 +59,7 @@ export class StorageDialogComponent implements OnInit, OnDestroy {
     }
   }
 
-  onDoneClick() {
+  public onDoneClick() {
     this.dialogRef.close();
-  }
-
-  async onPromoFormSubmit(value: PromoVOData) {
-    try {
-      this.waiting = true;
-      const response = await this.api.billing.redeemPromoCode(value);
-      await this.handleValidPromoCode(response);
-    } catch (err: unknown) {
-      this.showPromoCodeError(err);
-    } finally {
-      this.waiting = false;
-    }
-  }
-
-  private showPromoCodeError(err: unknown) {
-    const message =
-      err instanceof BillingResponse || err instanceof AccountResponse
-        ? err.getMessage()
-        : 'There was an error redeeming your code.';
-    this.resultMessage = { message, successful: false };
-  }
-
-  private async handleValidPromoCode(response: BillingResponse) {
-    await this.updateAccountStorageBytes(response);
-    this.event.dispatch({
-      entity: 'account',
-      action: 'submit_promo',
-    });
-    this.promoForm.reset();
-  }
-
-  private async updateAccountStorageBytes(response: BillingResponse) {
-    await this.account.refreshAccount();
-    const promo = response.getPromoVO();
-    const bytes = promo.sizeInMB * (1024 * 1024);
-    this.account.addStorageBytes(bytes);
-    this.showPromoCodeSuccess(bytes);
-  }
-
-  private showPromoCodeSuccess(bytes: number) {
-    const pipe = new FileSizePipe();
-    this.resultMessage = {
-      message: `Gift code redeemed for ${pipe.transform(bytes)} of storage`,
-      successful: true,
-    };
   }
 }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -66,6 +66,7 @@ import { AdvancedSettingsComponent } from './components/advanced-settings/advanc
 import { AccountSecurityComponent } from './components/account-security/account-security.component';
 import { ChangePasswordComponent } from './components/change-password/change-password.component';
 import { TwoFactorAuthComponent } from './components/two-factor-auth/two-factor-auth.component';
+import { RedeemGiftComponent } from './components/redeem-gift/redeem-gift.component';
 
 @NgModule({
   imports: [
@@ -125,6 +126,7 @@ import { TwoFactorAuthComponent } from './components/two-factor-auth/two-factor-
     AccountSecurityComponent,
     ChangePasswordComponent,
     TwoFactorAuthComponent,
+    RedeemGiftComponent,
   ],
   providers: [
     FolderViewService,


### PR DESCRIPTION
The MessageService currently cannot show messages above modals. The current form to redeem a gift code is hosted in a modal, so the error and success messages are not visible to users. Show the error and success messages in the modal instead.

**Steps to test:**
1. Open the storage dialog and open the redeem gift tab
2. Test that an error message appears with an invalid promo code
3. Test that a success message appears with a valid one
