### PR TITLE
Do not update account storage if it's already updated

### DIFF
--- a/src/app/core/components/redeem-gift/redeem-gift.component.spec.ts
+++ b/src/app/core/components/redeem-gift/redeem-gift.component.spec.ts
@@ -107,4 +107,14 @@ describe('StorageDialogComponent', () => {
 
     expect(instance.resultMessage.successful).toBeFalse();
   });
+
+  it('should not bump up account storage if it has already been done on the server side', async () => {
+    const { instance } = await shallow.render();
+    mockAccountService.addMoreSpaceAfterRefresh = true;
+    await instance.onPromoFormSubmit({ code: 'potato' });
+
+    expect(mockAccountService.account.spaceLeft).toBe(
+      5000 * 1024 * 1024 + 1024,
+    );
+  });
 });

--- a/src/app/core/components/redeem-gift/redeem-gift.component.ts
+++ b/src/app/core/components/redeem-gift/redeem-gift.component.ts
@@ -74,10 +74,17 @@ export class RedeemGiftComponent implements OnInit {
   }
 
   private async updateAccountStorageBytes(response: BillingResponse) {
+    const spaceBeforeRefresh = this.account.getAccount()?.spaceTotal;
     await this.account.refreshAccount();
+
+    const spaceAfterRefresh = this.account.getAccount()?.spaceTotal;
     const promo = response.getPromoVO();
     const bytes = promo.sizeInMB * (1024 * 1024);
-    this.account.addStorageBytes(bytes);
+
+    if (spaceBeforeRefresh == spaceAfterRefresh) {
+      this.account.addStorageBytes(bytes);
+    }
+
     this.showPromoCodeSuccess(bytes);
   }
 

--- a/src/app/core/components/redeem-gift/shared-mocks.ts
+++ b/src/app/core/components/redeem-gift/shared-mocks.ts
@@ -45,14 +45,28 @@ export interface MockApiService {
 export class MockAccountService {
   public addedStorage: number | undefined;
   public failRefresh: boolean = false;
+  public addMoreSpaceAfterRefresh: boolean = false;
+  public account: AccountVO = new AccountVO({
+    spaceLeft: 1024,
+    spaceTotal: 1024,
+  });
   public refreshAccount(): Promise<void> {
     if (this.failRefresh) {
       return Promise.reject();
     }
+    if (this.addMoreSpaceAfterRefresh) {
+      this.account.spaceLeft += 5000 * 1024 * 1024;
+      this.account.spaceTotal += 5000 * 1024 * 1024;
+    }
     return Promise.resolve();
+  }
+  public getAccount(): AccountVO {
+    return this.account;
   }
   public setAccount(_account: AccountVO): void {}
   public addStorageBytes(sizeInBytes: number): void {
+    this.account.spaceLeft += sizeInBytes;
+    this.account.spaceTotal += sizeInBytes;
     this.addedStorage = sizeInBytes;
   }
 }


### PR DESCRIPTION
When redeeming a promo code, the web-app updates the account client side to reflect the new storage the user has. However it also fetches an updated version of the account from the API, which means it may already get that storage update from the server. Update the logic to only run if the changes are not reflected in the server response.

**Steps to test:**
1. Redeem storage on an account
2. Without refreshing the page, view the current account storage
3. Verify that storage has increased the correct amount for the promo code used