### PR TITLE
Prefer Archivematica access copies over older ones

### DIFF
--- a/src/app/file-browser/components/download-button/download-button.component.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import { RecordVO } from '@models/index';
 import { DataService } from '@shared/services/data/data.service';
+import { FileFormat } from '@models/file-vo';
 import { MessageService } from '../../../shared/services/message/message.service';
 
 interface Format {
@@ -79,10 +80,12 @@ export class DownloadButtonComponent {
   displayDownloadOptions() {
     this.displayDownloadDropdown = true;
     const original = (this.selectedItem as RecordVO).FileVOs?.find(
-      (item) => item.format === 'file.format.original',
+      (item) => item.format === FileFormat.Original,
     );
     const converted = (this.selectedItem as RecordVO).FileVOs?.filter(
-      (item) => item.format === 'file.format.converted',
+      (item) =>
+        item.format === FileFormat.Converted ||
+        item.format === FileFormat.ArchivematicaAccess,
     ).map((item) => ({
       name: item.type,
       extension: item.type.split('.').pop(),

--- a/src/app/file-browser/components/download-button/download-button.component.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { RecordVO } from '@models/index';
 import { DataService } from '@shared/services/data/data.service';
-import { FileFormat } from '@models/file-vo';
 import { MessageService } from '../../../shared/services/message/message.service';
 
 interface Format {

--- a/src/app/file-browser/components/download-button/download-button.component.ts
+++ b/src/app/file-browser/components/download-button/download-button.component.ts
@@ -79,21 +79,9 @@ export class DownloadButtonComponent {
 
   displayDownloadOptions() {
     this.displayDownloadDropdown = true;
-    const original = (this.selectedItem as RecordVO).FileVOs?.find(
-      (item) => item.format === FileFormat.Original,
-    );
-    const converted = (this.selectedItem as RecordVO).FileVOs?.filter(
-      (item) =>
-        item.format === FileFormat.Converted ||
-        item.format === FileFormat.ArchivematicaAccess,
-    ).map((item) => ({
-      name: item.type,
-      extension: item.type.split('.').pop(),
-    }));
-    this.downloadOptions = [
-      { name: original?.type, extension: original?.type.split('.').pop() },
-      ...converted,
-    ];
+    this.downloadOptions = (
+      this.selectedItem as RecordVO
+    ).getDownloadOptionsList();
   }
 
   bringDropdownIntoView() {

--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
@@ -494,19 +494,8 @@ export class FileListControlsComponent implements OnDestroy, HasSubscriptions {
 
   displayDownloadOptions() {
     this.displayDownloadDropdown = true;
-    const original = (this.selectedItems[0] as RecordVO).FileVOs?.find(
-      (item) => item.format === 'file.format.original',
-    );
-    const converted = (this.selectedItems[0] as RecordVO).FileVOs?.filter(
-      (item) => item.format === 'file.format.converted',
-    ).map((item) => ({
-      name: item.type,
-      extension: item.type.split('.').pop(),
-    }));
-
-    this.downloadOptions = [
-      { name: original?.type, extension: original?.type.split('.').pop() },
-      ...converted,
-    ];
+    this.downloadOptions = (
+      this.selectedItems[0] as RecordVO
+    ).getDownloadOptionsList();
   }
 }

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -25,6 +25,8 @@ import type { KeysOfType } from '@shared/utilities/keysoftype';
 import { Subscription } from 'rxjs';
 import { SearchService } from '@search/services/search.service';
 import { ZoomingImageViewerComponent } from '@shared/components/zooming-image-viewer/zooming-image-viewer.component';
+import { FileFormat } from '@models/file-vo';
+import { GetAccessFile } from '@models/get-access-file';
 import { TagsService } from '../../../core/services/tags/tags.service';
 
 @Component({
@@ -194,9 +196,11 @@ export class FileViewerComponent implements OnInit, OnDestroy {
     this.isZoomableImage =
       this.currentRecord.type.includes('image') &&
       this.currentRecord.FileVOs?.length &&
-      ZoomingImageViewerComponent.chooseFullSizeImage(this.currentRecord);
+      typeof ZoomingImageViewerComponent.chooseFullSizeImage(
+        this.currentRecord,
+      ) !== 'undefined';
     this.isDocument = this.currentRecord.FileVOs?.some(
-      (obj: ItemVO) => obj.type.includes('pdf') || obj.type.includes('txt'),
+      (obj) => obj.type.includes('pdf') || obj.type.includes('txt'),
     );
     this.documentUrl = this.getDocumentUrl();
     this.setCurrentTags();
@@ -215,19 +219,17 @@ export class FileViewerComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    const original = find(this.currentRecord.FileVOs, {
-      format: 'file.format.original',
-    }) as any;
-    const pdf = find(this.currentRecord.FileVOs, (f) =>
-      f.type.includes('pdf'),
-    ) as any;
+    const original = this.currentRecord.FileVOs.find(
+      (file) => file.format === FileFormat.Original,
+    );
+    const access = GetAccessFile(this.currentRecord);
 
     let url;
 
     if (original?.type.includes('pdf') || original?.type.includes('txt')) {
       url = original?.fileURL;
-    } else if (pdf) {
-      url = pdf?.fileURL;
+    } else if (access) {
+      url = access?.fileURL;
     }
 
     if (!url) {

--- a/src/app/models/file-vo.ts
+++ b/src/app/models/file-vo.ts
@@ -1,0 +1,15 @@
+export const enum FileFormat {
+  Original = 'file.format.original',
+  Converted = 'file.format.converted',
+  ArchivematicaAccess = 'file.format.archivematica.access',
+}
+
+export interface PermanentFile {
+  fileId: number;
+  size: number;
+  format: FileFormat;
+  parentFileId?: number;
+  fileURL: string;
+  downloadURL: string;
+  type: string;
+}

--- a/src/app/models/get-access-file.spec.ts
+++ b/src/app/models/get-access-file.spec.ts
@@ -1,0 +1,87 @@
+/* @format */
+import { FileFormat, PermanentFile } from './file-vo';
+import { GetAccessFile, HasFiles } from './get-access-file';
+
+describe('GetAccessFile', () => {
+  function makeTestFile(params: Partial<PermanentFile> = {}): PermanentFile {
+    return Object.assign(
+      {
+        fileId: 0,
+        size: 0,
+        format: FileFormat.Original,
+        fileURL: 'test',
+        downloadURL: 'test',
+        type: 'test',
+      },
+      params,
+    );
+  }
+
+  it('should return null for an undefined object being passed in', () => {
+    let files: HasFiles;
+
+    expect(GetAccessFile(files)).toBeFalsy();
+  });
+
+  it('should return null for an object with no FileVOs', () => {
+    expect(GetAccessFile({ FileVOs: [] })).toBeFalsy();
+  });
+
+  it('should return the only given FileVO', () => {
+    expect(
+      GetAccessFile({
+        FileVOs: [makeTestFile()],
+      }),
+    ).toEqual(makeTestFile());
+  });
+
+  it('should prefer archivematica access copies every time', () => {
+    const archivematicaFile = makeTestFile({
+      format: FileFormat.ArchivematicaAccess,
+      fileId: 1,
+    });
+
+    expect(
+      GetAccessFile({
+        FileVOs: [
+          makeTestFile(),
+          makeTestFile({ format: FileFormat.Converted }),
+          archivematicaFile,
+          makeTestFile(),
+          makeTestFile({ format: FileFormat.Converted }),
+        ],
+      }),
+    ).toEqual(archivematicaFile);
+  });
+
+  it('should prefer converted copies to original files', () => {
+    const convertedFile = makeTestFile({
+      format: FileFormat.Converted,
+      fileId: 1,
+    });
+
+    expect(
+      GetAccessFile({
+        FileVOs: [makeTestFile(), convertedFile, makeTestFile()],
+      }),
+    ).toEqual(convertedFile);
+  });
+
+  it('should prefer pdf converted copies to other converted formats', () => {
+    const convertedFile = makeTestFile({
+      format: FileFormat.Converted,
+      fileId: 1,
+      type: 'type.file.pdf.pdfa',
+    });
+
+    expect(
+      GetAccessFile({
+        FileVOs: [
+          makeTestFile(),
+          makeTestFile({ format: FileFormat.Converted, fileId: 2 }),
+          convertedFile,
+        ],
+      }),
+    ).toEqual(convertedFile);
+  });
+});

--- a/src/app/models/get-access-file.ts
+++ b/src/app/models/get-access-file.ts
@@ -1,3 +1,4 @@
+import { prioritizeIf } from '@root/utils/prioritize-if';
 import { FileFormat, PermanentFile } from './file-vo';
 
 export interface HasFiles {
@@ -9,15 +10,10 @@ function getArchivematicaAccess(files: PermanentFile[]) {
 }
 
 function getPrioritizedConvertedFile(files: PermanentFile[]) {
-  return files
-    .filter((file) => file.format === FileFormat.Converted)
-    .sort((a, b) => {
-      const preferredType = 'pdf';
-      return (
-        Number(b.type.includes(preferredType)) -
-        Number(a.type.includes(preferredType))
-      );
-    })[0];
+  return prioritizeIf(
+    files.filter((file) => file.format === FileFormat.Converted),
+    (file) => file.type.includes('pdf'),
+  )[0];
 }
 
 export function GetAccessFile(record: HasFiles): PermanentFile | undefined {

--- a/src/app/models/get-access-file.ts
+++ b/src/app/models/get-access-file.ts
@@ -1,0 +1,30 @@
+import { FileFormat, PermanentFile } from './file-vo';
+
+export interface HasFiles {
+  FileVOs: PermanentFile[];
+}
+
+function getArchivematicaAccess(files: PermanentFile[]) {
+  return files.find((file) => file.format === FileFormat.ArchivematicaAccess);
+}
+
+function getPrioritizedConvertedFile(files: PermanentFile[]) {
+  return files
+    .filter((file) => file.format === FileFormat.Converted)
+    .sort((a, b) => {
+      const preferredType = 'pdf';
+      return (
+        Number(b.type.includes(preferredType)) -
+        Number(a.type.includes(preferredType))
+      );
+    })[0];
+}
+
+export function GetAccessFile(record: HasFiles): PermanentFile | undefined {
+  const files = record?.FileVOs ?? [];
+  return (
+    getArchivematicaAccess(files) ||
+    getPrioritizedConvertedFile(files) ||
+    files[0]
+  );
+}

--- a/src/app/models/record-vo.spec.ts
+++ b/src/app/models/record-vo.spec.ts
@@ -1,5 +1,6 @@
 /* @format */
 import { DataStatus } from './data-status.enum';
+import { FileFormat } from './file-vo';
 import { RecordVO, ShareVO } from '.';
 
 describe('RecordVO', () => {
@@ -104,5 +105,75 @@ describe('RecordVO', () => {
     record.update({ ShareVOs: [{}] });
 
     expect(record.ShareVOs[0]).toBeInstanceOf(ShareVO);
+  });
+
+  describe('Download options', () => {
+    it('returns an empty array for an empty record', () => {
+      const record = new RecordVO({});
+
+      expect(record.getDownloadOptionsList()).toEqual([]);
+    });
+
+    it('converts to download option format', () => {
+      const record = new RecordVO({});
+      record.FileVOs = [
+        {
+          format: FileFormat.Converted,
+          fileId: 0,
+          type: 'test.pdf',
+          fileURL: 'test',
+          downloadURL: 'test',
+          size: 0,
+        },
+        {
+          format: FileFormat.Converted,
+          fileId: 0,
+          type: 'test.odt',
+          fileURL: 'test',
+          downloadURL: 'test',
+          size: 0,
+        },
+      ];
+      const downloadOptions = record.getDownloadOptionsList();
+
+      expect(downloadOptions.length).toBe(2);
+      expect(downloadOptions[0].name).toBe('test.pdf');
+      expect(downloadOptions[0].extension).toBe('pdf');
+    });
+
+    it('prioritizes original before others', () => {
+      const record = new RecordVO({});
+      record.FileVOs = [
+        {
+          format: FileFormat.Converted,
+          fileId: 0,
+          type: 'test.pdf',
+          fileURL: 'test',
+          downloadURL: 'test',
+          size: 0,
+        },
+        {
+          format: FileFormat.Original,
+          fileId: 0,
+          type: 'test.docx',
+          fileURL: 'test',
+          downloadURL: 'test',
+          size: 0,
+        },
+        {
+          format: FileFormat.Converted,
+          fileId: 0,
+          type: 'test.odt',
+          fileURL: 'test',
+          downloadURL: 'test',
+          size: 0,
+        },
+      ];
+      const downloadOptions = record.getDownloadOptionsList();
+
+      expect(downloadOptions.length).toBe(3);
+      expect(downloadOptions[0].name).toBe('test.docx');
+      expect(downloadOptions[0].extension).toBe('docx');
+    });
   });
 });

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -11,7 +11,7 @@ import { LocnVOData } from './locn-vo';
 import { TagVOData } from './tag-vo';
 import { ArchiveVO } from './archive-vo';
 import { HasThumbnails } from './get-thumbnail';
-import { PermanentFile } from './file-vo';
+import { FileFormat, PermanentFile } from './file-vo';
 
 interface RecordVoOptions {
   dataStatus: DataStatus;
@@ -155,6 +155,20 @@ export class RecordVO
     if (this.ShareVOs) {
       this.ShareVOs = this.ShareVOs.map((data) => new ShareVO(data));
     }
+  }
+
+  public getDownloadOptionsList() {
+    const files = [...(this.FileVOs ?? [])];
+    return files
+      .sort(
+        (a, b) =>
+          Number(b.format === FileFormat.Original) -
+          Number(a.format === FileFormat.Original),
+      )
+      .map((file) => ({
+        name: file.type,
+        extension: file.type.split('.').pop(),
+      }));
   }
 }
 

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -3,6 +3,7 @@ import { BaseVO, BaseVOData, DynamicListChild } from '@models/base-vo';
 import { DataStatus } from '@models/data-status.enum';
 import { ShareVO, sortShareVOs } from '@models/share-vo';
 import { formatDateISOString } from '@shared/utilities/dateTime';
+import { prioritizeIf } from '@root/utils/prioritize-if';
 import { AccessRoleType } from './access-role';
 import { TimezoneVOData } from './timezone-vo';
 import { ChildItemData, HasParentFolder } from './folder-vo';
@@ -159,16 +160,13 @@ export class RecordVO
 
   public getDownloadOptionsList() {
     const files = [...(this.FileVOs ?? [])];
-    return files
-      .sort(
-        (a, b) =>
-          Number(b.format === FileFormat.Original) -
-          Number(a.format === FileFormat.Original),
-      )
-      .map((file) => ({
-        name: file.type,
-        extension: file.type.split('.').pop(),
-      }));
+    return prioritizeIf(
+      files,
+      (file) => file.format === FileFormat.Original,
+    ).map((file) => ({
+      name: file.type,
+      extension: file.type.split('.').pop(),
+    }));
   }
 }
 

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -11,6 +11,7 @@ import { LocnVOData } from './locn-vo';
 import { TagVOData } from './tag-vo';
 import { ArchiveVO } from './archive-vo';
 import { HasThumbnails } from './get-thumbnail';
+import { PermanentFile } from './file-vo';
 
 interface RecordVoOptions {
   dataStatus: DataStatus;
@@ -107,7 +108,7 @@ export class RecordVO
   // Other stuff
   public LocnVO: LocnVOData;
   public TimezoneVO: TimezoneVOData;
-  public FileVOs;
+  public FileVOs: PermanentFile[];
   public TagVOs: TagVOData[];
   public TextDataVOs;
   public ArchiveVOs: ArchiveVO[];

--- a/src/app/shared/components/audio/audio.component.ts
+++ b/src/app/shared/components/audio/audio.component.ts
@@ -1,26 +1,18 @@
-import { Component, OnInit, Input, OnChanges } from '@angular/core';
+/* @format */
+import { Component, Input, OnChanges } from '@angular/core';
 import { RecordVO } from '@models';
-import { find } from 'lodash';
+import { GetAccessFile } from '@models/get-access-file';
 
 @Component({
   selector: 'pr-audio',
   templateUrl: './audio.component.html',
-  styleUrls: ['./audio.component.scss']
+  styleUrls: ['./audio.component.scss'],
 })
 export class AudioComponent implements OnChanges {
   @Input() item: RecordVO;
   audioSrc: string;
-  constructor() { }
 
   ngOnChanges(): void {
-    const convertedFile = find(this.item.FileVOs, {format: 'file.format.converted'}) as any;
-    const originalFile = find(this.item.FileVOs, {format: 'file.format.original'}) as any;
-
-    if (convertedFile) {
-      this.audioSrc = convertedFile.fileURL;
-    } else if (originalFile) {
-      this.audioSrc = originalFile.fileURL;
-    }
+    this.audioSrc = GetAccessFile(this.item)?.fileURL;
   }
-
 }

--- a/src/app/shared/components/video/video.component.ts
+++ b/src/app/shared/components/video/video.component.ts
@@ -1,15 +1,16 @@
+/* @format */
 import { Component, OnInit, Input, ElementRef, Renderer2 } from '@angular/core';
 import { gsap } from 'gsap';
-import { find } from 'lodash';
 
 import { RecordVO } from '@root/app/models';
+import { GetAccessFile } from '@models/get-access-file';
 
 const FADE_IN_DURATION = 0.3;
 
 @Component({
   selector: 'pr-video',
   templateUrl: './video.component.html',
-  styleUrls: ['./video.component.scss']
+  styleUrls: ['./video.component.scss'],
 })
 export class VideoComponent implements OnInit {
   @Input() item: RecordVO;
@@ -19,39 +20,34 @@ export class VideoComponent implements OnInit {
   public videoSrc: string;
   public isProcessing: boolean;
 
-  constructor(private elementRef: ElementRef, private renderer: Renderer2) { }
+  constructor(
+    private elementRef: ElementRef,
+    private renderer: Renderer2,
+  ) {}
 
   ngOnInit() {
     this.videoElem = this.elementRef.nativeElement.querySelector('video');
-    this.videoWrapperElem = this.elementRef.nativeElement.querySelector('.pr-video-wrapper');
+    this.videoWrapperElem =
+      this.elementRef.nativeElement.querySelector('.pr-video-wrapper');
 
     this.videoElem.addEventListener('loadstart', (event) => {
       setTimeout(() => {
         this.renderer.removeClass(this.videoWrapperElem, 'loading');
-        gsap.from(
-          this.videoElem,
-          FADE_IN_DURATION,
-          {
-            opacity: 0,
-            ease: 'Power4.easeOut'
-          }
-        );
+        gsap.from(this.videoElem, FADE_IN_DURATION, {
+          opacity: 0,
+          ease: 'Power4.easeOut',
+        });
       }, 250);
     });
 
-    const convertedFile = find(this.item.FileVOs, {type: 'type.file.video.mp4', format: 'file.format.converted'}) as any;
-    const originalFile = find(this.item.FileVOs, {format: 'file.format.original'}) as any;
+    const accessFile = GetAccessFile(this.item);
 
-    if (convertedFile) {
-      this.videoSrc = convertedFile.fileURL;
-      this.isProcessing = false;
-    } else if (originalFile) {
-      this.videoSrc = originalFile.fileURL;
+    if (accessFile) {
+      this.videoSrc = accessFile.fileURL;
       this.isProcessing = false;
     } else {
       this.renderer.removeClass(this.videoWrapperElem, 'loading');
       this.isProcessing = true;
     }
   }
-
 }

--- a/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.ts
+++ b/src/app/shared/components/zooming-image-viewer/zooming-image-viewer.component.ts
@@ -10,6 +10,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
+import { GetAccessFile } from '@models/get-access-file';
 import { RecordVO } from '@models/index';
 import * as OpenSeaDragon from 'openseadragon';
 import { ZoomEvent, FullScreenEvent } from 'openseadragon';
@@ -84,13 +85,7 @@ export class ZoomingImageViewerComponent implements AfterViewInit, OnDestroy {
   }
 
   public static chooseFullSizeImage(record: RecordVO) {
-    if (record.FileVOs.length > 1) {
-      const convertedUrl = record.FileVOs.find(
-        (file) => file.format == 'file.format.converted',
-      )?.fileURL;
-      return convertedUrl ?? record.FileVOs[0]?.fileURL;
-    }
-    return record.FileVOs[0]?.fileURL;
+    return GetAccessFile(record)?.fileURL;
   }
 
   private enablePanning(flag: boolean): void {

--- a/src/utils/prioritize-if.spec.ts
+++ b/src/utils/prioritize-if.spec.ts
@@ -1,0 +1,24 @@
+/* @format */
+import { prioritizeIf } from './prioritize-if';
+
+describe('Utils: prioritizeIf', () => {
+  const alwaysFalse = (_: any) => false;
+  const alwaysTrue = (_: any) => true;
+  const isEven = (x: number) => x % 2 === 0;
+
+  it('returns an empty array when passed in an empty array', () => {
+    expect(prioritizeIf([], alwaysFalse)).toEqual([]);
+  });
+
+  it('keeps the array sorted if no objects pass the predicate', () => {
+    expect(prioritizeIf([1, 2, 3, 4, 5], alwaysFalse)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('keeps the array sorted if all objects pass the predicate', () => {
+    expect(prioritizeIf([1, 2, 3, 4, 5], alwaysTrue)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('prioritizes items that pass the predicate over those that do not', () => {
+    expect(prioritizeIf([1, 2, 3, 4, 5], isEven)).toEqual([2, 4, 1, 3, 5]);
+  });
+});

--- a/src/utils/prioritize-if.ts
+++ b/src/utils/prioritize-if.ts
@@ -1,0 +1,5 @@
+/* @format */
+
+export function prioritizeIf<T>(list: T[], predicate: (_: T) => boolean): T[] {
+  return list.sort((a, b) => Number(predicate(b)) - Number(predicate(a)));
+}


### PR DESCRIPTION
Prefer archivematica access copies over older converted access copies in the file viewer. This is accomplished with a centralized helper function that picks the proper access copy in our specific priority order. This function is then used in various file viewer components.

This also includes the change to the download options, since it depends on the new FileVO type definitions.

Resolves PER-9873 + PER-9902.

**Steps to test:**
1. If the environment you're testing on includes archivematica-generated access copies, then you can actually test this functionality. Make sure to verify new access copies are downloadable as well.
2. If not, verify that unit tests pass and that file viewing for all types (image, document, audio, video, are there others?) is otherwise not affected. Verify that downloading them still functions as well.