### PR TITLE
Log out user with expired JWT on V1 requests

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -26,6 +26,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { HttpV2Service } from '../http-v2/http-v2.service';
 import { EventService } from '../event/event.service';
 import { AnalyticsService } from '../analytics/analytics.service';
+import { HttpService } from '../http/http.service';
 
 const ACCOUNT_KEY = 'account';
 const ARCHIVE_KEY = 'archive';
@@ -61,6 +62,7 @@ export class AccountService {
     private cookies: CookieService,
     private dialog: DialogCdkService,
     private router: Router,
+    private http: HttpService,
     private httpv2: HttpV2Service,
     private location: LocationStrategy,
     private event: EventService,
@@ -87,11 +89,14 @@ export class AccountService {
       this.refreshRoot();
     }
 
-    this.httpv2.tokenExpired.subscribe(() => {
+    const tokenExpireHandler = () => {
       this.logOut().then(() => {
         window.location.reload();
       });
-    });
+    };
+
+    this.httpv2.tokenExpired.subscribe(tokenExpireHandler);
+    this.http.tokenExpired.subscribe(tokenExpireHandler);
   }
 
   public setAccount(newAccount: AccountVO) {

--- a/src/app/shared/services/account/tests/account.service.spec.ts
+++ b/src/app/shared/services/account/tests/account.service.spec.ts
@@ -9,6 +9,8 @@ import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { AuthResponse } from '@shared/services/api/index.repo';
 import { AccountVO, ArchiveVO, FolderVO, RecordVO } from '@root/app/models';
+import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
+import { HttpService } from '@shared/services/http/http.service';
 import { AppModule } from '../../../../app.module';
 import { StorageService } from '../../storage/storage.service';
 import { EditService } from '../../../../core/services/edit/edit.service';
@@ -205,5 +207,23 @@ describe('AccountService', () => {
     await instance.deductAccountStorage(-sizeOfItemsToDelete);
 
     expect(instance.getAccount().spaceLeft).toEqual(100400);
+  });
+
+  describe('Log out on token expiration', () => {
+    it('HttpV2Service', async () => {
+      const { instance, inject } = shallow.createService();
+      const logOut = spyOn(instance, 'logOut').and.rejectWith(false);
+      inject(HttpV2Service).tokenExpired.next();
+
+      expect(logOut).toHaveBeenCalled();
+    });
+
+    it('HttpService', async () => {
+      const { instance, inject } = shallow.createService();
+      const spy = spyOn(instance, 'logOut').and.rejectWith(false);
+      inject(HttpService).tokenExpired.next();
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/shared/services/http/http.service.ts
+++ b/src/app/shared/services/http/http.service.ts
@@ -1,8 +1,8 @@
 /* @format */
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, Subject, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { environment } from '@root/environments/environment';
 
 import { RequestVO } from '@models/request-vo';
@@ -20,6 +20,7 @@ interface RequestOptions {
   providedIn: 'root',
 })
 export class HttpService {
+  public tokenExpired = new Subject<void>();
   private apiUrl = environment.apiUrl;
   private defaultResponseClass = BaseResponse;
 
@@ -52,6 +53,12 @@ export class HttpService {
           } else {
             return new this.defaultResponseClass(response);
           }
+        }),
+        catchError((err) => {
+          if (err.status === 401) {
+            this.tokenExpired.next();
+          }
+          return throwError(err);
         }),
       );
   }


### PR DESCRIPTION
Some V1 endpoints require a JWT now, and will return with an error code if the token is expired. Log the user out if such an error code is returned similar to how we do with the HttpV2 service.

**Steps to test:**
1. Log in to your account
2. Once in the archive manager, open dev tools and delete or replace the AUTH_TOKEN value.
3. Try moving a folder and see if you get logged out or not.