### PR TITLE
PER-9892 Add opt in option to the sign up page

### DIFF
--- a/src/app/auth/components/signup/signup.component.html
+++ b/src/app/auth/components/signup/signup.component.html
@@ -80,21 +80,15 @@
   </div>
   <div class="auth-options">
     <div class="checkbox-container">
-      <pr-checkbox
-        [isChecked]="receiveUpdatesViaEmail"
-        (isCheckedChange)="receiveUpdatesViaEmail = $event"
-        [variant]="'secondary'"
-      ></pr-checkbox>
       <label class="form-check-label">
         I agree to receive updates via email
       </label>
+      <pr-toggle
+        [isChecked]="receiveUpdatesViaEmail"
+        (isCheckedChange)="receiveUpdatesViaEmail = $event"
+      ></pr-toggle>
     </div>
     <div class="checkbox-container">
-      <pr-checkbox
-        [isChecked]="agreedTerms"
-        (isCheckedChange)="agreedTerms = $event"
-        [variant]="'secondary'"
-      ></pr-checkbox>
       <label class="form-check-label" for="terms">
         I agree to the &nbsp;
         <a
@@ -104,6 +98,10 @@
           >Terms of Service</a
         >
       </label>
+      <pr-toggle
+        [isChecked]="agreedTerms"
+        (isCheckedChange)="agreedTerms = $event"
+      ></pr-toggle>
     </div>
   </div>
   <div class="buttons">

--- a/src/app/auth/components/signup/signup.component.html
+++ b/src/app/auth/components/signup/signup.component.html
@@ -79,20 +79,32 @@
     ></pr-form-input-glam>
   </div>
   <div class="auth-options">
-    <pr-checkbox
-      [isChecked]="agreedTerms"
-      (isCheckedChange)="agreedTerms = $event"
-      [variant]="'secondary'"
-    ></pr-checkbox>
-    <label class="form-check-label" for="terms">
-      I agree to the &nbsp;
-      <a
-        href="https://www.permanent.org/terms/"
-        target="_blank"
-        aria-label="Permanent.org Terms of Service"
-        >Terms of Service</a
-      >
-    </label>
+    <div class="checkbox-container">
+      <pr-checkbox
+        [isChecked]="receiveUpdatesViaEmail"
+        (isCheckedChange)="receiveUpdatesViaEmail = $event"
+        [variant]="'secondary'"
+      ></pr-checkbox>
+      <label class="form-check-label">
+        I agree to receive updates via email
+      </label>
+    </div>
+    <div class="checkbox-container">
+      <pr-checkbox
+        [isChecked]="agreedTerms"
+        (isCheckedChange)="agreedTerms = $event"
+        [variant]="'secondary'"
+      ></pr-checkbox>
+      <label class="form-check-label" for="terms">
+        I agree to the &nbsp;
+        <a
+          href="https://www.permanent.org/terms/"
+          target="_blank"
+          aria-label="Permanent.org Terms of Service"
+          >Terms of Service</a
+        >
+      </label>
+    </div>
   </div>
   <div class="buttons">
     <pr-button

--- a/src/app/auth/components/signup/signup.component.scss
+++ b/src/app/auth/components/signup/signup.component.scss
@@ -21,15 +21,19 @@
 
 .auth-options {
   display: flex;
-  align-items: center;
+  flex-direction: column;
 
-  & > label,
-  label > a {
-    color: white;
-    font-family: 'UsualRegular', sans-serif;
-    font-size: 14px;
+  & > .checkbox-container {
+    margin-bottom: 32px;
+
+    display: flex;
+    > label,
+    label > a {
+      color: white;
+      font-family: 'UsualRegular', sans-serif;
+      font-size: 14px;
+    }
   }
-  margin-bottom: 32px;
 }
 
 form {

--- a/src/app/auth/components/signup/signup.component.scss
+++ b/src/app/auth/components/signup/signup.component.scss
@@ -25,6 +25,7 @@
 
   & > .checkbox-container {
     margin-bottom: 32px;
+    justify-content: space-between;
 
     display: flex;
     > label,

--- a/src/app/auth/components/signup/signup.component.spec.ts
+++ b/src/app/auth/components/signup/signup.component.spec.ts
@@ -19,10 +19,16 @@ import { TEST_DATA } from '@core/core.module.spec';
 import { Router, ActivatedRoute } from '@angular/router';
 import { FORM_ERROR_MESSAGES } from '@shared/utilities/forms';
 import { ApiService } from '@shared/services/api/api.service';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import { CheckboxComponent } from '@root/app/component-library/components/checkbox/checkbox.component';
+import { AccountVO } from '@models/account-vo';
+import { AccountService } from '@shared/services/account/account.service';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
   let fixture: ComponentFixture<SignupComponent>;
+  let accountService: AccountService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -37,6 +43,7 @@ describe('SignupComponent', () => {
         CookieService,
         MessageService,
         ApiService,
+        AccountService,
         {
           provide: ActivatedRoute,
           useValue: {
@@ -57,6 +64,7 @@ describe('SignupComponent', () => {
     fixture = TestBed.createComponent(SignupComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    accountService = TestBed.inject(AccountService);
   });
 
   it('should create', () => {
@@ -178,5 +186,36 @@ describe('SignupComponent', () => {
     const loadingSpinner = compiled.querySelector('pr-loading-spinner');
 
     expect(loadingSpinner).toBeTruthy();
+  });
+
+  it('should pass receiveUpdatesViaEmail to signUp correctly', () => {
+    const formValue = {
+      email: 'test@example.com',
+      name: 'Test User',
+      password: 'password123',
+      confirm: 'password123',
+      invitation: 'inviteCode',
+    };
+
+    component.receiveUpdatesViaEmail = true;
+    component.agreedTerms = true; // assuming agreedTerms is needed
+
+    spyOn(accountService, 'signUp').and.returnValue(
+      Promise.resolve(new AccountVO({})),
+    );
+
+    component.onSubmit(formValue);
+
+    expect(accountService.signUp).toHaveBeenCalledWith(
+      formValue.email,
+      formValue.name,
+      formValue.password,
+      formValue.confirm,
+      component.agreedTerms,
+      true, // checks receiveUpdatesViaEmail is true
+      null,
+      formValue.invitation,
+      component.shouldCreateDefaultArchive(),
+    );
   });
 });

--- a/src/app/auth/components/signup/signup.component.ts
+++ b/src/app/auth/components/signup/signup.component.ts
@@ -47,6 +47,7 @@ export class SignupComponent {
   shareFromName: string;
   shareItemIsRecord = false;
   agreedTerms = false;
+  receiveUpdatesViaEmail = false;
 
   constructor(
     fb: UntypedFormBuilder,
@@ -108,7 +109,6 @@ export class SignupComponent {
         '',
         [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)],
       ],
-      optIn: [true],
     });
 
     const confirmPasswordControl = new UntypedFormControl('', [
@@ -141,7 +141,7 @@ export class SignupComponent {
         formValue.password,
         formValue.confirm,
         this.agreedTerms,
-        formValue.optIn,
+        this.receiveUpdatesViaEmail,
         null,
         formValue.invitation,
         this.shouldCreateDefaultArchive(),

--- a/src/app/component-library/components/toggle/toggle.component.scss
+++ b/src/app/component-library/components/toggle/toggle.component.scss
@@ -22,7 +22,7 @@
     height: 20px;
     border-radius: 25px;
     position: relative;
-    background-color: $toggle;
+    background-color: rgba(255, 255, 255, 0.32);
     transition: background-color 0.2s;
 
     & > .toggle-knob {


### PR DESCRIPTION
Add checkbox for email opt in option to the signup page

@k8lyn6 I kept the checkboxes in the front, because it was never mentioned to use the iOS looking ones. Should I change them to those? 