### PR TITLE
Use FontAwesome Pro Icons

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-node_modules-
 
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
 
       - name: Build Storybook
         run: npm run build-storybook

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -24,7 +24,7 @@ jobs:
             ${{ runner.os }}-node_modules-
 
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
 
       - name: Build
         env:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -54,7 +54,7 @@ jobs:
             ${{ runner.os }}-node_modules-
 
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
 
       - name: Build Storybook
         run: npm run build-storybook

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
       - name: Build
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_PROD }}

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -21,7 +21,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
       - name: Build
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_STAGING }}

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -53,7 +53,7 @@ jobs:
             ${{ runner.os }}-node_modules-
 
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
 
       - name: Build Storybook
         run: npm run build-storybook

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
       - name: Run Prettier
         run: npx prettier --check --require-pragma .
       - name: Run eslint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-node_modules-
 
       - name: Install dependencies
-        run: npm install
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
 
       - name: Run unit tests
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONTAWESOME_PACKAGE_TOKEN}

--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ This is the source code for Permanent.org's front-end.
 
 To get started, first create the file for the environment variables.
 
-```
+```sh
 cp .env.template .env
 ```
 
 Add your environment secrets to `.env`.
 
-Install the project dependencies with `npm install`.
+You need access to FontAwesome Pro packages to install dependencies. You can install the project dependencies with:
+
+```sh
+FONTAWESOME_PACKAGE_TOKEN="insert_token_here" npm install
+```
 
 Then run the app using `npm run dev` to point the dev server against your `local.permanent.org` VM accessible at `https://ng.permanent.org:4200`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.28",
         "@fortawesome/free-regular-svg-icons": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^5.13.0",
+        "@fortawesome/pro-regular-svg-icons": "^6.7.1",
+        "@fortawesome/pro-solid-svg-icons": "^6.7.1",
         "@ng-bootstrap/ng-bootstrap": "16.0.0",
         "@popperjs/core": "^2.11.8",
         "@sentry/browser": "7.119.1",
@@ -6358,6 +6360,44 @@
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/pro-regular-svg-icons": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/pro-regular-svg-icons/-/6.7.1/pro-regular-svg-icons-6.7.1.tgz",
+      "integrity": "sha512-P9De393pkvCAMYvS26US91a2eOJmWzawCsTJnXnFKwQeAjTvpo8fWOxSQ+391/dBQg0zLy9cMFmBzvVL4s+xxw==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/pro-regular-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.7.1/fontawesome-common-types-6.7.1.tgz",
+      "integrity": "sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/pro-solid-svg-icons": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/pro-solid-svg-icons/-/6.7.1/pro-solid-svg-icons-6.7.1.tgz",
+      "integrity": "sha512-YMehuODXC+puZRJigjfB+hwCeiUsfEfiDXJV0W1iSbrqX9xBbDl0Ovbnai3EUlwIVWpgfoWew6Cx207wwVAEnA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/pro-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.7.1/fontawesome-common-types-6.7.1.tgz",
+      "integrity": "sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ==",
       "engines": {
         "node": ">=6"
       }
@@ -38109,6 +38149,36 @@
       "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/pro-regular-svg-icons": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/pro-regular-svg-icons/-/6.7.1/pro-regular-svg-icons-6.7.1.tgz",
+      "integrity": "sha512-P9De393pkvCAMYvS26US91a2eOJmWzawCsTJnXnFKwQeAjTvpo8fWOxSQ+391/dBQg0zLy9cMFmBzvVL4s+xxw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.7.1"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "6.7.1",
+          "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.7.1/fontawesome-common-types-6.7.1.tgz",
+          "integrity": "sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ=="
+        }
+      }
+    },
+    "@fortawesome/pro-solid-svg-icons": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/pro-solid-svg-icons/-/6.7.1/pro-solid-svg-icons-6.7.1.tgz",
+      "integrity": "sha512-YMehuODXC+puZRJigjfB+hwCeiUsfEfiDXJV0W1iSbrqX9xBbDl0Ovbnai3EUlwIVWpgfoWew6Cx207wwVAEnA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.7.1"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "6.7.1",
+          "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.7.1/fontawesome-common-types-6.7.1.tgz",
+          "integrity": "sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ=="
+        }
       }
     },
     "@google-cloud/firestore": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-regular-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
+    "@fortawesome/pro-regular-svg-icons": "^6.7.1",
+    "@fortawesome/pro-solid-svg-icons": "^6.7.1",
     "@ng-bootstrap/ng-bootstrap": "16.0.0",
     "@popperjs/core": "^2.11.8",
     "@sentry/browser": "7.119.1",

--- a/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.ts
@@ -6,6 +6,8 @@ import {
   faHeart,
   faPeopleGroup,
   faScrollOld,
+  faShapes,
+  faSquareEllipsis,
   faUser,
 } from '@fortawesome/pro-regular-svg-icons';
 import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
@@ -25,7 +27,7 @@ export class ArchiveTypeIconComponent {
     'type:famhist': faScrollOld,
     'type:community': faPeopleGroup,
     'type:org': faBuildingColumns,
-    'type:other': faHeart,
-    'type:unsure': faHeart,
+    'type:other': faSquareEllipsis,
+    'type:unsure': faShapes,
   };
 }

--- a/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.ts
+++ b/src/app/onboarding/components/glam/archive-type-icon/archive-type-icon.component.ts
@@ -1,7 +1,13 @@
 import { Component, Input } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faHeart, faUser } from '@fortawesome/free-regular-svg-icons';
-import { faScroll } from '@fortawesome/free-solid-svg-icons';
+import {
+  faBuildingColumns,
+  faFamily,
+  faHeart,
+  faPeopleGroup,
+  faScrollOld,
+  faUser,
+} from '@fortawesome/pro-regular-svg-icons';
 import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
 
 @Component({
@@ -12,10 +18,14 @@ import { OnboardingTypes } from '@root/app/onboarding/shared/onboarding-screen';
 })
 export class ArchiveTypeIconComponent {
   @Input() public type: OnboardingTypes = OnboardingTypes.myself;
-  public readonly icons = {
+  public readonly icons: Record<OnboardingTypes, typeof faHeart> = {
     'type:myself': faHeart,
     'type:individual': faUser,
-    'type:family': faHeart,
-    'type:famhist': faScroll,
+    'type:family': faFamily,
+    'type:famhist': faScrollOld,
+    'type:community': faPeopleGroup,
+    'type:org': faBuildingColumns,
+    'type:other': faHeart,
+    'type:unsure': faHeart,
   };
 }

--- a/src/app/onboarding/components/glam/types/archive-types.ts
+++ b/src/app/onboarding/components/glam/types/archive-types.ts
@@ -54,8 +54,8 @@ export const archiveDescriptions = {
     'Create an archive that preserves the history of a community, group, or other association of people.',
   'type:org':
     'Create an archive that preserves the history of an organization or nonprofit.',
-  'type:other': '',
-  'type:unsure': '',
+  'type:other': 'Create an archive about something else.',
+  'type:unsure': 'I’m not sure what type of archive I want to create.',
 };
 
 export const archiveOptionsWithArticle = [


### PR DESCRIPTION
Use FontAwesome Pro icons in the Glam onboarding and fill in the descriptions for the "other" and "unsure" archive types. Note that you will now need a FontAwesome token to install dependencies on this project:

```sh
FONTAWESOME_PACKAGE_TOKEN="insert_token_here" npm install
```

**Steps to test:**
1. Check that new icons are used when selecting an archive type in glam onboarding