### PR TITLE
Fix CustomOverlayContainer test failures

### DIFF
--- a/src/app/dialog-cdk/custom-overlay-container.spec.ts
+++ b/src/app/dialog-cdk/custom-overlay-container.spec.ts
@@ -26,31 +26,26 @@ describe('CustomOverlayContainer', () => {
     expect(customOverlayContainer).toBeTruthy();
   });
 
-  describe('_createContainer', () => {
-    it('should append the container to pr-app-root if it exists', () => {
-      const mockAppRoot = document.createElement('pr-app-root');
-      document.body.appendChild(mockAppRoot);
+  it('should append the container to pr-app-root if it exists', () => {
+    const mockBodyNode = document.createElement('body');
+    const mockAppRoot = document.createElement('pr-app-root');
+    mockBodyNode.appendChild(mockAppRoot);
 
-      customOverlayContainer['_createContainer']();
+    customOverlayContainer.appendContainer(mockBodyNode);
 
-      const container = document.querySelector('.cdk-overlay-container');
+    const container = mockBodyNode.querySelector('.cdk-overlay-container');
 
-      expect(container).toBeTruthy();
-      expect(mockAppRoot.contains(container!)).toBeTrue();
+    expect(container).toBeTruthy();
+    expect(mockAppRoot.contains(container!)).toBeTrue();
+  });
 
-      mockAppRoot.remove();
-      container?.remove();
-    });
+  it('should append the container to document.body if pr-app-root does not exist', () => {
+    const mockBodyNode = document.createElement('body');
+    customOverlayContainer.appendContainer(mockBodyNode);
 
-    it('should append the container to document.body if pr-app-root does not exist', () => {
-      customOverlayContainer['_createContainer']();
+    const container = mockBodyNode.querySelector('.cdk-overlay-container');
 
-      const container = document.querySelector('.cdk-overlay-container');
-
-      expect(container).toBeTruthy();
-      expect(document.body.contains(container!)).toBeTrue();
-
-      container?.remove();
-    });
+    expect(container).toBeTruthy();
+    expect(mockBodyNode.contains(container!)).toBeTrue();
   });
 });

--- a/src/app/dialog-cdk/custom-overlay-container.ts
+++ b/src/app/dialog-cdk/custom-overlay-container.ts
@@ -4,16 +4,16 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class CustomOverlayContainer extends OverlayContainer {
-  protected _createContainer(): void {
+  public appendContainer(node: Element): void {
     const container = document.createElement('div');
     container.classList.add('cdk-overlay-container');
 
-    const parent = document.querySelector('pr-app-root') || document.body;
-    if (parent) {
-      parent.appendChild(container);
-    } else {
-      document.body.appendChild(container);
-    }
+    const parent = node.querySelector('pr-app-root') || node;
+    parent.appendChild(container);
     this._containerElement = container;
+  }
+
+  protected _createContainer(): void {
+    this.appendContainer(document.body);
   }
 }


### PR DESCRIPTION
These tests were utilizing the Document object in ways that were not perfectly isolated. While they had some cleanup logic, other tests may manipulate the Document in such a way that make these tests fail. Fix this by allowing tests to inject a node to search for instead of defaulting to `document.body`. The `document.body` node is used in the actual `_createContainer()` method.

Since this is mostly a testing adjustment, this probably does not need manual QA.