### PR TITLE
Fix bug with uploading folders into public

### DIFF
--- a/src/app/core/components/main/main.component.ts
+++ b/src/app/core/components/main/main.component.ts
@@ -401,6 +401,10 @@ export class MainComponent
     }
 
     const items = (dragEvent.event as DragEvent).dataTransfer.items;
+    const supportsFolderUpload = items[0].webkitGetAsEntry !== null;
+    const copiedItems = Array.from(items).map(
+      (i) => i.webkitGetAsEntry && i.webkitGetAsEntry(),
+    );
 
     let targetFolder: FolderVO;
 
@@ -416,14 +420,14 @@ export class MainComponent
           'Upload to public',
           'This is a public folder. Are you sure you want to upload here?',
         );
-      } catch (error) {
+      } catch (_) {
         return;
       }
     }
 
-    if (items?.length && items[0].webkitGetAsEntry != null) {
+    if (copiedItems.length && supportsFolderUpload) {
       // browser supports folders and file entry
-      this.upload.uploadFolders(targetFolder, Array.from(items));
+      this.upload.uploadFolders(targetFolder, copiedItems);
     } else {
       this.upload.uploadFiles(targetFolder, Array.from(files));
     }

--- a/src/app/core/services/upload/upload.service.ts
+++ b/src/app/core/services/upload/upload.service.ts
@@ -147,10 +147,10 @@ export class UploadService implements HasSubscriptions, OnDestroy {
     return this.uploadSession.queueFiles(parentFolder, files);
   }
 
-  async uploadFolders(parentFolder: FolderVO, items: DataTransferItem[]) {
+  async uploadFolders(parentFolder: FolderVO, entries: FileSystemEntry[]) {
     this.debug(
       'uploadFolders %d items to folder %o',
-      items.length,
+      entries.length,
       parentFolder,
     );
 
@@ -162,7 +162,6 @@ export class UploadService implements HasSubscriptions, OnDestroy {
 
     foldersByPath.set('', { path: '', folder: parentFolder });
 
-    const entries = items.map((i) => i.webkitGetAsEntry());
     await getItemsFromItemList(entries);
     this.createFoldersAndUploadFiles(foldersByPath, filesByPath);
 


### PR DESCRIPTION
Asynchronous calls caused by the confirmation dialog that pops up when a user uploads into the public workspace ended up causing some objects to preemptively go out of scope. To fix this, copy the FileSystemEntries from the DataTransferItemList before any async calls so we can pass it directly into `UploadService.uploadFolders`. It seems like we cannot copy the DataTransferItemList directly, but since we only want the FileSystemEntries anyway, we can just save that instead.

I wasn't able to recreate the in-browser deletion behavior in tests with our mocks but if anyone has any ideas I'd be happy to try again.

**Stepz 2 Test:**
1. Try uploading a folder into public and verify it works
2. Make sure uploading an individual file also works in public
3. Verify that uploading in the private workspace still works as well.