### PR TITLE
Fix "an error was thrown in afterAll" test failure

### DIFF
--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -105,9 +105,11 @@ export class AccountService {
     this.setStorage(this.account?.keepLoggedIn, ACCOUNT_KEY, this.account);
 
     // set account data on Sentry scope
-    Sentry.configureScope((scope) => {
-      scope.setUser({ id: this.account.accountId });
-    });
+    if (this.account?.accountId) {
+      Sentry.configureScope((scope) => {
+        scope.setUser({ id: this.account.accountId });
+      });
+    }
   }
 
   public setArchive(newArchive: ArchiveVO) {


### PR DESCRIPTION
This elusive test failure could sometimes be seen in random tests throughout the web-app, always with the unhelpful message that `accountId` is undefined but providing no actual context of which test is actually failing.

The current lead is that this test failure is caused by the `AccountService.setAccount` method. This method also ends up configuring the current Sentry scope so that the current user ID can be logged by Sentry. There is no null check for this action, so tests where we nullify the current account are subject to possibly fail.

Add a null check around this Sentry scope check. Ideally this Sentry code should probably live outside of the AccountService so that we can skip running it in unit tests to begin with.

This PR does not need manual QA review.