### PR TITLE
Fix Glam Onboarding With Shares tests

### DIFF
--- a/src/app/models/invite-vo.ts
+++ b/src/app/models/invite-vo.ts
@@ -1,6 +1,15 @@
 /* @format */
 import { BaseVO } from '@models/base-vo';
-import { ArchiveVO, AccountVO, RecordVO, FolderVO, ShareVO } from '.';
+import { AccountVOData } from './account-vo';
+import {
+  ArchiveVO,
+  AccountVO,
+  RecordVO,
+  FolderVO,
+  ShareVO,
+  RecordVOData,
+  FolderVOData,
+} from '.';
 
 type InviteStatusType =
   | 'status.invite.pending'
@@ -59,4 +68,8 @@ export interface InviteVOData {
 
   byArchiveId?: number;
   accessRole?: string;
+
+  AccountVO?: AccountVOData;
+  RecordVO?: RecordVOData;
+  FolderVO?: FolderVOData;
 }

--- a/src/app/onboarding/components/glam/archive-creation-start-screen/archive-creation-start-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/archive-creation-start-screen/archive-creation-start-screen.component.spec.ts
@@ -78,9 +78,8 @@ describe('ArchiveCreationStartScreenComponent', () => {
   });
 
   it('should not set hasShareToken if shareToken does not exist in localStorage', async () => {
-    const { instance, fixture } = await shallow.render();
-
     spyOn(localStorage, 'getItem').and.returnValue(null);
+    const { instance, fixture } = await shallow.render();
 
     instance.ngOnInit();
     fixture.detectChanges();


### PR DESCRIPTION
The tests made for `ArchiveCreationWithShareComponent` had some issues with mocking that created intermittent test failures. Fix these by providing the same mock to each test so we don't have to mock out HTTP response information for each test, and also use some more abstract logic in our assertions instead of using a spy on our mock. A test with duplicated setup and assertions has also been deleted since it is unnecessary.

This PR also fixes a related error on the `ArchiveCreationStartScreen` component that is caused by a similar issue.

This does not need any manual QA adjustments, as the only change to production code is in type information which would be caught by tests and the build process.