### PR TITLE
Call v2 version of registerRecord on all uploads

### DIFF
--- a/src/app/core/services/upload/uploader.spec.ts
+++ b/src/app/core/services/upload/uploader.spec.ts
@@ -1,0 +1,100 @@
+import { EventService } from '@shared/services/event/event.service';
+import { ApiService } from '@shared/services/api/api.service';
+import { HttpClient } from '@angular/common/http';
+import { FolderVO, RecordVO, SimpleVO } from '@models/index';
+import { RecordResponse } from '@shared/services/api/record.repo';
+import { Uploader } from './uploader';
+import { UploadItem } from './uploadItem';
+
+class MockApiService {
+  public static gotPresigned: boolean = false;
+  public static registeredRecord: RecordVO = null;
+  public static registeredDestination: string = null;
+  public static reset() {
+    MockApiService.gotPresigned = false;
+    MockApiService.registeredRecord = null;
+    MockApiService.registeredDestination = null;
+  }
+  public record = {
+    async registerRecord(record: RecordVO, url: string) {
+      MockApiService.registeredRecord = record;
+      MockApiService.registeredDestination = url;
+      return record;
+    },
+    async getPresignedUrl() {
+      MockApiService.gotPresigned = true;
+      return new RecordResponse({
+        isSuccessful: true,
+        Results: [
+          {
+            data: [
+              {
+                SimpleVO: new SimpleVO({
+                  key: 'Result',
+                  value: {
+                    destinationUrl: 'testurl',
+                    presignedPost: {
+                      url: 'presignedTesturl',
+                      fields: {
+                        bucket: 'test',
+                        'X-Amz-Algorithm': 'test',
+                        'X-Amz-Credential': 'test',
+                        'X-Amz-Date': 'test',
+                        key: 'test',
+                        Policy: 'test',
+                        'X-Amz-Signature': 'test',
+                      },
+                    },
+                  },
+                }),
+              },
+            ],
+          },
+        ],
+      });
+    },
+  };
+}
+
+class MockHttpClient {
+  public hitUrl: string = null;
+  public formData: FormData = null;
+  public post(url: string, formdata: FormData, options: any) {
+    this.hitUrl = url;
+    this.formData = formdata;
+    return {
+      forEach: async () => {},
+    };
+  }
+}
+
+describe('Uploader', () => {
+  let uploader: Uploader;
+  let api: MockApiService;
+  let http: MockHttpClient;
+
+  beforeEach(() => {
+    MockApiService.reset();
+    api = new MockApiService();
+    http = new MockHttpClient();
+    uploader = new Uploader(
+      api as unknown as ApiService,
+      http as unknown as HttpClient,
+      new EventService(),
+    );
+  });
+
+  it('can do a single-part upload', async () => {
+    const uploadItem = new UploadItem(
+      new File([], 'test.txt'),
+      new FolderVO({ folderId: 1, folder_linkId: 1 }),
+    );
+    await uploader.uploadFile(uploadItem, () => {});
+
+    expect(MockApiService.gotPresigned).toBeTrue();
+    expect(http.hitUrl).toBe('presignedTesturl');
+    expect(MockApiService.registeredRecord.displayName).toBe('test.txt');
+    expect(MockApiService.registeredRecord.parentFolderId).toBe(1);
+    expect(MockApiService.registeredDestination).toBe('testurl');
+  });
+});

--- a/src/app/core/services/upload/uploader.ts
+++ b/src/app/core/services/upload/uploader.ts
@@ -40,22 +40,21 @@ export class Uploader {
   };
 
   private registerRecord = async (item: UploadItem, destinationUrl: string) => {
-    const registerResponse = await this.api.record.registerRecord(
-      item.RecordVO,
-      destinationUrl,
-    );
-    if (registerResponse.isSuccessful !== true) {
-      throw registerResponse;
+    try {
+      const record = await this.api.record.registerRecord(
+        item.RecordVO,
+        destinationUrl,
+      );
+
+      this.event.dispatch({
+        action: 'submit',
+        entity: 'record',
+        record,
+      });
+      return record;
+    } catch (response) {
+      throw response;
     }
-
-    const record = registerResponse.Results[0].data[0].RecordVO;
-
-    this.event.dispatch({
-      action: 'submit',
-      entity: 'record',
-      record,
-    });
-    return registerResponse;
   };
 
   private upload = async (

--- a/src/app/shared/services/api/record.repo.spec.ts
+++ b/src/app/shared/services/api/record.repo.spec.ts
@@ -1,11 +1,21 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { environment } from '@root/environments/environment';
 
 import { TEST_DATA, TEST_DATA_2 } from '@core/core.module.spec';
 import { HttpService, Observable } from '@shared/services/http/http.service';
 import { RecordRepo, RecordResponse } from '@shared/services/api/record.repo';
-import { SimpleVO, AccountPasswordVO, AccountVO, ArchiveVO } from '@root/app/models';
+import {
+  SimpleVO,
+  AccountPasswordVO,
+  AccountVO,
+  ArchiveVO,
+  RecordVO,
+} from '@root/app/models';
+import { HttpV2Service } from '../http-v2/http-v2.service';
 
 describe('RecordRepo', () => {
   let repo: RecordRepo;
@@ -13,18 +23,50 @@ describe('RecordRepo', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule
-      ],
-      providers: [HttpService]
+      imports: [HttpClientTestingModule],
+      providers: [HttpService, HttpV2Service],
     });
 
-    repo = new RecordRepo(TestBed.get(HttpService));
-    httpMock = TestBed.get(HttpTestingController);
+    repo = new RecordRepo(
+      TestBed.inject(HttpService),
+      TestBed.inject(HttpV2Service),
+    );
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
     httpMock.verify();
   });
 
+  it('should use a V2 request for registerRecord', (done) => {
+    const testRecord = new RecordVO({
+      displayName: 'test',
+      parentFolderId: 1,
+      uploadFileName: 'test.jpg',
+      size: 1234,
+    });
+    const testUrl = 'test';
+
+    repo
+      .registerRecord(testRecord, testUrl)
+      .then((_) => {
+        done();
+      })
+      .catch(done.fail);
+
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/record/registerRecord`,
+    );
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
+    expect(req.request.body).toEqual({
+      displayName: testRecord.displayName,
+      parentFolderId: testRecord.parentFolderId,
+      uploadFileName: testRecord.uploadFileName,
+      size: testRecord.size,
+      s3url: testUrl,
+    });
+    req.flush(testRecord);
+  });
 });

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -8,6 +8,7 @@ import {
 
 import { StorageService } from '@shared/services/storage/storage.service';
 import { ThumbnailCache } from '@shared/utilities/thumbnail-cache/thumbnail-cache';
+import { firstValueFrom } from 'rxjs';
 import { getFirst } from '../http-v2/http-v2.service';
 
 const MIN_WHITELIST: (keyof RecordVO)[] = [
@@ -97,17 +98,20 @@ export class RecordRepo extends BaseRepo {
     ]);
   }
 
-  public registerRecord(
-    recordVO: RecordVO,
-    s3url: string,
-  ): Promise<RecordResponse> {
-    return this.http.sendRequestPromise('/record/registerRecord', {
-      RecordVO: recordVO,
-      SimpleVO: {
-        key: 's3url',
-        value: s3url,
-      },
-    });
+  public registerRecord(recordVO: RecordVO, s3url: string): Promise<RecordVO> {
+    return firstValueFrom(
+      this.httpV2.post(
+        '/record/registerRecord',
+        {
+          displayName: recordVO.displayName,
+          parentFolderId: recordVO.parentFolderId,
+          uploadFileName: recordVO.uploadFileName,
+          size: recordVO.size,
+          s3url,
+        },
+        RecordVO,
+      ),
+    )[0];
   }
 
   public getMultipartUploadURLs(

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -98,19 +98,24 @@ export class RecordRepo extends BaseRepo {
     ]);
   }
 
-  public registerRecord(recordVO: RecordVO, s3url: string): Promise<RecordVO> {
-    return firstValueFrom(
-      this.httpV2.post(
-        '/record/registerRecord',
-        {
-          displayName: recordVO.displayName,
-          parentFolderId: recordVO.parentFolderId,
-          uploadFileName: recordVO.uploadFileName,
-          size: recordVO.size,
-          s3url,
-        },
-        RecordVO,
-      ),
+  public async registerRecord(
+    recordVO: RecordVO,
+    s3url: string,
+  ): Promise<RecordVO> {
+    return (
+      await firstValueFrom(
+        this.httpV2.post(
+          '/record/registerRecord',
+          {
+            displayName: recordVO.displayName,
+            parentFolderId: recordVO.parentFolderId,
+            uploadFileName: recordVO.uploadFileName,
+            size: recordVO.size,
+            s3url,
+          },
+          RecordVO,
+        ),
+      )
     )[0];
   }
 


### PR DESCRIPTION
We previously only used this for multipart uploads. Migrate to the V2 version of this endpoint.

**Steps to test:**
1. Verify that uploads of files under 50MB in size still work properly.