### PR TITLE
Build and Upload Storybook in Github Workflows

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -42,6 +42,34 @@ jobs:
           name: dist
           path: dist
 
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Archive `storybook-static`
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook
+          path: storybook-static
+
   upload-sourcemaps:
     needs: build
     runs-on: ubuntu-latest
@@ -74,7 +102,7 @@ jobs:
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:
-    needs: build
+    needs: [build, build-storybook]
     runs-on: ubuntu-latest
     steps:
       - name: Download dist
@@ -83,11 +111,18 @@ jobs:
           name: dist
           path: dist
 
+      - name: Download storybook
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook
+          path: storybook
+
       - name: Create a tar archive
         run: |
           cd ..
           mkdir mdot
           mv web-app/dist mdot/dist
+          mv web-app/storybook mdot/storybook
           tar -czvf mdot.tar.gz mdot
 
       - name: Configure AWS Credentials

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -36,6 +36,34 @@ jobs:
         with:
           name: dist
           path: dist
+  
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Archive `storybook-static`
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook
+          path: storybook-static
 
   upload-sourcemaps:
     needs: build
@@ -66,7 +94,7 @@ jobs:
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:
-    needs: build
+    needs: [build, build-storybook]
     runs-on: ubuntu-latest
     steps:
       - name: Download dist
@@ -74,11 +102,17 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Download storybook
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook
+          path: storybook
       - name: Create a tar archive
         run: |
           cd ..
           mkdir mdot
           mv web-app/dist mdot/dist
+          mv web-app/storybook mdot/storybook
           tar -czvf mdot.tar.gz mdot
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -36,6 +36,33 @@ jobs:
         with:
           name: dist
           path: dist
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Archive `storybook-static`
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook
+          path: storybook-static
 
   upload-sourcemaps:
     needs: build
@@ -66,7 +93,7 @@ jobs:
           sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
 
   upload-code:
-    needs: build
+    needs: [build, build-storybook]
     runs-on: ubuntu-latest
     steps:
       - name: Download dist
@@ -74,11 +101,17 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Download storybook
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook
+          path: storybook
       - name: Create a tar archive
         run: |
           cd ..
           mkdir mdot
           mv web-app/dist mdot/dist
+          mv web-app/storybook mdot/storybook
           tar -czvf mdot.tar.gz mdot
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+/storybook-static
 
 # dependencies
 /node_modules


### PR DESCRIPTION
To make Storybook easier to access for non-developers, we want to build a static version of it that gets deployed to each environment. This requires building a copy of Storybook alongside the main production build and then uploading that static Storybook directory as well. This is done by creating a new `build-storybook` step. Both Storybook and the main production build are uploaded in the `upload-code` step.

Also update .gitignore to ignore the statically built Storybook directory.

**Steps to test:**
1. Run a build of this branch and deploy it to a test environment (the deploy is done automatically on dev)
2. After the deployment is done, ssh into the backend box for the environment and check that `/data/www/mdot` contains a `storybook` directory alongside its usual `dist` directory.
3. Check that the `storybook` directory has built HTML/JavaScript files in it.

This does not need any QA.