### PR TITLE
Integrate Glam Onboarding Feature Flag

### DIFF
--- a/load-secrets.js
+++ b/load-secrets.js
@@ -25,15 +25,15 @@ for (const secret of optionalSecrets) {
 if (missingSecrets.length) {
   console.error(
     `ERROR: Missing the following environment variables: ${missingSecrets.join(
-      ','
-    )}`
+      ',',
+    )}`,
   );
   process.exit(1);
 }
 
 // write to secrets.ts file
 const secretsFileContent = `export const SECRETS = { ${requiredSecrets
-  .map((name) => `${name}: '${process.env[name]}'`)
+  .map((name) => `'${name}': '${process.env[name]}'`)
   .join(', ')} }`;
 try {
   writeFileSync(outputFile, secretsFileContent);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -50,6 +50,7 @@ import { DataService } from '@shared/services/data/data.service';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { RouteHistoryModule } from './route-history/route-history.module';
 import { CustomOverlayContainer } from './dialog-cdk/custom-overlay-container';
+import { FeatureFlagModule } from './feature-flag/feature-flag.module';
 
 declare var ga: any;
 
@@ -156,6 +157,7 @@ export class PermErrorHandler implements ErrorHandler {
     FontAwesomeModule,
     FormsModule,
     RouteHistoryModule,
+    FeatureFlagModule,
   ],
   exports: [],
   declarations: [AppComponent, MessageComponent],

--- a/src/app/feature-flag/feature-flag.module.ts
+++ b/src/app/feature-flag/feature-flag.module.ts
@@ -3,10 +3,15 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FEATURE_FLAG_API } from './types/feature-flag-api';
 import { FeatureFlagApiService } from './services/feature-flag-api.service';
+import { FeatureFlagService } from './services/feature-flag.service';
 
 @NgModule({
   declarations: [],
   imports: [CommonModule],
   providers: [{ provide: FEATURE_FLAG_API, useClass: FeatureFlagApiService }],
 })
-export class FeatureFlagModule {}
+export class FeatureFlagModule {
+  constructor(feature: FeatureFlagService) {
+    feature.fetchFromApi();
+  }
+}

--- a/src/app/feature-flag/services/feature-flag-api.service.spec.ts
+++ b/src/app/feature-flag/services/feature-flag-api.service.spec.ts
@@ -27,15 +27,17 @@ describe('FeatureFlagApiService', () => {
   });
 
   it('can fetch feature flags from the back end', (done) => {
-    const expectedFlags: FeatureFlag[] = [
-      { name: 'potato', globallyEnabled: true },
-      { name: 'tomato', globallyEnabled: true },
-    ];
+    const expectedFlags = {
+      items: [
+        { name: 'potato', globallyEnabled: true },
+        { name: 'tomato', globallyEnabled: true },
+      ],
+    };
 
     service
       .getFeatureFlags()
       .then((flags) => {
-        expect(flags).toEqual(expectedFlags);
+        expect(flags).toEqual(expectedFlags.items);
         done();
       })
       .catch(() => {

--- a/src/app/feature-flag/services/feature-flag-api.service.spec.ts
+++ b/src/app/feature-flag/services/feature-flag-api.service.spec.ts
@@ -28,10 +28,7 @@ describe('FeatureFlagApiService', () => {
 
   it('can fetch feature flags from the back end', (done) => {
     const expectedFlags = {
-      items: [
-        { name: 'potato', globallyEnabled: true },
-        { name: 'tomato', globallyEnabled: true },
-      ],
+      items: [{ name: 'potato' }, { name: 'tomato' }],
     };
 
     service

--- a/src/app/feature-flag/services/feature-flag-api.service.spec.ts
+++ b/src/app/feature-flag/services/feature-flag-api.service.spec.ts
@@ -46,6 +46,7 @@ describe('FeatureFlagApiService', () => {
 
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Request-Version')).toBe('2');
+    expect(req.request.headers.get('Authorization')).toBeFalsy();
     req.flush(expectedFlags);
   });
 

--- a/src/app/feature-flag/services/feature-flag-api.service.ts
+++ b/src/app/feature-flag/services/feature-flag-api.service.ts
@@ -13,9 +13,12 @@ export class FeatureFlagApiService implements FeatureFlagApi {
 
   public async getFeatureFlags(): Promise<FeatureFlag[]> {
     try {
-      return await firstValueFrom(
-        this.http.get(`/v2/feature-flags`, {}, null, { authToken: false }),
+      const response = await firstValueFrom(
+        this.http.get<{ items: FeatureFlag[] }>(`/v2/feature-flags`, {}, null, {
+          authToken: false,
+        }),
       );
+      return response[0].items;
     } catch {
       return [];
     }

--- a/src/app/feature-flag/services/feature-flag-api.service.ts
+++ b/src/app/feature-flag/services/feature-flag-api.service.ts
@@ -13,7 +13,9 @@ export class FeatureFlagApiService implements FeatureFlagApi {
 
   public async getFeatureFlags(): Promise<FeatureFlag[]> {
     try {
-      return await firstValueFrom(this.http.get(`/v2/feature-flags`));
+      return await firstValueFrom(
+        this.http.get(`/v2/feature-flags`, {}, null, { authToken: false }),
+      );
     } catch {
       return [];
     }

--- a/src/app/feature-flag/services/feature-flag.service.spec.ts
+++ b/src/app/feature-flag/services/feature-flag.service.spec.ts
@@ -60,14 +60,11 @@ describe('FeatureFlagService', () => {
   });
 
   it('should fetch from the API on init', async () => {
-    mockApi.flags = [
-      { name: 'api0', globallyEnabled: true },
-      { name: 'api1', globallyEnabled: false },
-    ];
+    mockApi.flags = [{ name: 'api0', globallyEnabled: true }, { name: 'api1' }];
     await service.fetchFromApi();
 
     expect(service.isEnabled('api0')).toBeTrue();
-    expect(service.isEnabled('api1')).toBeFalse();
+    expect(service.isEnabled('api1')).toBeTrue();
   });
 
   it('should fetch from Secrets on local environment', async () => {

--- a/src/app/feature-flag/services/feature-flag.service.spec.ts
+++ b/src/app/feature-flag/services/feature-flag.service.spec.ts
@@ -1,5 +1,6 @@
 /* @format */
 import { TestBed } from '@angular/core/testing';
+import { SecretsService } from '@shared/services/secrets/secrets.service';
 import { FeatureFlag } from '../types/feature-flag';
 import { FEATURE_FLAG_API, FeatureFlagApi } from '../types/feature-flag-api';
 import { FeatureFlagService } from './feature-flag.service';
@@ -12,16 +13,32 @@ class MockFeatureFlagApi implements FeatureFlagApi {
   }
 }
 
+class MockSecretsService {
+  private secrets = new Map<string, string>();
+  public get(key: string) {
+    return (this.secrets.has && this.secrets.get(key)) || '';
+  }
+
+  public set(key: string, value: string) {
+    this.secrets.set(key, value);
+  }
+}
+
 describe('FeatureFlagService', () => {
   let service: FeatureFlagService;
   let mockApi: MockFeatureFlagApi;
+  let secrets: MockSecretsService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [{ provide: FEATURE_FLAG_API, useClass: MockFeatureFlagApi }],
+      providers: [
+        { provide: FEATURE_FLAG_API, useClass: MockFeatureFlagApi },
+        { provide: SecretsService, useClass: MockSecretsService },
+      ],
     });
     service = TestBed.inject(FeatureFlagService);
     mockApi = TestBed.inject(FEATURE_FLAG_API) as MockFeatureFlagApi;
+    secrets = TestBed.inject(SecretsService) as unknown as MockSecretsService;
   });
 
   it('should be created', () => {
@@ -51,5 +68,14 @@ describe('FeatureFlagService', () => {
 
     expect(service.isEnabled('api0')).toBeTrue();
     expect(service.isEnabled('api1')).toBeFalse();
+  });
+
+  it('should fetch from Secrets on local environment', async () => {
+    secrets.set('TEST', 'true');
+    secrets.set('TEST2', '');
+    await service.fetchFromApi();
+
+    expect(service.isEnabled('TEST')).toBeTrue();
+    expect(service.isEnabled('TEST2')).toBeFalse();
   });
 });

--- a/src/app/feature-flag/services/feature-flag.service.ts
+++ b/src/app/feature-flag/services/feature-flag.service.ts
@@ -19,7 +19,7 @@ export class FeatureFlagService {
   public async fetchFromApi(): Promise<void> {
     try {
       const flags = await this.api.getFeatureFlags();
-      flags.forEach((flag) => this.set(flag.name, flag.globallyEnabled));
+      flags.forEach((flag) => this.set(flag.name, true));
     } catch {
       // Do nothing
     }

--- a/src/app/feature-flag/services/feature-flag.service.ts
+++ b/src/app/feature-flag/services/feature-flag.service.ts
@@ -1,5 +1,6 @@
 /* @format */
 import { Inject, Injectable, Optional } from '@angular/core';
+import { SecretsService } from '@shared/services/secrets/secrets.service';
 import { FEATURE_FLAG_API, FeatureFlagApi } from '../types/feature-flag-api';
 
 @Injectable({
@@ -10,6 +11,7 @@ export class FeatureFlagService {
 
   constructor(
     @Optional() @Inject(FEATURE_FLAG_API) private api: FeatureFlagApi,
+    private secrets: SecretsService,
   ) {
     this.fetchFromApi();
   }
@@ -28,6 +30,17 @@ export class FeatureFlagService {
   }
 
   public isEnabled(flag: string): boolean {
-    return this.flags.has(flag) && this.flags.get(flag);
+    return (
+      (this.flags.has(flag) && this.flags.get(flag)) ||
+      this.doesSecretExist(flag)
+    );
+  }
+
+  private doesSecretExist(flag: string): boolean {
+    try {
+      return `${this.secrets.get(flag)}`.length > 0;
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/app/feature-flag/types/feature-flag.ts
+++ b/src/app/feature-flag/types/feature-flag.ts
@@ -2,5 +2,5 @@
 
 export interface FeatureFlag {
   name: string;
-  globallyEnabled: boolean;
+  globallyEnabled?: boolean;
 }

--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
@@ -21,6 +21,7 @@ import {
 import { AnalyticsService } from '@shared/services/analytics/analytics.service';
 import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
 import { SkipOnboardingDialogComponent } from '@core/components/skip-onboarding-dialog/skip-onboarding-dialog.component';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 import {
   reasons,
   goals,
@@ -96,8 +97,9 @@ export class CreateNewArchiveComponent implements OnInit {
     private accountService: AccountService,
     private event: EventService,
     private onboardingService: OnboardingService,
+    feature: FeatureFlagService,
   ) {
-    this.isGlam = localStorage.getItem('isGlam') === 'true';
+    this.isGlam = feature.isEnabled('glam-onboarding');
     if (!this.isGlam) {
       this.screen = 'create';
     }

--- a/src/app/onboarding/components/onboarding/onboarding.component.ts
+++ b/src/app/onboarding/components/onboarding/onboarding.component.ts
@@ -14,6 +14,7 @@ import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { partition as lodashPartition } from 'lodash';
 import { EventService } from '@shared/services/event/event.service';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 
 @Component({
   selector: 'pr-onboarding',
@@ -45,12 +46,13 @@ export class OnboardingComponent implements OnInit {
     private account: AccountService,
     private detector: ChangeDetectorRef,
     private event: EventService,
+    feature: FeatureFlagService,
   ) {
     if (route.snapshot.data.onboardingScreen) {
       this.screen = route.snapshot.data.onboardingScreen as OnboardingScreen;
     }
 
-    this.isGlam = localStorage.getItem('isGlam') === 'true';
+    this.isGlam = feature.isEnabled('glam-onboarding');
   }
 
   ngOnInit(): void {

--- a/src/app/onboarding/onboarding.module.ts
+++ b/src/app/onboarding/onboarding.module.ts
@@ -11,6 +11,7 @@ import { CoreModule } from '@core/core.module';
 import { SkipOnboardingDialogComponent } from '@core/components/skip-onboarding-dialog/skip-onboarding-dialog.component';
 import { DialogCdkModule } from '../dialog-cdk/dialog-cdk.module';
 import { ComponentsModule } from '../component-library/components.module';
+import { FeatureFlagModule } from '../feature-flag/feature-flag.module';
 import { OnboardingRoutingModule } from './onboarding.routes';
 import { OnboardingComponent } from './components/onboarding/onboarding.component';
 import { WelcomeScreenComponent } from './components/welcome-screen/welcome-screen.component';
@@ -63,6 +64,7 @@ import { OnboardingService } from './services/onboarding.service';
     ComponentsModule,
     GlamArchiveTypeSelectComponent,
     ArchiveTypeIconComponent,
+    FeatureFlagModule,
   ],
   providers: [OnboardingService],
 })


### PR DESCRIPTION
Instead of using `localStorage`, Glam onboarding is now configured with a feature flag defined in the environment's database. Also let the Feature Flag service use environment variables as fallback to make it easier to test them in local or other ephemeral environments.

**Steps to Test:**
1. Sign up in an environment with the feature flag disabled and verify that old onboarding is presented to the user
2. Enable the feature flag and verify that glam onboarding is now shown instead

To test this in local, you can add `glam-onboarding` to `optional-secrets` and `.env`, and restart the development server whenever the flag is changed. An empty string (or absent flag) is considered a disabled feature flag.