### PR TITLE
Load archives/tags properly on login

### DIFF
--- a/src/app/auth/components/login/login.component.spec.ts
+++ b/src/app/auth/components/login/login.component.spec.ts
@@ -1,39 +1,178 @@
 /* @format */
 import { NgModule } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import { Shallow } from 'shallow-render';
 import { LoginComponent } from '@auth/components/login/login.component';
 import { MessageService } from '@shared/services/message/message.service';
 import { TEST_DATA } from '@core/core.module.spec';
 import { AccountService } from '@shared/services/account/account.service';
+import { AuthResponse } from '@shared/services/api/auth.repo';
+import { TestBed } from '@angular/core/testing';
+import { DeviceService } from '@shared/services/device/device.service';
+import { ArchiveVO } from '@models/index';
+
+const testEmail = 'unittest@example.com';
 
 @NgModule()
 class DummyModule {}
 
-class MockAccountService {}
+class MockAccountService {
+  public switchedToDefaultArchive: boolean = false;
+  public archives: ArchiveVO[] = [];
+  public mfaResponse: boolean = false;
+  public failResponse: boolean = false;
+  public responseMessage: string = '';
+  public async logIn(
+    _email: string,
+    _password: string,
+    _rememberMe: string,
+    _keepLoggedIn: string,
+  ) {
+    const resp = new AuthResponse({
+      isSuccessful: !this.failResponse && !this.mfaResponse,
+    });
+    resp.setMessage([this.responseMessage]);
+    if (this.failResponse) {
+      throw resp;
+    } else {
+      return resp;
+    }
+  }
 
-class MockActivatedRoute {}
+  public async refreshArchives() {
+    return this.archives;
+  }
+
+  public getArchives() {
+    return this.archives;
+  }
+
+  public async switchToDefaultArchive() {
+    this.switchedToDefaultArchive = true;
+  }
+}
+
+class MockActivatedRoute {
+  public snapshot: { queryParams: Record<string, string> } = {
+    queryParams: {},
+  };
+}
+
+class MockRouter {
+  public navigatedRoute: string[] = [];
+  public async navigate(path: string[]) {
+    this.navigatedRoute = path;
+  }
+}
+
+class MockMessageService {
+  showMessage(_: string) {}
+}
+
+class LoginTestingHarness {
+  private component: LoginComponent;
+  constructor(
+    private account: MockAccountService,
+    private route: MockActivatedRoute,
+  ) {}
+
+  public setComponent(instance: LoginComponent) {
+    this.component = instance;
+  }
+
+  public setupLoginError(): void {
+    this.account.failResponse = true;
+    this.account.responseMessage = 'unknown error';
+  }
+
+  public setupIncorrectLogin(): void {
+    this.account.failResponse = true;
+    this.account.responseMessage = 'warning.signin.unknown';
+  }
+
+  public setupMfa(): void {
+    this.account.mfaResponse = true;
+    this.account.responseMessage = 'warning.auth.mfaToken';
+  }
+
+  public setupVerify(): void {
+    this.account.mfaResponse = true;
+    this.account.responseMessage = 'status.auth.need';
+  }
+
+  public setupShareByUrl(param: string): void {
+    this.route.snapshot.queryParams.shareByUrl = param;
+  }
+
+  public setupTimelineCta(): void {
+    this.route.snapshot.queryParams.cta = 'timeline';
+  }
+
+  public setupNormalLogin(): void {
+    this.account.archives = [new ArchiveVO({ archiveId: 1 })];
+  }
+
+  public setupOnboarding(): void {
+    this.account.archives = [];
+  }
+
+  public async testLogin() {
+    this.component.loginForm.patchValue({
+      email: testEmail,
+      password: 'testpassword',
+    });
+
+    await this.component.onSubmit({
+      email: testEmail,
+      password: 'testpassword',
+      rememberMe: true,
+      keepLoggedIn: true,
+    });
+  }
+
+  public getMessageSpy(inject: typeof TestBed.inject) {
+    return spyOn(inject(MessageService), 'showMessage').and.callThrough();
+  }
+
+  public hasPasswordBeenCleared(): boolean {
+    return this.component.loginForm.value.password.length == 0;
+  }
+}
 
 describe('LoginComponent', () => {
   let shallow: Shallow<LoginComponent>;
   let cookieService: Map<string, string>;
-
-  const testEmail = 'unittest@example.com';
+  let accountService: MockAccountService;
+  let activatedRoute: MockActivatedRoute;
+  let router: MockRouter;
+  let harness: LoginTestingHarness;
 
   beforeEach(() => {
+    accountService = new MockAccountService();
+    activatedRoute = new MockActivatedRoute();
+    router = new MockRouter();
     cookieService = new Map<string, string>();
     cookieService.set('rememberMe', testEmail);
-    shallow = new Shallow(LoginComponent, DummyModule)
-      .provideMock(
-        {
-          provide: AccountService,
-          useClass: MockAccountService,
+    harness = new LoginTestingHarness(accountService, activatedRoute);
+    shallow = new Shallow(LoginComponent, DummyModule).provideMock(
+      {
+        provide: AccountService,
+        useValue: accountService,
+      },
+      { provide: ActivatedRoute, useValue: activatedRoute },
+      { provide: CookieService, useValue: cookieService },
+      { provide: MessageService, useClass: MockMessageService },
+      { provide: Router, useValue: router },
+      {
+        provide: DeviceService,
+        useValue: {
+          isMobile() {
+            return true;
+          },
         },
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
-        { provide: CookieService, useValue: cookieService },
-      )
-      .provide(MessageService);
+      },
+    );
   });
 
   it('should create', async () => {
@@ -105,5 +244,91 @@ describe('LoginComponent', () => {
     });
 
     expect(instance.loginForm.valid).toBeTruthy();
+  });
+
+  it('should log in the user if they have archives', async () => {
+    const { instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupNormalLogin();
+    await harness.testLogin();
+
+    expect(router.navigatedRoute).toContain('/');
+    expect(accountService.switchedToDefaultArchive).toBeTrue();
+  });
+
+  it('should redirect to onboarding if the user has no archives', async () => {
+    const { instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupOnboarding();
+    await harness.testLogin();
+
+    expect(router.navigatedRoute.join('/')).toContain('onboarding');
+  });
+
+  it('should redirect to public if the user is coming from timeline view', async () => {
+    const { instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupTimelineCta();
+    await harness.testLogin();
+
+    expect(router.navigatedRoute).toContain('/public');
+  });
+
+  it('should redirect to a sharebyurl if the param is set', async () => {
+    const { instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupShareByUrl('test-1234');
+    await harness.testLogin();
+
+    expect(router.navigatedRoute).toContain('/share');
+    expect(router.navigatedRoute).toContain('test-1234');
+  });
+
+  it('should redirect to Verify page if user needs verification', async () => {
+    const { instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupVerify();
+    await harness.testLogin();
+
+    expect(router.navigatedRoute).toContain('verify');
+  });
+
+  it('should redirect to MFA page if user needs MFA', async () => {
+    const { instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupMfa();
+    await harness.testLogin();
+
+    expect(router.navigatedRoute).toContain('mfa');
+  });
+
+  it('should show an error message in case of login failure', async () => {
+    const { inject, instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupLoginError();
+    const messageSpy = harness.getMessageSpy(inject);
+    await harness.testLogin();
+
+    expect(messageSpy).toHaveBeenCalled();
+    expect(harness.hasPasswordBeenCleared()).toBeFalse();
+  });
+
+  it('should show an error message in case of wrong username/password', async () => {
+    const { inject, instance } = await shallow.render();
+
+    harness.setComponent(instance);
+    harness.setupIncorrectLogin();
+    const messageSpy = harness.getMessageSpy(inject);
+    await harness.testLogin();
+
+    expect(messageSpy).toHaveBeenCalled();
+    expect(harness.hasPasswordBeenCleared()).toBeTrue();
   });
 });

--- a/src/app/auth/components/login/login.component.spec.ts
+++ b/src/app/auth/components/login/login.component.spec.ts
@@ -1,104 +1,109 @@
 /* @format */
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NgModule } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
-
+import { Shallow } from 'shallow-render';
 import { LoginComponent } from '@auth/components/login/login.component';
-import { LogoComponent } from '@auth/components/logo/logo.component';
-import { FormInputComponent } from '@shared/components/form-input/form-input.component';
 import { MessageService } from '@shared/services/message/message.service';
 import { TEST_DATA } from '@core/core.module.spec';
 import { AccountService } from '@shared/services/account/account.service';
-import { FORM_ERROR_MESSAGES } from '@shared/utilities/forms';
+
+@NgModule()
+class DummyModule {}
+
+class MockAccountService {}
+
+class MockActivatedRoute {}
 
 describe('LoginComponent', () => {
-  let component: LoginComponent;
-  let fixture: ComponentFixture<LoginComponent>;
+  let shallow: Shallow<LoginComponent>;
+  let cookieService: Map<string, string>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [LogoComponent, LoginComponent, FormInputComponent],
-      imports: [
-        FormsModule,
-        ReactiveFormsModule,
-        HttpClientTestingModule,
-        RouterTestingModule,
-      ],
-      providers: [CookieService, MessageService, AccountService],
-    }).compileComponents();
-  }));
+  const testEmail = 'unittest@example.com';
 
   beforeEach(() => {
-    const cookieService = TestBed.get(CookieService) as CookieService;
-    cookieService.set('rememberMe', TEST_DATA.account.primaryEmail);
-    fixture = TestBed.createComponent(LoginComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    cookieService = new Map<string, string>();
+    cookieService.set('rememberMe', testEmail);
+    shallow = new Shallow(LoginComponent, DummyModule)
+      .provideMock(
+        {
+          provide: AccountService,
+          useClass: MockAccountService,
+        },
+        { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        { provide: CookieService, useValue: cookieService },
+      )
+      .provide(MessageService);
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should create', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance).toBeTruthy();
   });
 
-  it('should autofill with the email from cookies', () => {
-    expect(component.loginForm.value.email).toEqual(
-      TEST_DATA.account.primaryEmail,
-    );
+  it('should autofill with the email from cookies', async () => {
+    const { instance } = await shallow.render();
+
+    expect(instance.loginForm.value.email).toEqual(testEmail);
   });
 
-  it('should set error for missing email', () => {
-    component.loginForm.get('email').markAsTouched();
-    component.loginForm.patchValue({
+  it('should set error for missing email', async () => {
+    const { instance } = await shallow.render();
+    instance.loginForm.get('email').markAsTouched();
+    instance.loginForm.patchValue({
       email: '',
       password: TEST_DATA.user.password,
     });
 
-    expect(component.loginForm.invalid).toBeTruthy();
-    expect(component.loginForm.get('email').errors.required).toBeTruthy();
+    expect(instance.loginForm.invalid).toBeTruthy();
+    expect(instance.loginForm.get('email').errors.required).toBeTruthy();
   });
 
-  it('should set error for invalid email', () => {
-    component.loginForm.get('email').markAsTouched();
-    component.loginForm.patchValue({
+  it('should set error for invalid email', async () => {
+    const { instance } = await shallow.render();
+    instance.loginForm.get('email').markAsTouched();
+    instance.loginForm.patchValue({
       email: 'lasld;f;aslkj',
       password: TEST_DATA.user.password,
     });
 
-    expect(component.loginForm.invalid).toBeTruthy();
-    expect(component.loginForm.get('email').errors.email).toBeTruthy();
+    expect(instance.loginForm.invalid).toBeTruthy();
+    expect(instance.loginForm.get('email').errors.email).toBeTruthy();
   });
 
-  it('should set error for missing password', () => {
-    component.loginForm.get('password').markAsTouched();
-    component.loginForm.patchValue({
+  it('should set error for missing password', async () => {
+    const { instance } = await shallow.render();
+    instance.loginForm.get('password').markAsTouched();
+    instance.loginForm.patchValue({
       email: TEST_DATA.user.email,
       password: '',
     });
 
-    expect(component.loginForm.invalid).toBeTruthy();
-    expect(component.loginForm.get('password').errors.required).toBeTruthy();
+    expect(instance.loginForm.invalid).toBeTruthy();
+    expect(instance.loginForm.get('password').errors.required).toBeTruthy();
   });
 
-  it('should set error for too short password', () => {
-    component.loginForm.get('password').markAsTouched();
-    component.loginForm.patchValue({
+  it('should set error for too short password', async () => {
+    const { instance } = await shallow.render();
+    instance.loginForm.get('password').markAsTouched();
+    instance.loginForm.patchValue({
       email: TEST_DATA.user.email,
       password: 'short',
     });
 
-    expect(component.loginForm.invalid).toBeTruthy();
-    expect(component.loginForm.get('password').errors.minlength).toBeTruthy();
+    expect(instance.loginForm.invalid).toBeTruthy();
+    expect(instance.loginForm.get('password').errors.minlength).toBeTruthy();
   });
 
-  it('should have no errors when email and password valid', () => {
-    component.loginForm.markAsTouched();
-    component.loginForm.patchValue({
+  it('should have no errors when email and password valid', async () => {
+    const { instance } = await shallow.render();
+    instance.loginForm.markAsTouched();
+    instance.loginForm.patchValue({
       email: TEST_DATA.user.email,
       password: TEST_DATA.user.password,
     });
 
-    expect(component.loginForm.valid).toBeTruthy();
+    expect(instance.loginForm.valid).toBeTruthy();
   });
 });

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -52,7 +52,7 @@ export class LoginComponent {
   onSubmit(formValue: any) {
     this.waiting = true;
 
-    this.accountService
+    return this.accountService
       .logIn(
         formValue.email,
         formValue.password,

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -110,23 +110,27 @@ export class LoginComponent {
             window.location.assign(`/app/public?cta=timeline`);
           }
         } else {
-          const archives = this.accountService
-            .getArchives()
-            .filter((archive) => !archive.isPending());
-          if (archives.length > 0) {
-            this.router
-              .navigate(['/'], { queryParamsHandling: 'preserve' })
-              .then(() => {
-                this.message.showMessage({
-                  message: `Logged in as ${
-                    this.accountService.getAccount().primaryEmail
-                  }.`,
-                  style: 'success',
-                });
+          this.accountService.refreshArchives().then(() => {
+            const archives = this.accountService
+              .getArchives()
+              .filter((archive) => !archive.isPending());
+            if (archives.length > 0) {
+              this.accountService.switchToDefaultArchive().then(() => {
+                this.router
+                  .navigate(['/'], { queryParamsHandling: 'preserve' })
+                  .then(() => {
+                    this.message.showMessage({
+                      message: `Logged in as ${
+                        this.accountService.getAccount().primaryEmail
+                      }.`,
+                      style: 'success',
+                    });
+                  });
               });
-          } else {
-            this.router.navigate(['/app/onboarding']);
-          }
+            } else {
+              this.router.navigate(['/app/onboarding']);
+            }
+          });
         }
       })
       .catch((response: AuthResponse) => {

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -49,7 +49,12 @@ export class LoginComponent {
     });
   }
 
-  onSubmit(formValue: any) {
+  onSubmit(formValue: {
+    email: string;
+    password: string;
+    rememberMe: boolean;
+    keepLoggedIn: boolean;
+  }) {
     this.waiting = true;
 
     return this.accountService

--- a/src/app/core/services/tags/tags.service.spec.ts
+++ b/src/app/core/services/tags/tags.service.spec.ts
@@ -3,27 +3,57 @@ import { TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 
 import { AccountService } from '@shared/services/account/account.service';
-import { ArchiveVO, RecordVO } from '@models';
+import { ArchiveVO, RecordVO, TagVO } from '@models';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ApiService } from '@shared/services/api/api.service';
+import { EventEmitter } from '@angular/core';
 import { TagsService } from './tags.service';
+
+class MockApiService {
+  public tag = new MockTagsRepo();
+}
+class MockTagsRepo {
+  public apiCalls: number = 0;
+  async getTagsByArchive(_archiveId: number) {
+    this.apiCalls++;
+    return {
+      getTagVOsData(): TagVO[] {
+        return [
+          new TagVO({ tagId: 1, name: 'tagOne' }),
+          new TagVO({ tagId: 2, name: 'tagTwo' }),
+        ];
+      },
+    };
+  }
+}
+
+class MockAccountService {
+  public archiveChange = new EventEmitter<ArchiveVO>();
+  public archive = new ArchiveVO({ archiveId: 1 });
+
+  public getArchive() {
+    return this.archive;
+  }
+}
 
 describe('TagsService', () => {
   let service: TagsService;
+  let api: MockApiService;
+  let account: MockAccountService;
 
   beforeEach(() => {
+    api = new MockApiService();
+    account = new MockAccountService();
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
-        ApiService,
+        {
+          provide: ApiService,
+          useValue: api,
+        },
         {
           provide: AccountService,
-          useValue: {
-            getArchive: () => new ArchiveVO({ archiveId: 1 }),
-            archiveChange: {
-              subscribe: (callback) => new Subscription(),
-            },
-          },
+          useValue: account,
         },
       ],
     });
@@ -31,8 +61,37 @@ describe('TagsService', () => {
     service = TestBed.inject(TagsService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('should fetch tags once on creation', (done) => {
+    service.getTags$().subscribe((tags) => {
+      expect(tags.length).toBe(2);
+      expect(api.tag.apiCalls).toBe(1);
+      done();
+    });
+  });
+
+  it('should fetch tags once on archive update', (done) => {
+    let created = false;
+    service.getTags$().subscribe((tags) => {
+      if (!created) {
+        created = true;
+        api.tag.apiCalls = 0;
+        account.archiveChange.next(new ArchiveVO({}));
+      } else {
+        expect(tags.length).toBe(2);
+        expect(api.tag.apiCalls).toBe(1);
+        done();
+      }
+    });
+  });
+
+  it('should reset tags on archive update if no archive is set', (done) => {
+    service.getTags$().subscribe(async () => {
+      account.archive = undefined;
+      await service.refreshTags();
+
+      expect(service.getTags().length).toBe(0);
+      done();
+    });
   });
 
   it('should only cache tags from the current archive', () => {

--- a/src/app/core/services/tags/tags.service.ts
+++ b/src/app/core/services/tags/tags.service.ts
@@ -13,7 +13,7 @@ import { ApiService } from '@shared/services/api/api.service';
   providedIn: 'root',
 })
 export class TagsService {
-  private tags: Map<number, TagVOData> = new Map();
+  private tags: Map<number, TagVOData> = new Map<number, TagVOData>();
   private tagsSubject: Subject<TagVOData[]> = new Subject();
   private itemsTagsSubject: Subject<TagVOData[]> = new Subject();
   private debug = debug('service:tagsService');
@@ -25,7 +25,6 @@ export class TagsService {
 
     this.account.archiveChange.subscribe(() => {
       this.resetTags();
-      this.refreshTags();
     });
 
     debugSubscribable('getTags', this.debug, this.getTags$());


### PR DESCRIPTION
The default (non-MFA) login process does not load up to date archive information as part of its flow. As a result, all logins currently redirect the user to onboarding since the login code doesn't see any archives that belong to the user. Thankfully this doesn't actually create any major issues, since the onboarding page immediately runs a check for archives and redirects the user back to the private workspace.

This does create a few subtle issues though:
  - The default archive is not being set in a way that the TagsService can notice
  - The "Logged in as $user" message is not being displayed

The former issue in particular means that tags are not loaded properly in a standard login. Add a call to "refreshArchives" in the login process so we can properly run the "non-onboarding non-MFA" login routine, and then add a call to `switchToDefaultArchive` in that routine since we know the user has at least one non-pending archive that must be a default. The latter function call also triggers an event that causes the TagsService to load all archive tags correctly.

**Steps to test:**
1. On an account **without** MFA enabled, add some records to the root of the private workspace and add some tags to them.
2. Create a subdirectory in the private workspace, upload a new record into it, and then add a brand new tag onto that record that is not used elsewhere in the archive.
3. Log out and log back in. Try editing the tags of any specific items in the root of the private workspace. Under this branch, the new tag you just created should be visible in the tags list of the metadata editor. Under the main branch, it should not be visible.
- Bonus check: Verify that `getTagsByArchive` is not being called twice in rapid succession in the developer network logs on login