### PR TITLE
Profile settings dialog fixes

### DIFF
--- a/src/app/core/components/main/main.component.scss
+++ b/src/app/core/components/main/main.component.scss
@@ -15,6 +15,10 @@
   }
 }
 
+pr-folder-picker {
+  z-index: 1010;
+}
+
 @include desktop {
   :host {
     display: flex;

--- a/src/app/route-history/route-history.service.spec.ts
+++ b/src/app/route-history/route-history.service.spec.ts
@@ -65,4 +65,13 @@ describe('RouteHistoryService', () => {
     await router.navigate(['/profile']);
     expectRoutesToBeUndefined();
   });
+
+  it('should not record history on popstate', async () => {
+    await router.navigate(['/home']);
+    await router.navigate(['/profile']);
+    (service as any).popstate = true;
+    await router.navigate(['/home']);
+
+    expect(service.previousRoute).toBeUndefined();
+  });
 });

--- a/src/app/route-history/route-history.service.ts
+++ b/src/app/route-history/route-history.service.ts
@@ -1,6 +1,6 @@
 /* @format */
 import { Injectable, OnDestroy } from '@angular/core';
-import { Event, NavigationEnd, Router } from '@angular/router';
+import { Event, NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 @Injectable({
@@ -11,12 +11,19 @@ export class RouteHistoryService implements OnDestroy {
   public previousRoute: string;
 
   private subscription: Subscription;
+  private popstate: boolean = false;
 
   constructor(router: Router) {
     this.subscription = router.events.subscribe((event: Event) => {
+      if (event instanceof NavigationStart) {
+        if (event.navigationTrigger === 'popstate') {
+          this.popstate = true;
+        }
+      }
       if (event instanceof NavigationEnd) {
-        this.previousRoute = this.currentRoute;
+        this.previousRoute = this.popstate ? undefined : this.currentRoute;
         this.currentRoute = event.url;
+        this.popstate = false;
       }
     });
   }

--- a/src/app/shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component.ts
+++ b/src/app/shared/components/routed-dialog-wrapper/routed-dialog-wrapper.component.ts
@@ -63,10 +63,10 @@ export class RoutedDialogWrapperComponent
   }
 
   ngOnDestroy(): void {
+    this.closedByNavigate = true;
     if (this.dialogRef) {
       this.dialogRef.close();
     }
-    this.closedByNavigate = true;
     unsubscribeAll(this.subscriptions);
   }
 


### PR DESCRIPTION
This PR features two fixes to the profile settings dialog:
- The "view on web" button has now been fixed
- The change profile / banner buttons now work as expected

This can be tested locally or by deploying to the `dev` environment.

**Steps to test:**
1. Verify that an archive's profile and banner can be updated
2. Verify that the "view on web" button now works
    - When on the archive's public profile, hit the back button in the browser, and then verify that the close button (the back arrow at the top of the screen) properly redirects the user back to the archive manager.