### PR TITLE
Add FeatureFlagModule and FeatureFlagService

### DIFF
--- a/src/app/feature-flag/feature-flag.module.ts
+++ b/src/app/feature-flag/feature-flag.module.ts
@@ -1,0 +1,12 @@
+/* @format */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FEATURE_FLAG_API } from './types/feature-flag-api';
+import { FeatureFlagApiService } from './services/feature-flag-api.service';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule],
+  providers: [{ provide: FEATURE_FLAG_API, useClass: FeatureFlagApiService }],
+})
+export class FeatureFlagModule {}

--- a/src/app/feature-flag/services/feature-flag-api.service.spec.ts
+++ b/src/app/feature-flag/services/feature-flag-api.service.spec.ts
@@ -1,0 +1,66 @@
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
+import { environment } from '@root/environments/environment';
+import { FeatureFlag } from '../types/feature-flag';
+import { FeatureFlagApiService } from './feature-flag-api.service';
+
+describe('FeatureFlagApiService', () => {
+  let service: FeatureFlagApiService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [HttpV2Service],
+    });
+    service = TestBed.inject(FeatureFlagApiService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('can fetch feature flags from the back end', (done) => {
+    const expectedFlags: FeatureFlag[] = [
+      { name: 'potato', globallyEnabled: true },
+      { name: 'tomato', globallyEnabled: true },
+    ];
+
+    service
+      .getFeatureFlags()
+      .then((flags) => {
+        expect(flags).toEqual(expectedFlags);
+        done();
+      })
+      .catch(() => {
+        done.fail();
+      });
+
+    const req = http.expectOne(`${environment.apiUrl}/v2/feature-flags`);
+
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
+    req.flush(expectedFlags);
+  });
+
+  it('can silently handles errors from the server', (done) => {
+    service
+      .getFeatureFlags()
+      .then((flags) => {
+        expect(flags.length).toBe(0);
+        done();
+      })
+      .catch(() => {
+        done.fail();
+      });
+
+    const req = http.expectOne(`${environment.apiUrl}/v2/feature-flags`);
+    req.flush({}, { status: 400, statusText: 'Bad Request' });
+  });
+});

--- a/src/app/feature-flag/services/feature-flag-api.service.ts
+++ b/src/app/feature-flag/services/feature-flag-api.service.ts
@@ -1,0 +1,21 @@
+/* @format */
+import { Injectable } from '@angular/core';
+import { HttpV2Service } from '@shared/services/http-v2/http-v2.service';
+import { firstValueFrom } from 'rxjs';
+import { FeatureFlag } from '../types/feature-flag';
+import { FeatureFlagApi } from '../types/feature-flag-api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FeatureFlagApiService implements FeatureFlagApi {
+  constructor(private http: HttpV2Service) {}
+
+  public async getFeatureFlags(): Promise<FeatureFlag[]> {
+    try {
+      return await firstValueFrom(this.http.get(`/v2/feature-flags`));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/app/feature-flag/services/feature-flag.service.spec.ts
+++ b/src/app/feature-flag/services/feature-flag.service.spec.ts
@@ -1,0 +1,55 @@
+/* @format */
+import { TestBed } from '@angular/core/testing';
+import { FeatureFlag } from '../types/feature-flag';
+import { FEATURE_FLAG_API, FeatureFlagApi } from '../types/feature-flag-api';
+import { FeatureFlagService } from './feature-flag.service';
+
+class MockFeatureFlagApi implements FeatureFlagApi {
+  public flags: FeatureFlag[] = [];
+
+  public async getFeatureFlags(): Promise<FeatureFlag[]> {
+    return this.flags;
+  }
+}
+
+describe('FeatureFlagService', () => {
+  let service: FeatureFlagService;
+  let mockApi: MockFeatureFlagApi;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: FEATURE_FLAG_API, useClass: MockFeatureFlagApi }],
+    });
+    service = TestBed.inject(FeatureFlagService);
+    mockApi = TestBed.inject(FEATURE_FLAG_API) as MockFeatureFlagApi;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should be able to set a feature flag', () => {
+    service.set('test', true);
+  });
+
+  it('should be able to test a feature flag that is not set', () => {
+    expect(service.isEnabled('potato')).toBeFalse();
+  });
+
+  it('should be able to test a feature flag that is set', () => {
+    service.set('test', true);
+
+    expect(service.isEnabled('test')).toBeTrue();
+  });
+
+  it('should fetch from the API on init', async () => {
+    mockApi.flags = [
+      { name: 'api0', globallyEnabled: true },
+      { name: 'api1', globallyEnabled: false },
+    ];
+    await service.fetchFromApi();
+
+    expect(service.isEnabled('api0')).toBeTrue();
+    expect(service.isEnabled('api1')).toBeFalse();
+  });
+});

--- a/src/app/feature-flag/services/feature-flag.service.ts
+++ b/src/app/feature-flag/services/feature-flag.service.ts
@@ -1,0 +1,33 @@
+/* @format */
+import { Inject, Injectable, Optional } from '@angular/core';
+import { FEATURE_FLAG_API, FeatureFlagApi } from '../types/feature-flag-api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FeatureFlagService {
+  private flags = new Map<string, boolean>();
+
+  constructor(
+    @Optional() @Inject(FEATURE_FLAG_API) private api: FeatureFlagApi,
+  ) {
+    this.fetchFromApi();
+  }
+
+  public async fetchFromApi(): Promise<void> {
+    try {
+      const flags = await this.api.getFeatureFlags();
+      flags.forEach((flag) => this.set(flag.name, flag.globallyEnabled));
+    } catch {
+      // Do nothing
+    }
+  }
+
+  public set(flag: string, enabled: boolean): void {
+    this.flags.set(flag, enabled);
+  }
+
+  public isEnabled(flag: string): boolean {
+    return this.flags.has(flag) && this.flags.get(flag);
+  }
+}

--- a/src/app/feature-flag/types/feature-flag-api.ts
+++ b/src/app/feature-flag/types/feature-flag-api.ts
@@ -1,0 +1,11 @@
+/* @format */
+import { InjectionToken } from '@angular/core';
+import { FeatureFlag } from './feature-flag';
+
+export interface FeatureFlagApi {
+  getFeatureFlags(): Promise<FeatureFlag[]>;
+}
+
+export const FEATURE_FLAG_API = new InjectionToken<FeatureFlagApi>(
+  'FeatureFlagApi',
+);

--- a/src/app/feature-flag/types/feature-flag.ts
+++ b/src/app/feature-flag/types/feature-flag.ts
@@ -1,0 +1,6 @@
+/* @format */
+
+export interface FeatureFlag {
+  name: string;
+  globallyEnabled: boolean;
+}


### PR DESCRIPTION
Add a service designed to query feature flags that are fetched from the API. This behavior is implemented in two classes: one for storing and querying the currently set flags and one for initially fetching them from the API.

It is designed like this so that we can test these functionalities on their own and so that the FeatureFlagService can be used in unit tests without any mocking. Any components that query FeatureFlags can just use the service directly and use the `set` method to manipulate feature flags directly in the test.

Since this is adding a service that is not currently used by any components, there is no way to manually test this in production, however the whole service is covered by unit tests. This PR will not go through a QA review; please check and run the unit tests to verify correct behavior.