### PR TITLE
Add secrets to env when building storybook

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -63,6 +63,10 @@ jobs:
 
       - name: Build Storybook
         run: npm run build-storybook
+        env:
+          GOOGLE_API_KEY: "-"
+          FIREBASE_API_KEY: "-"
+          STRIPE_API_KEY: "-"
 
       - name: Archive `storybook-static`
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -58,6 +58,10 @@ jobs:
 
       - name: Build Storybook
         run: npm run build-storybook
+        env:
+          GOOGLE_API_KEY: "-"
+          FIREBASE_API_KEY: "-"
+          STRIPE_API_KEY: "-"
 
       - name: Archive `storybook-static`
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -57,6 +57,10 @@ jobs:
 
       - name: Build Storybook
         run: npm run build-storybook
+        env:
+          GOOGLE_API_KEY: "-"
+          FIREBASE_API_KEY: "-"
+          STRIPE_API_KEY: "-"
 
       - name: Archive `storybook-static`
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I forgor to actually supply required secrets. Thankfully, these tokens aren't actually used, they just need to be defined at all so we don't even need to supply an actual token for these.

PER-9954: Generate secrets as part of Storybook build