### PR TITLE
List all accepted archives at end of Glam onboarding

### DIFF
--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.html
@@ -130,7 +130,6 @@
 
 @if (screen === 'finalize' && isGlam) {
   <pr-finalize-archive-creation-screen
-    [name]="name ? name : pendingArchive.fullName"
     (finalizeArchiveOutput)="onSubmit()"
   ></pr-finalize-archive-creation-screen>
 }

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
@@ -127,17 +127,4 @@ describe('CreateNewArchiveComponent #onboarding', () => {
     expect(submitButton.disabled).toBe(true);
     expect(skipStepButton.disabled).toBe(true);
   });
-
-  it('should register a created archive with the onboarding service', async () => {
-    const { instance, inject } = await shallow.render();
-    instance.name = 'Unit Test';
-    instance.archiveType = 'type.archive.person';
-    await instance.onSubmit();
-    const onboardingService = inject(OnboardingService);
-    const registeredArchives = onboardingService.getFinalArchives();
-
-    expect(registeredArchives.length).toBe(1);
-    expect(registeredArchives[0].fullName).toBe('Unit Test');
-    expect(registeredArchives[0].type).toBe('type.archive.person');
-  });
 });

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.spec.ts
@@ -7,6 +7,7 @@ import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { AccountVO } from '@models/account-vo';
 import { EventService } from '@shared/services/event/event.service';
+import { OnboardingService } from '../../services/onboarding.service';
 import { CreateNewArchiveComponent } from './create-new-archive.component';
 
 let calledCreate: boolean = false;
@@ -59,7 +60,8 @@ describe('CreateNewArchiveComponent #onboarding', () => {
       .mock(ApiService, mockApiService)
       .mock(AccountService, mockAccountService)
       .provide(EventService)
-      .dontMock(EventService);
+      .dontMock(EventService)
+      .dontMock(OnboardingService);
   });
 
   it('should exist', async () => {
@@ -124,5 +126,18 @@ describe('CreateNewArchiveComponent #onboarding', () => {
 
     expect(submitButton.disabled).toBe(true);
     expect(skipStepButton.disabled).toBe(true);
+  });
+
+  it('should register a created archive with the onboarding service', async () => {
+    const { instance, inject } = await shallow.render();
+    instance.name = 'Unit Test';
+    instance.archiveType = 'type.archive.person';
+    await instance.onSubmit();
+    const onboardingService = inject(OnboardingService);
+    const registeredArchives = onboardingService.getFinalArchives();
+
+    expect(registeredArchives.length).toBe(1);
+    expect(registeredArchives[0].fullName).toBe('Unit Test');
+    expect(registeredArchives[0].type).toBe('type.archive.person');
   });
 });

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
@@ -183,7 +183,6 @@ export class CreateNewArchiveComponent implements OnInit {
         } else {
           response = await this.api.archive.create(archive);
           createdArchive = response.getArchiveVO();
-          this.onboardingService.registerArchive(createdArchive);
         }
       } catch (archiveError) {
         this.error.emit('An error occurred. Please try again.');

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
@@ -30,6 +30,7 @@ import {
   archiveOptions,
   ArchiveCreateEvent,
 } from '../glam/types/archive-types';
+import { OnboardingService } from '../../services/onboarding.service';
 
 type NewArchiveScreen =
   | 'goals'
@@ -94,6 +95,7 @@ export class CreateNewArchiveComponent implements OnInit {
     private dialog: DialogCdkService,
     private accountService: AccountService,
     private event: EventService,
+    private onboardingService: OnboardingService,
   ) {
     this.isGlam = localStorage.getItem('isGlam') === 'true';
     if (!this.isGlam) {
@@ -181,6 +183,7 @@ export class CreateNewArchiveComponent implements OnInit {
         } else {
           response = await this.api.archive.create(archive);
           createdArchive = response.getArchiveVO();
+          this.onboardingService.registerArchive(createdArchive);
         }
       } catch (archiveError) {
         this.error.emit('An error occurred. Please try again.');

--- a/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.scss
+++ b/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.scss
@@ -17,7 +17,7 @@ p {
 }
 
 .text {
-  font-size: 0.6rem;
+  font-size: 1rem;
   font-family: 'UsualRegular', sans-serif;
 }
 

--- a/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.spec.ts
+++ b/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.spec.ts
@@ -4,6 +4,7 @@ import { AccountService } from '@shared/services/account/account.service';
 import { ArchiveVO } from '@models/index';
 import { ApiService } from '@shared/services/api/api.service';
 import { OnboardingModule } from '../../onboarding.module';
+import { OnboardingService } from '../../services/onboarding.service';
 import { GlamPendingArchivesComponent } from './glam-pending-archives.component';
 
 const mockAccountService = {
@@ -24,7 +25,8 @@ describe('GlamPendingArchivesComponent', () => {
         archive: {
           accept: (archive: ArchiveVO) => Promise.resolve(),
         },
-      });
+      })
+      .dontMock(OnboardingService);
   });
 
   it('should create the component', async () => {
@@ -135,5 +137,30 @@ describe('GlamPendingArchivesComponent', () => {
     });
 
     expect(instance.isSelected(1)).toBeFalse();
+  });
+
+  it('should register accepted archives with the onboardingservice', async () => {
+    const { instance, inject } = await shallow.render();
+    const archives: ArchiveVO[] = [
+      new ArchiveVO({
+        archiveId: 1,
+        fullName: 'Test Archive',
+      }),
+      new ArchiveVO({
+        archiveId: 2,
+        fullName: 'Test Archive',
+      }),
+      new ArchiveVO({
+        archiveId: 3,
+        fullName: 'Test Archive',
+      }),
+    ];
+    for (const archive of archives) {
+      await instance.selectArchive(archive);
+    }
+    instance.next();
+    const onboardingService = inject(OnboardingService);
+
+    expect(onboardingService.getFinalArchives().length).toBe(3);
   });
 });

--- a/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.spec.ts
+++ b/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.spec.ts
@@ -17,8 +17,10 @@ const mockAccountService = {
 
 describe('GlamPendingArchivesComponent', () => {
   let shallow: Shallow<GlamPendingArchivesComponent>;
+  let onboardingService: OnboardingService;
 
   beforeEach(async () => {
+    onboardingService = new OnboardingService();
     shallow = new Shallow(GlamPendingArchivesComponent, OnboardingModule)
       .mock(AccountService, mockAccountService)
       .mock(ApiService, {
@@ -26,6 +28,7 @@ describe('GlamPendingArchivesComponent', () => {
           accept: (archive: ArchiveVO) => Promise.resolve(),
         },
       })
+      .provide({ provide: OnboardingService, useValue: onboardingService })
       .dontMock(OnboardingService);
   });
 
@@ -162,5 +165,20 @@ describe('GlamPendingArchivesComponent', () => {
     const onboardingService = inject(OnboardingService);
 
     expect(onboardingService.getFinalArchives().length).toBe(3);
+  });
+
+  it('fetches previously accepted archives from onboarding service', async () => {
+    const archive = new ArchiveVO({ archiveId: 1, fullName: 'Archive 1' });
+    onboardingService.registerArchive(archive);
+
+    const { instance } = await shallow.render({
+      bind: {
+        pendingArchives: [archive],
+      },
+    });
+
+    expect(instance.acceptedArchives.length).toBe(1);
+    expect(instance.acceptedArchives[0].archiveId).toBe(archive.archiveId);
+    expect(instance.selectedArchive).not.toBeNull();
   });
 });

--- a/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.ts
+++ b/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.ts
@@ -25,6 +25,8 @@ export class GlamPendingArchivesComponent {
     private api: ApiService,
     private onboardingService: OnboardingService,
   ) {
+    this.acceptedArchives = [...this.onboardingService.getFinalArchives()];
+    this.selectedArchive = this.acceptedArchives[0] ?? null;
     this.accountName = this.account.getAccount().fullName;
   }
 
@@ -33,9 +35,6 @@ export class GlamPendingArchivesComponent {
   }
 
   next(): void {
-    for (const archive of this.acceptedArchives) {
-      this.onboardingService.registerArchive(archive);
-    }
     this.nextOutput.emit(this.selectedArchive);
   }
 
@@ -43,6 +42,7 @@ export class GlamPendingArchivesComponent {
     try {
       await this.api.archive.accept(archive);
       this.acceptedArchives.push(archive);
+      this.onboardingService.registerArchive(archive);
       if (!this.selectedArchive) {
         this.selectedArchive = archive;
       }

--- a/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.ts
+++ b/src/app/onboarding/components/glam-pending-archives/glam-pending-archives.component.ts
@@ -3,6 +3,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ArchiveVO } from '@models/index';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
+import { OnboardingService } from '../../services/onboarding.service';
 
 @Component({
   selector: 'pr-glam-pending-archives',
@@ -22,6 +23,7 @@ export class GlamPendingArchivesComponent {
   constructor(
     private account: AccountService,
     private api: ApiService,
+    private onboardingService: OnboardingService,
   ) {
     this.accountName = this.account.getAccount().fullName;
   }
@@ -31,6 +33,9 @@ export class GlamPendingArchivesComponent {
   }
 
   next(): void {
+    for (const archive of this.acceptedArchives) {
+      this.onboardingService.registerArchive(archive);
+    }
     this.nextOutput.emit(this.selectedArchive);
   }
 

--- a/src/app/onboarding/components/glam/create-archive-for-me-screen/create-archive-for-me-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/create-archive-for-me-screen/create-archive-for-me-screen.component.spec.ts
@@ -2,6 +2,7 @@
 import { Shallow } from 'shallow-render';
 import { AccountService } from '@shared/services/account/account.service';
 import { By } from '@angular/platform-browser';
+import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
 import { OnboardingModule } from '../../../onboarding.module';
 import { CreateArchiveForMeScreenComponent } from './create-archive-for-me-screen.component';
 
@@ -13,10 +14,10 @@ describe('CreateArchiveForMeScreenComponent', () => {
   let shallow: Shallow<CreateArchiveForMeScreenComponent>;
 
   beforeEach(async () => {
-    shallow = new Shallow(
-      CreateArchiveForMeScreenComponent,
-      OnboardingModule,
-    ).mock(AccountService, mockAccountService);
+    shallow = new Shallow(CreateArchiveForMeScreenComponent, OnboardingModule)
+      .mock(AccountService, mockAccountService)
+      .provide(OnboardingService)
+      .dontMock(OnboardingService);
   });
 
   it('should create', async () => {

--- a/src/app/onboarding/components/glam/create-archive-for-me-screen/create-archive-for-me-screen.component.ts
+++ b/src/app/onboarding/components/glam/create-archive-for-me-screen/create-archive-for-me-screen.component.ts
@@ -1,6 +1,8 @@
 /* @format */
 import { Component, Output, EventEmitter } from '@angular/core';
 import { AccountService } from '@shared/services/account/account.service';
+import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
+import { ArchiveVO } from '@models/index';
 import { ArchiveCreateEvent } from '../types/archive-types';
 
 @Component({
@@ -15,7 +17,10 @@ export class CreateArchiveForMeScreenComponent {
   @Output() goBackOutput = new EventEmitter<string>();
   @Output() continueOutput = new EventEmitter<ArchiveCreateEvent>();
 
-  constructor(private account: AccountService) {
+  constructor(
+    private account: AccountService,
+    private onboardingService: OnboardingService,
+  ) {
     this.name = this.account.getAccount().fullName;
   }
 
@@ -24,6 +29,9 @@ export class CreateArchiveForMeScreenComponent {
   }
 
   public continue(): void {
+    this.onboardingService.registerArchive(
+      new ArchiveVO({ fullName: this.name, accessRole: 'access.role.owner' }),
+    );
     this.continueOutput.emit({
       screen: 'goals',
       type: this.TYPE,

--- a/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.html
+++ b/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.html
@@ -15,18 +15,22 @@
         >
       </p>
       <div class="archive-info">
-        <div>
-          <img
-            src="assets/svg/onboarding/default-archive.svg"
-            alt="Custom Archive Icon"
-          />
-          <p>
-            The <b>{{ name }}</b> Archive
-          </p>
-        </div>
-        <div class="square">
-          <span>OWNER</span>
-        </div>
+        @for (archive of archives; track archive.archiveId) {
+          <div class="single-archive">
+            <div>
+              <img
+                src="assets/svg/onboarding/default-archive.svg"
+                alt="Custom Archive Icon"
+              />
+              <p>
+                The <b>{{ archive.fullName }}</b> Archive
+              </p>
+            </div>
+            <div class="square">
+              <span>{{ archive.accessRole | accessRole }}</span>
+            </div>
+          </div>
+        }
       </div>
       <hr />
     </div>

--- a/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.scss
+++ b/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.scss
@@ -29,20 +29,21 @@ p {
 .square {
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.08);
-  width: 72px;
   padding: 6px;
 
   & > span {
     color: white;
+    text-transform: uppercase;
   }
 }
 
-.archive-info {
+.single-archive {
   display: flex;
   flex-direction: row;
   gap: 16px;
   align-items: center;
   justify-content: space-between;
+  margin-bottom: 1rem;
 
   & > div {
     display: flex;

--- a/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.spec.ts
@@ -1,16 +1,24 @@
 /* @format */
 import { Shallow } from 'shallow-render';
+import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
+import { ArchiveVO } from '@models/index';
+import { AccessRolePipe } from '@shared/pipes/access-role.pipe';
 import { OnboardingModule } from '../../../onboarding.module';
 import { FinalizeArchiveCreationScreenComponent } from './finalize-archive-creation-screen.component';
 
 describe('FinalizeArchiveCreationScreenComponent', () => {
   let shallow: Shallow<FinalizeArchiveCreationScreenComponent>;
+  let onboardingService: OnboardingService;
 
   beforeEach(async () => {
+    onboardingService = new OnboardingService();
     shallow = new Shallow(
       FinalizeArchiveCreationScreenComponent,
       OnboardingModule,
-    );
+    )
+      .provide({ provide: OnboardingService, useValue: onboardingService })
+      .dontMock(OnboardingService)
+      .dontMock(AccessRolePipe);
   });
 
   it('should create', async () => {
@@ -21,12 +29,41 @@ describe('FinalizeArchiveCreationScreenComponent', () => {
 
   it('should display the archive name correctly', async () => {
     const name = 'Test Archive';
-    const { fixture, find } = await shallow.render({ bind: { name } });
+    onboardingService.registerArchive(new ArchiveVO({ fullName: name }));
+    const { find } = await shallow.render();
     const archiveNameElement = find('.archive-info p');
 
     expect(archiveNameElement.nativeElement.textContent).toContain(
       `The ${name} Archive`,
     );
+  });
+
+  it('it should display multiple archives with access roles correctly', async () => {
+    onboardingService.registerArchive(
+      new ArchiveVO({ fullName: 'Unit Test', accessRole: 'access.role.owner' }),
+    );
+    onboardingService.registerArchive(
+      new ArchiveVO({
+        fullName: 'Unit Test 2',
+        accessRole: 'access.role.editor',
+      }),
+    );
+    onboardingService.registerArchive(
+      new ArchiveVO({
+        fullName: 'Unit Test 3',
+        accessRole: 'access.role.viewer',
+      }),
+    );
+
+    const { find } = await shallow.render();
+    const archiveNameElement = find('.archive-info .single-archive');
+
+    expect(archiveNameElement.length).toBe(3);
+    expect(archiveNameElement[0].nativeElement.textContent).toContain(
+      'Unit Test Archive',
+    );
+
+    expect(archiveNameElement[0].nativeElement.textContent).toContain('Owner');
   });
 
   it('should emit finalizeArchiveOutput when finalizeArchive is called', async () => {

--- a/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.ts
+++ b/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.ts
@@ -1,5 +1,7 @@
 /* @format */
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { ArchiveVO } from '@models/index';
+import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
 
 @Component({
   selector: 'pr-finalize-archive-creation-screen',
@@ -7,9 +9,13 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
   styleUrl: './finalize-archive-creation-screen.component.scss',
 })
 export class FinalizeArchiveCreationScreenComponent {
-  @Input() name: string = '';
   @Output() finalizeArchiveOutput = new EventEmitter<string>();
+  public archives: ArchiveVO[];
   public isArchiveSubmitted: boolean = false;
+
+  constructor(onboardingService: OnboardingService) {
+    this.archives = onboardingService.getFinalArchives();
+  }
 
   finalizeArchive() {
     this.isArchiveSubmitted = true;

--- a/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.ts
+++ b/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Output, EventEmitter } from '@angular/core';
 import { ArchiveVO } from '@models/index';
 import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
 

--- a/src/app/onboarding/components/glam/name-archive-screen/name-archive-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/name-archive-screen/name-archive-screen.component.spec.ts
@@ -2,6 +2,7 @@
 import { Shallow } from 'shallow-render';
 import { By } from '@angular/platform-browser';
 import { ReactiveFormsModule } from '@angular/forms';
+import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
 import { OnboardingModule } from '../../../onboarding.module';
 import { NameArchiveScreenComponent } from './name-archive-screen.component';
 
@@ -9,9 +10,10 @@ describe('NameArchiveScreenComponent', () => {
   let shallow: Shallow<NameArchiveScreenComponent>;
 
   beforeEach(async () => {
-    shallow = new Shallow(NameArchiveScreenComponent, OnboardingModule).import(
-      ReactiveFormsModule,
-    );
+    shallow = new Shallow(NameArchiveScreenComponent, OnboardingModule)
+      .import(ReactiveFormsModule)
+      .provide(OnboardingService)
+      .dontMock(OnboardingService);
   });
 
   it('should create', async () => {

--- a/src/app/onboarding/components/glam/name-archive-screen/name-archive-screen.component.ts
+++ b/src/app/onboarding/components/glam/name-archive-screen/name-archive-screen.component.ts
@@ -5,6 +5,9 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
+import { AccessRole } from '@models/access-role';
+import { ArchiveVO } from '@models/index';
+import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
 
 @Component({
   selector: 'pr-name-archive-screen',
@@ -18,7 +21,10 @@ export class NameArchiveScreenComponent implements OnInit {
   @Output() backToCreateEmitter = new EventEmitter<string>();
   @Output() archiveCreatedEmitter = new EventEmitter<string>();
 
-  constructor(private fb: UntypedFormBuilder) {
+  constructor(
+    private fb: UntypedFormBuilder,
+    private onboardingService: OnboardingService,
+  ) {
     this.nameForm = fb.group({
       archiveName: ['', [Validators.required]],
     });
@@ -35,6 +41,12 @@ export class NameArchiveScreenComponent implements OnInit {
   public createArchive(): void {
     if (this.nameForm.valid) {
       this.archiveCreatedEmitter.emit(this.nameForm.value.archiveName);
+      this.onboardingService.registerArchive(
+        new ArchiveVO({
+          fullName: this.nameForm.value.archiveName,
+          accessRole: 'access.role.owner',
+        }),
+      );
     }
   }
 }

--- a/src/app/onboarding/components/onboarding/onboarding.component.stories.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.stories.ts
@@ -18,6 +18,7 @@ import { Subject } from 'rxjs';
 import { ArchiveSmallComponent } from '@shared/components/archive-small/archive-small.component';
 import { BgImageSrcDirective } from '@shared/directives/bg-image-src.directive';
 import { ComponentsModule } from '@root/app/component-library/components.module';
+import { AccessRolePipe } from '@shared/pipes/access-role.pipe';
 import { WelcomeScreenComponent } from '../welcome-screen/welcome-screen.component';
 import { CreateNewArchiveComponent } from '../create-new-archive/create-new-archive.component';
 import { ArchiveTypeSelectComponent } from '../archive-type-select/archive-type-select.component';
@@ -36,6 +37,7 @@ import { ArchiveTypeIconComponent } from '../glam/archive-type-icon/archive-type
 import { GlamPendingArchivesComponent } from '../glam-pending-archives/glam-pending-archives.component';
 import { PendingArchiveComponent } from '../glam/pending-archive/pending-archive.component';
 import { ArchiveCreationWithShareComponent } from '../archive-creation-with-share/archive-creation-with-share.component';
+import { OnboardingService } from '../../services/onboarding.service';
 import { OnboardingComponent } from './onboarding.component';
 
 class MockAccountService {
@@ -183,6 +185,7 @@ export default {
         GlamPendingArchivesComponent,
         PendingArchiveComponent,
         ArchiveCreationWithShareComponent,
+        AccessRolePipe,
       ],
       imports: [
         CommonModule,
@@ -196,6 +199,7 @@ export default {
         { provide: ActivatedRoute, useValue: { snapshot: { data: {} } } },
         { provide: AccountService, useClass: MockAccountService },
         { provide: ApiService, useClass: MockApiService },
+        OnboardingService,
       ],
     }),
   ],

--- a/src/app/onboarding/onboarding.module.ts
+++ b/src/app/onboarding/onboarding.module.ts
@@ -31,6 +31,7 @@ import { GlamOnboardingHeaderComponent } from './components/glam/glam-header/gla
 import { GlamPendingArchivesComponent } from './components/glam-pending-archives/glam-pending-archives.component';
 import { PendingArchiveComponent } from './components/glam/pending-archive/pending-archive.component';
 import { ArchiveCreationWithShareComponent } from './components/archive-creation-with-share/archive-creation-with-share.component';
+import { OnboardingService } from './services/onboarding.service';
 
 @NgModule({
   declarations: [
@@ -63,12 +64,10 @@ import { ArchiveCreationWithShareComponent } from './components/archive-creation
     GlamArchiveTypeSelectComponent,
     ArchiveTypeIconComponent,
   ],
+  providers: [OnboardingService],
 })
 export class OnboardingModule {
-  constructor(
-    private resolver: ComponentFactoryResolver,
-    private library: FaIconLibrary,
-  ) {
+  constructor(private library: FaIconLibrary) {
     library.addIcons(faHeart);
   }
 }

--- a/src/app/onboarding/services/onboarding.service.spec.ts
+++ b/src/app/onboarding/services/onboarding.service.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed } from '@angular/core/testing';
+import { ArchiveVO } from '@models/index';
+import { OnboardingService } from './onboarding.service';
+
+describe('OnboardingService', () => {
+  let service: OnboardingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(OnboardingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('can register a created archive and fetch it', () => {
+    service.registerArchive(
+      new ArchiveVO({ fullName: 'Unit Test', accessRole: 'access.role.owner' }),
+    );
+    const archives = service.getFinalArchives();
+
+    expect(archives.length).toBe(1);
+    expect(archives[0].fullName).toBe('Unit Test');
+    expect(archives[0].accessRole).toBe('access.role.owner');
+  });
+});

--- a/src/app/onboarding/services/onboarding.service.ts
+++ b/src/app/onboarding/services/onboarding.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { ArchiveVO } from '@models/index';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OnboardingService {
+  private onboardedArchives: ArchiveVO[] = [];
+
+  constructor() {}
+
+  public registerArchive(archive: ArchiveVO): void {
+    this.onboardedArchives.push(archive);
+  }
+
+  public getFinalArchives(): ArchiveVO[] {
+    return this.onboardedArchives;
+  }
+}


### PR DESCRIPTION
Right now the final congratulations / "finalize" screen lists a user's created archive. If a user has archive invites they can accept multiple archives during onboarding but only one is showing and it is listed as an owner regardless of the access role of the archive. Update this congrats screen to handle multiple archives and list out all their access roles correctly.

This PR involves the creation of a new `OnboardingService` which mainly acts as a place to store "registered archives" and then get that final list of archives in the end. This is a better pattern for sharing information between components with complex flows compared to the Input/Output system we're using now, but I also think that the onboarding flow has complex enough behavior to warrant some of that behavior moving into a dedicated service anyway. I didn't want this 1 point ticket to involve a complete refactoring of glam onboarding logic, so this service is pretty bare right now. As we continue to improve the onboarding flow, I hope we can continue to move things into this service.

**Steps to test:**
1. Run through the glam onboarding flow and verify that when you create an archive it still shows up properly.
2. Run through the glam onboarding flow with multiple archive invitations, preferably with access roles besides owner. Verify that at the end of the process all archives are listed with correct access roles.

This can be tested through the onboarding Storybook demo by running `npm run storybook`.