### PR TITLE
Pass client into PledgeData

### DIFF
--- a/src/app/pledge/components/new-pledge/new-pledge.component.ts
+++ b/src/app/pledge/components/new-pledge/new-pledge.component.ts
@@ -212,6 +212,7 @@ export class NewPledgeComponent implements OnInit, AfterViewInit {
       stripeToken: stripeResult.token.id,
       zip: stripeResult.token.card?.address_zip,
       timestamp: new Date().getTime(),
+      client: 'Web App',
     };
 
     try {
@@ -317,4 +318,5 @@ export interface PledgeData {
   id?: string;
   paid?: boolean;
   stripeChargeId?: string;
+  client?: 'Web App';
 }


### PR DESCRIPTION
We can specify what client is making a storage transaction now. Send this data to donations-firebase so it can write a nice description.

**Note:** This does nothing and potentially causes errors if [the corresponding donations-firebase changes](https://github.com/PermanentOrg/donations-firebase/pull/81) are not deployed. Do not merge this until it that is merged.

**Steps to test:**
(Ensure that the corresponding donations-firebase changes are deployed first)
1. Under a test environment (local/dev/staging), make a storage transaction with a Stripe test card.
2. Verify the transaction was successful with no errors.
3. Log into Stripe and view the Transactions dashboard with Test Mode enabled. The description field for your transaction should say "Web App Storage Transaction" instead of just listing an ID.