### PR TITLE
Remove GLAM components from normal onboarding

### DIFF
--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
@@ -84,18 +84,6 @@
           </button>
         </div>
       </div>
-      <pr-select-archive-type-screen
-        (navigationEmitter)="setScreen($event)"
-        (submitEmitter)="handleCreationScreenEvents($event)"
-        *ngIf="screen === 'create'"
-      ></pr-select-archive-type-screen>
-      `
-      <pr-name-archive-screen
-        *ngIf="screen === 'name-archive'"
-        (backToCreateEmitter)="setScreen($event)"
-        (archiveCreatedEmitter)="navigateToGoals($event)"
-        [name]="name"
-      ></pr-name-archive-screen>
     </div>
   </div>
   <div
@@ -118,7 +106,6 @@
       (submitEmitter)="handleCreationScreenEvents($event)"
       *ngIf="screen === 'create'"
     ></pr-select-archive-type-screen>
-    `
     <pr-name-archive-screen
       *ngIf="screen === 'name-archive'"
       (backToCreateEmitter)="setScreen($event)"


### PR DESCRIPTION
These were accidentally copied to the standard onboarding flow. Get rid of them.

This is a pretty urgent fix since it's been deployed to production. However, at this point we should seriously consider a proper refactoring of GLAM onboarding to prevent issues like this from happening again. Refactoring would involve properly isolating the flows from each other so that one's logic or components cannot leak into the other.