### PR TITLE
Generate secrets when building for Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jest": "jest",
     "prettier": "prettier",
     "storybook": "ng run mdot:storybook",
-    "build-storybook": "ng run mdot:build-storybook"
+    "build-storybook": "npm run secrets && ng run mdot:build-storybook"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
While no API keys are needed in Storybook, the components in the web-app still expect all of our secret constants to be defined and some components are broken in static Storybook builds. Generate secrets before doing any static Storybook builds to address this.

PER-9954: Generate secrets as part of Storybook build