### PR TITLE
PER-9881: The location picker never closes

### DIFF
--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -161,7 +161,7 @@
         class="sidebar-item-content"
         (click)="onLocationClick()"
         tabindex="0"
-        (focus)="onLocationClick()"
+        (keydown)="onLocationEnterPress($event)"
         [class.can-edit]="canEdit"
       >
         <pr-static-map [location]="selectedItem.LocnVO"></pr-static-map>

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -6,9 +6,8 @@ import { EditService } from '@core/services/edit/edit.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { ArchiveVO, RecordVO } from '@models/index';
 import { of } from 'rxjs';
+import { RecordCastPipe } from '@shared/pipes/cast.pipe';
 import { SidebarComponent } from './sidebar.component';
-
-const itemsArray = [new RecordVO({}), new RecordVO({})];
 
 const mockDataService = {
   selectedItems$: () =>
@@ -19,11 +18,11 @@ const mockDataService = {
         }),
       ]),
     ),
-  fetchFullItems: (itemsArray) => {},
+  fetchFullItems: (_) => {},
 };
 
 const mockEditService = {
-  openLocationDialog: (record) => {},
+  openLocationDialog: (_) => {},
 };
 
 class MockAccountService {
@@ -47,14 +46,15 @@ describe('SidebarComponent', () => {
         provide: DataService,
         useValue: mockDataService,
       })
-      .provide({
+      .provideMock({
         provide: EditService,
         useValue: mockEditService,
       })
       .provideMock({
         provide: AccountService,
         useClass: MockAccountService,
-      });
+      })
+      .dontMock(RecordCastPipe);
   });
 
   it('should create', async () => {
@@ -64,22 +64,17 @@ describe('SidebarComponent', () => {
   });
 
   it('should open location dialog on Enter key press if editable', async () => {
-    const { instance, fixture, inject } = await shallow.render();
+    const { instance } = await shallow.render();
 
-    inject(AccountService);
+    const locationDialogSpy = spyOn(
+      mockEditService,
+      'openLocationDialog',
+    ).and.callThrough();
 
-    instance.canEdit = true;
-    instance.selectedItem = new RecordVO({
-      accessRole: 'access.role.owner',
-    });
-    instance.selectedItems = [instance.selectedItem];
-    fixture.detectChanges();
-
-    const mockEvent = new KeyboardEvent('keydown', { key: 'Enter' });
-    instance.onLocationEnterPress(mockEvent);
-
-    expect(mockEditService.openLocationDialog).toHaveBeenCalledWith(
-      instance.selectedItem,
+    instance.onLocationEnterPress(
+      new KeyboardEvent('keydown', { key: 'Enter' }),
     );
+
+    expect(locationDialogSpy).toHaveBeenCalledWith(instance.selectedItem);
   });
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -8,6 +8,8 @@ import { ArchiveVO, RecordVO } from '@models/index';
 import { of } from 'rxjs';
 import { SidebarComponent } from './sidebar.component';
 
+const itemsArray = [new RecordVO({}), new RecordVO({})];
+
 const mockDataService = {
   selectedItems$: () =>
     of(
@@ -17,6 +19,7 @@ const mockDataService = {
         }),
       ]),
     ),
+  fetchFullItems: (itemsArray) => {},
 };
 
 const mockEditService = {

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -77,4 +77,62 @@ describe('SidebarComponent', () => {
 
     expect(locationDialogSpy).toHaveBeenCalledWith(instance.selectedItem);
   });
+
+  it('should set currentTab correctly when setCurrentTab is called', async () => {
+    const { instance, fixture } = await shallow.render();
+
+    instance.setCurrentTab('info');
+    fixture.detectChanges();
+
+    expect(instance.currentTab).toBe('info');
+
+    instance.isRootFolder = false;
+    instance.isPublicItem = false;
+    instance.setCurrentTab('sharing');
+    fixture.detectChanges();
+
+    expect(instance.currentTab).toBe('sharing');
+  });
+
+  it('should call editService.openLocationDialog when onLocationClick is called if editable', async () => {
+    const { instance, inject } = await shallow.render();
+    const editService = inject(EditService);
+    spyOn(editService, 'openLocationDialog');
+  
+    instance.canEdit = true;
+    instance.selectedItem = new RecordVO({}); 
+  
+    instance.onLocationClick();
+    
+    expect(editService.openLocationDialog).toHaveBeenCalledWith(instance.selectedItem);
+  });
+  
+
+  it('should correctly update canEdit and canShare when checkPermissions is called', async () => {
+    const { instance } = await shallow.render();
+
+    instance.selectedItem = new RecordVO({
+      accessRole: 'access.role.editor',
+    });
+    instance.selectedItems = [instance.selectedItem];
+    instance.isRootFolder = false;
+    instance.isPublicItem = false;
+
+    instance.checkPermissions();
+
+    expect(instance.canEdit).toBe(true);
+    expect(instance.canShare).toBe(true);
+
+    instance.selectedItem = new RecordVO({
+      accessRole: 'access.role.viewer',
+    });
+    instance.selectedItems = [instance.selectedItem];
+    instance.isRootFolder = false;
+    instance.isPublicItem = false;
+
+    instance.checkPermissions();
+
+    expect(instance.canEdit).toBe(false);
+    expect(instance.canShare).toBe(true);
+  });
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -98,15 +98,16 @@ describe('SidebarComponent', () => {
     const { instance, inject } = await shallow.render();
     const editService = inject(EditService);
     spyOn(editService, 'openLocationDialog');
-  
+
     instance.canEdit = true;
-    instance.selectedItem = new RecordVO({}); 
-  
+    instance.selectedItem = new RecordVO({});
+
     instance.onLocationClick();
-    
-    expect(editService.openLocationDialog).toHaveBeenCalledWith(instance.selectedItem);
+
+    expect(editService.openLocationDialog).toHaveBeenCalledWith(
+      instance.selectedItem,
+    );
   });
-  
 
   it('should correctly update canEdit and canShare when checkPermissions is called', async () => {
     const { instance } = await shallow.render();

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -160,10 +160,17 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
   async onFinishEditing(property: KeysOfType<ItemVO, String>, value: string) {
     this.editService.saveItemVoProperty(this.selectedItem, property, value);
     this.cdr.detectChanges();
+    console.log('here');
   }
 
   onLocationClick() {
     if (this.canEdit) {
+      this.editService.openLocationDialog(this.selectedItem);
+    }
+  }
+
+  onLocationEnterPress(e: KeyboardEvent): void {
+    if (this.canEdit && e.key === 'Enter') {
       this.editService.openLocationDialog(this.selectedItem);
     }
   }

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -160,7 +160,6 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
   async onFinishEditing(property: KeysOfType<ItemVO, String>, value: string) {
     this.editService.saveItemVoProperty(this.selectedItem, property, value);
     this.cdr.detectChanges();
-    console.log('here');
   }
 
   onLocationClick() {

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -51,10 +51,10 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 
     this.subscriptions.push(
       this.dataService.selectedItems$().subscribe(async (selectedItems) => {
-        if (!selectedItems.size) {
+        if (!selectedItems?.size) {
           this.selectedItem = this.dataService.currentFolder;
           this.selectedItems = null;
-        } else if (selectedItems.size === 1) {
+        } else if (selectedItems?.size === 1) {
           this.selectedItem = Array.from(selectedItems.keys())[0];
           this.selectedItems = null;
         } else {
@@ -132,7 +132,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
       !viewOnly &&
       this.accountService.checkMinimumArchiveAccess(AccessRole.Editor);
 
-    if (items.length !== 1) {
+    if (items?.length !== 1) {
       this.canShare = false;
     } else {
       this.canShare =

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -93,6 +93,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
         }
         if (
           this.selectedItem instanceof RecordVO &&
+          this.selectedItem.FileVOs &&
           this.selectedItem.FileVOs[0]
         ) {
           this.originalFileExtension = this.selectedItem.FileVOs.find(

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -51,10 +51,10 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 
     this.subscriptions.push(
       this.dataService.selectedItems$().subscribe(async (selectedItems) => {
-        if (!selectedItems?.size) {
+        if (!selectedItems.size) {
           this.selectedItem = this.dataService.currentFolder;
           this.selectedItems = null;
-        } else if (selectedItems?.size === 1) {
+        } else if (selectedItems.size === 1) {
           this.selectedItem = Array.from(selectedItems.keys())[0];
           this.selectedItems = null;
         } else {
@@ -133,7 +133,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
       !viewOnly &&
       this.accountService.checkMinimumArchiveAccess(AccessRole.Editor);
 
-    if (items?.length !== 1) {
+    if (items.length !== 1) {
       this.canShare = false;
     } else {
       this.canShare =


### PR DESCRIPTION
Change the focus event to keydown event so the location picker closes when the user presses done.

Steps to test:

Open the location picker and select a location, then click done.
The location picker should close