### PR TITLE
Remove the old welcome dialog and invitation dialog components

### DIFF
--- a/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
@@ -211,16 +211,17 @@ describe('OnboardingComponent #onboarding', () => {
     expect(removeItemSpy).toHaveBeenCalledWith('shareToken');
   });
 
-  it('should navigate to /app if shareToken is not in localStorage', async () => {
+  it('should navigate to /app/welcome if shareToken is not in localStorage and isGlam is false', async () => {
     const { instance, fixture } = await shallow.render();
 
     spyOn(localStorage, 'getItem').and.returnValue(null);
-
+    instance.isGlam = false;
+    instance.acceptedInvite = false;
     instance.setScreen(OnboardingScreen.done);
     instance.selectedPendingArchive = null;
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(mockRouter.navigate).toHaveBeenCalledWith(['/app']);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/app', 'welcome']);
   });
 });

--- a/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
@@ -59,9 +59,7 @@ const mockMessageService = {
 };
 
 const mockRouter = {
-  async navigate(path: any[]) {
-    return {};
-  },
+  navigate: jasmine.createSpy('navigate'),
 };
 
 describe('OnboardingComponent #onboarding', () => {
@@ -211,5 +209,18 @@ describe('OnboardingComponent #onboarding', () => {
 
     expect(getItemSpy).toHaveBeenCalledWith('shareToken');
     expect(removeItemSpy).toHaveBeenCalledWith('shareToken');
+  });
+
+  it('should navigate to /app if shareToken is not in localStorage', async () => {
+    const { instance, fixture } = await shallow.render();
+
+    spyOn(localStorage, 'getItem').and.returnValue(null);
+
+    instance.setScreen(OnboardingScreen.done);
+    instance.selectedPendingArchive = null;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/app']);
   });
 });

--- a/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.spec.ts
@@ -224,4 +224,35 @@ describe('OnboardingComponent #onboarding', () => {
 
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/app', 'welcome']);
   });
+
+  it('should navigate to /app if shareToken is not in localStorage and isGlam is true', async () => {
+    const { instance, fixture } = await shallow.render();
+
+    spyOn(localStorage, 'getItem').and.returnValue(null);
+    instance.isGlam = true;
+    instance.acceptedInvite = false;
+    instance.setScreen(OnboardingScreen.done);
+    instance.selectedPendingArchive = null;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/app']);
+  });
+
+  it('should navigate to /app/welcome-invite if shareToken is not in localStorage and isGlam is true', async () => {
+    const { instance, fixture } = await shallow.render();
+
+    spyOn(localStorage, 'getItem').and.returnValue(null);
+    instance.isGlam = false;
+    instance.acceptedInvite = true;
+    instance.setScreen(OnboardingScreen.done);
+    instance.selectedPendingArchive = null;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith([
+      '/app',
+      'welcome-invitation',
+    ]);
+  });
 });

--- a/src/app/onboarding/components/onboarding/onboarding.component.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.ts
@@ -90,9 +90,14 @@ export class OnboardingComponent implements OnInit {
       this.selectedPendingArchive = null;
     }
     if (screen === OnboardingScreen.done) {
+      if (!this.isGlam && this.acceptedInvite) {
+        this.router.navigate(['/app', 'welcome-invitation']);
+      }
       if (localStorage.getItem('shareToken')) {
         localStorage.removeItem('shareToken');
         this.router.navigate(['/app', 'shares']);
+      } else if (!this.isGlam) {
+        this.router.navigate(['/app', 'welcome']);
       } else {
         this.router.navigate(['/app']);
       }

--- a/src/app/onboarding/components/onboarding/onboarding.component.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.ts
@@ -90,14 +90,11 @@ export class OnboardingComponent implements OnInit {
       this.selectedPendingArchive = null;
     }
     if (screen === OnboardingScreen.done) {
-      if (this.acceptedInvite) {
-        this.router.navigate(['/app', 'welcome-invitation']);
-      }
       if (localStorage.getItem('shareToken')) {
         localStorage.removeItem('shareToken');
         this.router.navigate(['/app', 'shares']);
       } else {
-        this.router.navigate(['/app', 'welcome']);
+        this.router.navigate(['/app']);
       }
     }
   }


### PR DESCRIPTION
I have removed the old welcome dialogs because with the new onboarding they are not needed anymore.

Steps to test:
1. Create a new account (with or without invitation)
2. Go through the onboarding process
3. When done, it should redirect you to the private workspace, without any dialog popping up