### PR TITLE
PER-9916-exiting-onboarding-on-refresh

### DIFF
--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,45 +1,59 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  Router,
+} from '@angular/router';
 import { Observable } from 'rxjs';
 import { AccountService } from '@shared/services/account/account.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
-export class AuthGuard  {
-  constructor (private account: AccountService, private router: Router) {}
+export class AuthGuard {
+  constructor(
+    private account: AccountService,
+    private router: Router,
+  ) {}
 
   canActivate(
     next: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
-  ): Promise<boolean> {
-    return this.account.checkSession()
-    .then((isSessionValid: boolean) => {
-      if (isSessionValid && this.account.isLoggedIn()) {
-        return true;
-      } else {
-        if (isSessionValid !== this.account.isLoggedIn()) {
-          this.account.clear();
+    state: RouterStateSnapshot,
+  ): Promise<any> {
+    return this.account
+      .checkSession()
+      .then((isSessionValid: boolean) => {
+        if (isSessionValid && this.account.isLoggedIn()) {
+          return true;
+        } else {
+          if (isSessionValid !== this.account.isLoggedIn()) {
+            this.account.clear();
+          }
+          this.router.navigate(['/app', 'auth', 'login'], {
+            queryParams: next.queryParams,
+          });
+          return false;
         }
-        this.router.navigate(['/app', 'auth', 'login'], { queryParams: next.queryParams });
+      })
+      .catch(() => {
+        this.account.clear();
+        this.router.navigate(['/app', 'auth', 'login'], {
+          queryParams: next.queryParams,
+        });
         return false;
-      }
-    })
-    .catch(() => {
-      this.account.clear();
-      this.router.navigate(['/app', 'auth', 'login'], { queryParams: next.queryParams });
-      return false;
-    });
+      });
   }
 
   canActivateChild(
     next: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
+    state: RouterStateSnapshot,
   ): Observable<boolean> | Promise<boolean> | boolean {
     if (this.account.isLoggedIn()) {
       return true;
     } else {
-      this.router.navigate(['/app', 'auth', 'login'], { queryParams: next.queryParams });
+      this.router.navigate(['/app', 'onboarding'], {
+        queryParams: next.queryParams,
+      });
       return false;
     }
   }

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
@@ -101,6 +101,13 @@ export class CreateNewArchiveComponent implements OnInit {
     if (!this.isGlam) {
       this.screen = 'create';
     }
+
+    const screen = sessionStorage.getItem('onboardingScreen');
+    if (screen) {
+      this.screen = screen as NewArchiveScreen;
+    } else {
+      sessionStorage.setItem('onboardingScreen', this.screen);
+    }
   }
 
   ngOnInit(): void {
@@ -119,6 +126,26 @@ export class CreateNewArchiveComponent implements OnInit {
       entity: 'account',
       action: 'start_onboarding',
     });
+
+    const storageGoals = sessionStorage.getItem('goals');
+    if (storageGoals) {
+      this.selectedGoals = JSON.parse(storageGoals);
+    }
+
+    const storageReasons = sessionStorage.getItem('reasons');
+    if (storageReasons) {
+      this.selectedReasons = JSON.parse(storageReasons);
+    }
+
+    const storageName = sessionStorage.getItem('archiveName');
+    if (storageName) {
+      this.name = storageName;
+    }
+
+    const storageType = sessionStorage.getItem('archiveType');
+    if (storageType) {
+      this.archiveType = storageType;
+    }
   }
 
   public onBackPress(): void {
@@ -132,6 +159,7 @@ export class CreateNewArchiveComponent implements OnInit {
       this.screen = 'goals';
       this.progress.emit(1);
     }
+    sessionStorage.setItem('onboardingScreen', this.screen);
   }
 
   public setScreen(screen: NewArchiveScreen): void {
@@ -147,6 +175,7 @@ export class CreateNewArchiveComponent implements OnInit {
       action: action,
     });
     this.screen = screen;
+    sessionStorage.setItem('onboardingScreen', screen);
     if (screen === 'reasons') {
       this.progress.emit(2);
       this.chartPathClicked.emit();
@@ -250,10 +279,12 @@ export class CreateNewArchiveComponent implements OnInit {
     if (this.screen === 'goals') {
       this.screen = 'reasons';
       this.progress.emit(2);
+      sessionStorage.setItem('onboardingScreen', this.screen);
       this.selectedGoals = [];
     } else if (this.screen === 'reasons') {
       this.selectedReasons = [];
       this.onSubmit();
+      sessionStorage.removeItem('onboardingScreen');
     }
   }
 
@@ -264,8 +295,9 @@ export class CreateNewArchiveComponent implements OnInit {
   private setName(archiveTypeTag: OnboardingTypes): void {
     switch (archiveTypeTag) {
       case OnboardingTypes.unsure:
-        const name = this.accountService.getAccount().fullName;
+        const name = this.accountService.getAccount()?.fullName;
         this.name = name;
+        sessionStorage.setItem('archiveName', name);
         break;
       default:
         this.name = '';
@@ -284,8 +316,10 @@ export class CreateNewArchiveComponent implements OnInit {
   public handleCreationScreenEvents(event: Record<string, string>): void {
     this.archiveTypeTag = event.tag as OnboardingTypes;
     this.archiveType = event.type;
+    sessionStorage.setItem('archiveType', this.archiveType);
+    sessionStorage.setItem('archiveTypeTag', this.archiveTypeTag);
     this.headerText = event.headerText;
-    this.screen = event.screen as NewArchiveScreen;
+    this.setScreen(event.screen as NewArchiveScreen);
   }
 
   public onValueChange(value: {
@@ -300,6 +334,7 @@ export class CreateNewArchiveComponent implements OnInit {
 
   public navigateToGoals(event: string) {
     this.name = event;
+    sessionStorage.setItem('archiveName', this.name);
     this.setScreen('goals');
   }
 
@@ -318,5 +353,13 @@ export class CreateNewArchiveComponent implements OnInit {
   public handleReasonsEmit(event): void {
     this.selectedReasons = event.reasons;
     this.setScreen(event.screen as NewArchiveScreen);
+  }
+
+  private clearSessionStorage(): void {
+    sessionStorage.removeItem('goals');
+    sessionStorage.removeItem('reasons');
+    sessionStorage.removeItem('archiveName');
+    sessionStorage.removeItem('archiveType');
+    sessionStorage.removeItem('archiveTypeTag');
   }
 }

--- a/src/app/onboarding/components/glam/create-archive-for-me-screen/create-archive-for-me-screen.component.ts
+++ b/src/app/onboarding/components/glam/create-archive-for-me-screen/create-archive-for-me-screen.component.ts
@@ -32,6 +32,8 @@ export class CreateArchiveForMeScreenComponent {
     this.onboardingService.registerArchive(
       new ArchiveVO({ fullName: this.name, accessRole: 'access.role.owner' }),
     );
+    sessionStorage.setItem('archiveName', this.name);
+    sessionStorage.setItem('archiveType', this.TYPE);
     this.continueOutput.emit({
       screen: 'goals',
       type: this.TYPE,

--- a/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/finalize-archive-creation-screen/finalize-archive-creation-screen.component.spec.ts
@@ -28,9 +28,9 @@ describe('FinalizeArchiveCreationScreenComponent', () => {
   });
 
   it('should display the archive name correctly', async () => {
-    const name = 'Test Archive';
+    const name = 'John Doe';
     onboardingService.registerArchive(new ArchiveVO({ fullName: name }));
-    const { find } = await shallow.render();
+    const { fixture, find } = await shallow.render();
     const archiveNameElement = find('.archive-info p');
 
     expect(archiveNameElement.nativeElement.textContent).toContain(

--- a/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.spec.ts
@@ -18,7 +18,6 @@ describe('GlamGoalsScreenComponent', () => {
     });
 
     spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
-      console.log(`Mock setItem called with key: ${key}, value: ${value}`);
     });
   });
 

--- a/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.spec.ts
@@ -17,8 +17,7 @@ describe('GlamGoalsScreenComponent', () => {
       return store[key] || null;
     });
 
-    spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
-    });
+    spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {});
   });
 
   it('should create', async () => {

--- a/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.spec.ts
@@ -9,6 +9,17 @@ describe('GlamGoalsScreenComponent', () => {
 
   beforeEach(async () => {
     shallow = new Shallow(GlamGoalsScreenComponent, OnboardingModule);
+
+    spyOn(sessionStorage, 'getItem').and.callFake((key) => {
+      const store = {
+        goals: JSON.stringify(['Mock Goal']),
+      };
+      return store[key] || null;
+    });
+
+    spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
+      console.log(`Mock setItem called with key: ${key}, value: ${value}`);
+    });
   });
 
   it('should create', async () => {
@@ -21,6 +32,25 @@ describe('GlamGoalsScreenComponent', () => {
     const { instance } = await shallow.render();
 
     expect(instance.goals).toEqual(goals);
+  });
+
+  it('should initialize selectedGoals from sessionStorage', async () => {
+    const { instance } = await shallow.render();
+
+    expect(sessionStorage.getItem).toHaveBeenCalledWith('goals');
+    expect(instance.selectedGoals).toEqual(['Mock Goal']);
+  });
+
+  it('should update sessionStorage when addGoal is called', async () => {
+    const { instance } = await shallow.render();
+    const goal = 'Test Goal';
+
+    instance.addGoal(goal);
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      'goals',
+      JSON.stringify(['Mock Goal', 'Test Goal']),
+    );
   });
 
   it('should add goal to selectedGoals when addGoal is called', async () => {
@@ -46,7 +76,7 @@ describe('GlamGoalsScreenComponent', () => {
 
     expect(outputs.goalsOutput.emit).toHaveBeenCalledWith({
       screen: 'name-archive',
-      goals: [],
+      goals: ['Mock Goal'],
     });
   });
 
@@ -58,7 +88,7 @@ describe('GlamGoalsScreenComponent', () => {
 
     expect(outputs.goalsOutput.emit).toHaveBeenCalledWith({
       screen: 'reasons',
-      goals: [goal],
+      goals: ['Mock Goal', goal],
     });
   });
 });

--- a/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.ts
+++ b/src/app/onboarding/components/glam/glam-goals-screen/glam-goals-screen.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { goals } from '../../../shared/onboarding-screen';
 
 interface OutputModel {
@@ -12,13 +12,20 @@ interface OutputModel {
   templateUrl: './glam-goals-screen.component.html',
   styleUrl: './glam-goals-screen.component.scss',
 })
-export class GlamGoalsScreenComponent {
+export class GlamGoalsScreenComponent implements OnInit {
   public goals = [];
   @Input() selectedGoals: string[] = [];
   @Output() goalsOutput = new EventEmitter<OutputModel>();
 
   constructor() {
     this.goals = goals;
+  }
+
+  ngOnInit(): void {
+    const storageGoals = sessionStorage.getItem('goals');
+    if (storageGoals) {
+      this.selectedGoals = JSON.parse(storageGoals);
+    }
   }
 
   backToNameArchive() {
@@ -40,5 +47,6 @@ export class GlamGoalsScreenComponent {
     } else {
       this.selectedGoals.push(goal);
     }
+    sessionStorage.setItem('goals', JSON.stringify(this.selectedGoals));
   }
 }

--- a/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.spec.ts
@@ -18,7 +18,6 @@ describe('GlamReasonsScreenComponent', () => {
     });
 
     spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
-      console.log(`Mock setItem called with key: ${key}, value: ${value}`);
     });
   });
 

--- a/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.spec.ts
@@ -9,6 +9,17 @@ describe('GlamReasonsScreenComponent', () => {
 
   beforeEach(async () => {
     shallow = new Shallow(GlamReasonsScreenComponent, OnboardingModule);
+
+    spyOn(sessionStorage, 'getItem').and.callFake((key) => {
+      const store = {
+        reasons: JSON.stringify(['Mock Reason']),
+      };
+      return store[key] || null;
+    });
+
+    spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
+      console.log(`Mock setItem called with key: ${key}, value: ${value}`);
+    });
   });
 
   it('should create', async () => {
@@ -21,6 +32,25 @@ describe('GlamReasonsScreenComponent', () => {
     const { instance } = await shallow.render();
 
     expect(instance.reasons).toEqual(reasons);
+  });
+
+  it('should initialize selectedReasons from sessionStorage', async () => {
+    const { instance } = await shallow.render();
+
+    expect(sessionStorage.getItem).toHaveBeenCalledWith('reasons');
+    expect(instance.selectedReasons).toEqual(['Mock Reason']);
+  });
+
+  it('should update sessionStorage when addReason is called', async () => {
+    const { instance } = await shallow.render();
+    const reason = 'Test Reason';
+
+    instance.addReason(reason);
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      'reasons',
+      JSON.stringify(['Mock Reason', 'Test Reason']),
+    );
   });
 
   it('should add reason to selectedReasons when addReason is called', async () => {
@@ -48,7 +78,7 @@ describe('GlamReasonsScreenComponent', () => {
 
     expect(outputs.reasonsEmit.emit).toHaveBeenCalledWith({
       screen: 'finalize',
-      reasons: [reason],
+      reasons: ['Mock Reason', reason],
     });
   });
 
@@ -60,7 +90,7 @@ describe('GlamReasonsScreenComponent', () => {
 
     expect(outputs.reasonsEmit.emit).toHaveBeenCalledWith({
       screen: 'goals',
-      reasons: [reason],
+      reasons: ['Mock Reason', reason],
     });
   });
 });

--- a/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.spec.ts
+++ b/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.spec.ts
@@ -17,8 +17,7 @@ describe('GlamReasonsScreenComponent', () => {
       return store[key] || null;
     });
 
-    spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
-    });
+    spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {});
   });
 
   it('should create', async () => {

--- a/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.ts
+++ b/src/app/onboarding/components/glam/glam-reasons-screen/glam-reasons-screen.component.ts
@@ -1,5 +1,5 @@
 /* @format */
-import { Component, Output, EventEmitter, Input } from '@angular/core';
+import { Component, Output, EventEmitter, Input, OnInit } from '@angular/core';
 import { reasons } from '../../../shared/onboarding-screen';
 
 interface ReasonsEmit {
@@ -12,7 +12,7 @@ interface ReasonsEmit {
   templateUrl: './glam-reasons-screen.component.html',
   styleUrl: './glam-reasons-screen.component.scss',
 })
-export class GlamReasonsScreenComponent {
+export class GlamReasonsScreenComponent implements OnInit {
   public reasons = [];
   @Input() selectedReasons = [];
   @Output() backToGoalsOutput = new EventEmitter<ReasonsEmit>();
@@ -20,6 +20,13 @@ export class GlamReasonsScreenComponent {
 
   constructor() {
     this.reasons = reasons;
+  }
+
+  ngOnInit(): void {
+    const storageReasons = sessionStorage.getItem('reasons');
+    if (storageReasons) {
+      this.selectedReasons = JSON.parse(storageReasons);
+    }
   }
 
   backToGoals() {
@@ -39,5 +46,6 @@ export class GlamReasonsScreenComponent {
     } else {
       this.selectedReasons.push(reason);
     }
+    sessionStorage.setItem('reasons', JSON.stringify(this.selectedReasons));
   }
 }

--- a/src/app/onboarding/components/glam/name-archive-screen/name-archive-screen.component.ts
+++ b/src/app/onboarding/components/glam/name-archive-screen/name-archive-screen.component.ts
@@ -1,25 +1,33 @@
 /* @format */
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import { AccessRole } from '@models/access-role';
 import { ArchiveVO } from '@models/index';
 import { OnboardingService } from '@root/app/onboarding/services/onboarding.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'pr-name-archive-screen',
   templateUrl: './name-archive-screen.component.html',
   styleUrl: './name-archive-screen.component.scss',
 })
-export class NameArchiveScreenComponent implements OnInit {
+export class NameArchiveScreenComponent implements OnInit, OnDestroy {
   public nameForm: UntypedFormGroup;
 
   @Input() name = '';
   @Output() backToCreateEmitter = new EventEmitter<string>();
   @Output() archiveCreatedEmitter = new EventEmitter<string>();
+  private nameSubscription: Subscription;
 
   constructor(
     private fb: UntypedFormBuilder,
@@ -31,7 +39,23 @@ export class NameArchiveScreenComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    const storageName = sessionStorage.getItem('archiveName');
+    if (storageName) {
+      this.name = storageName;
+    }
     this.nameForm.patchValue({ archiveName: this.name });
+
+    this.nameSubscription = this.nameForm
+      .get('archiveName')
+      .valueChanges.subscribe((value) => {
+        sessionStorage.setItem('archiveName', value);
+      });
+  }
+
+  ngOnDestroy(): void {
+    if (this.nameSubscription) {
+      this.nameSubscription.unsubscribe();
+    }
   }
 
   public backToCreate(): void {

--- a/src/app/onboarding/components/glam/select-archive-type-screen/select-archive-type-screen.component.ts
+++ b/src/app/onboarding/components/glam/select-archive-type-screen/select-archive-type-screen.component.ts
@@ -22,6 +22,14 @@ export class SelectArchiveTypeScreenComponent implements OnInit {
   @Output() submitEmitter = new EventEmitter<Record<string, string>>();
 
   ngOnInit(): void {
+    const storageTag = sessionStorage.getItem('archiveTypeTag');
+    const storageType = sessionStorage.getItem('archiveType');
+
+    if (storageTag && storageType) {
+      this.tag = storageTag;
+      this.type = storageType;
+    }
+
     if (this.tag) {
       this.buttonText = generateElementText(
         this.tag,

--- a/src/app/onboarding/guards/onboarding.auth.guard.ts
+++ b/src/app/onboarding/guards/onboarding.auth.guard.ts
@@ -24,6 +24,7 @@ export class OnboardingAuthGuard  {
         }
         return true;
       });
+      
     }
     return this.router.parseUrl('/app/auth');
   }

--- a/src/app/shared/services/account/account.service.ts
+++ b/src/app/shared/services/account/account.service.ts
@@ -210,7 +210,7 @@ export class AccountService {
           const account = this.getStorage('account');
           newAccount.keepLoggedIn = account?.keepLoggedIn;
           this.account.update(newAccount);
-          this.archive.update(newArchive);
+          this.archive?.update(newArchive);
           this.setStorage(newAccount.keepLoggedIn, ARCHIVE_KEY, this.archive);
         } else {
           throw loggedIn;


### PR DESCRIPTION
Because of a user having no archive during onboarding, the onboarding process would throw an error each time the page would refresh, loggging the user out.

I have fixed that problem and added the current steps of onboarding to the session storage so that the user can continue where they left off after refreshing, but if the tab is closed all the progress is being erased

Steps to test:
1. Create a new archive
2. Go to the onboarding page
3. Refresh and the user should still be logged in
4. Go through each process, refreshing each itme, and the data should persist