### PR TITLE
Pull out duplicated jobs from Github workflows

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,4 +1,4 @@
-name: Dev build
+name: Dev build and deploy
 
 on:
   push:
@@ -8,136 +8,40 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-
-      - name: Install dependencies
-        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
-
-      - name: Build
-        env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_DEV }}
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_DEV }}
-          STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
-          RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
-          STELA_DOMAIN: ${{ secrets.STELA_DOMAIN_DEV }}
-          MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_DEV }}
-        run: npm run build:dev
-
-      - name: Archive `dist`
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist
+    uses: ./.github/workflows/build.yml
+    secrets:
+      google-api-key: ${{ secrets.GOOGLE_API_KEY_DEV }}
+      firebase-api-key: ${{ secrets.FIREBASE_API_KEY_DEV }}
+      stripe-api-key: ${{ secrets.STRIPE_TEST_KEY }}
+      recaptcha-api-key: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
+      stela-domain: ${{ secrets.STELA_DOMAIN_DEV }}
+      mixpanel-token: ${{ secrets.MIXPANEL_TOKEN_DEV }}
+      fusionauth-host: ${{ secrets.FUSIONAUTH_HOST_DEV }}
+      fontawesome-token: ${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}
+    with:
+      build-command: "build:dev"
+      artifact-name: "dev"
 
   build-storybook:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-
-      - name: Install dependencies
-        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
-
-      - name: Build Storybook
-        run: npm run build-storybook
-        env:
-          GOOGLE_API_KEY: "-"
-          FIREBASE_API_KEY: "-"
-          STRIPE_API_KEY: "-"
-
-      - name: Archive `storybook-static`
-        uses: actions/upload-artifact@v4
-        with:
-          name: storybook
-          path: storybook-static
+    uses: ./.github/workflows/build-storybook.yml
+    secrets: inherit
+    with:
+      artifact-name: "dev"
 
   upload-sourcemaps:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@v2
-        with:
-          token: ${{ secrets.SENTRY_TOKEN }}
-          organization: permanentorg
-          project: mdot
-
-      - name: Download dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-
-      - name: Upload sourcemaps
-        shell: bash
-        run: |
-          cp -r dist/mdot dist/app
-          cp -r dist/mdot dist/share
-          cp -r dist/mdot dist/p
-          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
-          sentry-cli releases set-commits $VERSION --auto --ignore-missing
-          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
+    uses: ./.github/workflows/upload-sourcemaps.yml
+    secrets: inherit
+    with:
+      artifact-name: "dev"
 
   upload-code:
     needs: [build, build-storybook]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-
-      - name: Download storybook
-        uses: actions/download-artifact@v4
-        with:
-          name: storybook
-          path: storybook
-
-      - name: Create a tar archive
-        run: |
-          cd ..
-          mkdir mdot
-          mv web-app/dist mdot/dist
-          mv web-app/storybook mdot/storybook
-          tar -czvf mdot.tar.gz mdot
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: Copy package to S3
-        run: aws s3 cp ../mdot.tar.gz s3://permanent-repos/dev/mdot.tar.gz
+    uses: ./.github/workflows/upload-code.yml
+    secrets: inherit
+    with:
+      artifact-name: "dev"
+      s3-destination: "s3://permanent-repos/dev/mdot.tar.gz"
 
   deploy:
     needs: [upload-code, upload-sourcemaps]

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -1,4 +1,4 @@
-name: Prod build
+name: Prod build and upload
 
 on:
   push:
@@ -7,122 +7,37 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-      - name: Install dependencies
-        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
-      - name: Build
-        env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_PROD }}
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_PROD }}
-          STRIPE_API_KEY: ${{ secrets.STRIPE_LIVE_KEY }}
-          RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY }}
-          FUSIONAUTH_HOST: ${{ secrets.FUSIONAUTH_PROD_HOST }}
-          STELA_DOMAIN: ${{ secrets.STELA_DOMAIN_PROD }}
-          MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
-        run: npm run build
-      - name: Archive `dist`
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist
-  
+    uses: ./.github/workflows/build.yml
+    secrets:
+      google-api-key: ${{ secrets.GOOGLE_API_KEY_PROD }}
+      firebase-api-key: ${{ secrets.FIREBASE_API_KEY_PROD }}
+      stripe-api-key: ${{ secrets.STRIPE_LIVE_KEY }}
+      recaptcha-api-key: ${{ secrets.RECAPTCHA_API_KEY }}
+      fusionauth-host: ${{ secrets.FUSIONAUTH_PROD_HOST }}
+      stela-domain: ${{ secrets.STELA_DOMAIN_PROD }}
+      mixpanel-token: ${{ secrets.MIXPANEL_TOKEN_PROD }}
+      fontawesome-token: ${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}
+    with:
+      build-command: "build"
+      artifact-name: "prod"
+
   build-storybook:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-
-      - name: Install dependencies
-        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
-
-      - name: Build Storybook
-        run: npm run build-storybook
-        env:
-          GOOGLE_API_KEY: "-"
-          FIREBASE_API_KEY: "-"
-          STRIPE_API_KEY: "-"
-
-      - name: Archive `storybook-static`
-        uses: actions/upload-artifact@v4
-        with:
-          name: storybook
-          path: storybook-static
+    uses: ./.github/workflows/build-storybook.yml
+    secrets: inherit
+    with:
+      artifact-name: "prod"
 
   upload-sourcemaps:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@v2
-        with:
-          token: ${{ secrets.SENTRY_TOKEN }}
-          organization: permanentorg
-          project: mdot
-      - name: Download dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-      - name: Upload sourcemaps
-        shell: bash
-        run: |
-          cp -r dist/mdot dist/app
-          cp -r dist/mdot dist/share
-          cp -r dist/mdot dist/p
-          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
-          sentry-cli releases set-commits $VERSION --auto --ignore-missing
-          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
+    uses: ./.github/workflows/upload-sourcemaps.yml
+    secrets: inherit
+    with:
+      artifact-name: "prod"
 
   upload-code:
     needs: [build, build-storybook]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-      - name: Download storybook
-        uses: actions/download-artifact@v4
-        with:
-          name: storybook
-          path: storybook
-      - name: Create a tar archive
-        run: |
-          cd ..
-          mkdir mdot
-          mv web-app/dist mdot/dist
-          mv web-app/storybook mdot/storybook
-          tar -czvf mdot.tar.gz mdot
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Copy package to S3
-        run: aws s3 cp ../mdot.tar.gz s3://permanent-repos/prod/mdot.tar.gz
+    uses: ./.github/workflows/upload-code.yml
+    secrets: inherit
+    with:
+      artifact-name: "prod"
+      s3-destination: "s3://permanent-repos/prod/mdot.tar.gz"

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -1,4 +1,4 @@
-name: Staging build
+name: Staging build and upload
 
 on:
   push:
@@ -8,120 +8,37 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-      - name: Install dependencies
-        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
-      - name: Build
-        env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_STAGING }}
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY_STAGING }}
-          STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_KEY }}
-          RECAPTCHA_API_KEY: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
-          STELA_DOMAIN: ${{ secrets.STELA_DOMAIN_STAGING }}
-          MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_DEV }}
-        run: npm run build:staging
-      - name: Archive `dist`
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist
+    uses: ./.github/workflows/build.yml
+    secrets:
+      google-api-key: ${{ secrets.GOOGLE_API_KEY_STAGING }}
+      firebase-api-key: ${{ secrets.FIREBASE_API_KEY_STAGING }}
+      stripe-api-key: ${{ secrets.STRIPE_TEST_KEY }}
+      recaptcha-api-key: ${{ secrets.RECAPTCHA_API_KEY_DEV }}
+      stela-domain: ${{ secrets.STELA_DOMAIN_STAGING }}
+      mixpanel-token: ${{ secrets.MIXPANEL_TOKEN_DEV }}
+      fusionauth-host: ${{ secrets.FUSIONAUTH_HOST_DEV }}
+      fontawesome-token: ${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}
+    with:
+      build-command: "build:staging"
+      artifact-name: "staging"
+
   build-storybook:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-
-      - name: Install dependencies
-        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
-
-      - name: Build Storybook
-        run: npm run build-storybook
-        env:
-          GOOGLE_API_KEY: "-"
-          FIREBASE_API_KEY: "-"
-          STRIPE_API_KEY: "-"
-
-      - name: Archive `storybook-static`
-        uses: actions/upload-artifact@v4
-        with:
-          name: storybook
-          path: storybook-static
+    uses: ./.github/workflows/build-storybook.yml
+    secrets: inherit
+    with:
+      artifact-name: "staging"
 
   upload-sourcemaps:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@v2
-        with:
-          token: ${{ secrets.SENTRY_TOKEN }}
-          organization: permanentorg
-          project: mdot
-      - name: Download dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-      - name: Upload sourcemaps
-        shell: bash
-        run: |
-          cp -r dist/mdot dist/app
-          cp -r dist/mdot dist/share
-          cp -r dist/mdot dist/p
-          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
-          sentry-cli releases set-commits $VERSION --auto --ignore-missing
-          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
+    uses: ./.github/workflows/upload-sourcemaps.yml
+    secrets: inherit
+    with:
+      artifact-name: "staging"
 
   upload-code:
     needs: [build, build-storybook]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-      - name: Download storybook
-        uses: actions/download-artifact@v4
-        with:
-          name: storybook
-          path: storybook
-      - name: Create a tar archive
-        run: |
-          cd ..
-          mkdir mdot
-          mv web-app/dist mdot/dist
-          mv web-app/storybook mdot/storybook
-          tar -czvf mdot.tar.gz mdot
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Copy package to S3
-        run: aws s3 cp ../mdot.tar.gz s3://permanent-repos/staging/mdot.tar.gz
+    uses: ./.github/workflows/upload-code.yml
+    secrets: inherit
+    with:
+      artifact-name: "staging"
+      s3-destination: "s3://permanent-repos/staging/mdot.tar.gz"

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -1,0 +1,41 @@
+name: Build static Storybook
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Artifact name to be downloaded later. "-storybook" is appended to the end.'
+        required: true
+        type: string
+jobs:
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Install dependencies
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}" npm install
+
+      - name: Build Storybook
+        run: npm run build-storybook
+        env:
+          GOOGLE_API_KEY: "-"
+          FIREBASE_API_KEY: "-"
+          STRIPE_API_KEY: "-"
+
+      - name: Archive `storybook-static`
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}-storybook
+          path: storybook-static
+          retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: Build deployable images
+on:
+  workflow_call:
+    secrets:
+      google-api-key:
+        description: "Google API key"
+        required: true
+      firebase-api-key:
+        description: "Firebase API key"
+        required: true
+      stripe-api-key:
+        description: "Stripe API key"
+        required: true
+      recaptcha-api-key:
+        description: "Recaptcha API key"
+        required: true
+      stela-domain:
+        description: "Domain to route Stela requests to"
+        required: true
+      mixpanel-token:
+        description: "Mixpanel API key"
+        required: true
+      fontawesome-token:
+        description: "FontAwesome package token"
+        required: true
+    inputs:
+      build-command:
+        description: 'The npm action that is run to build the Angular application.'
+        default: 'build'
+        required: false
+        type: string
+      artifact-name:
+        description: 'Artifact name to be downloaded later'
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Install dependencies
+        run: FONTAWESOME_PACKAGE_TOKEN="${{ secrets.fontawesome-token }}" npm install
+
+      - name: Build
+        env:
+          GOOGLE_API_KEY: ${{ secrets.google-api-key }}
+          FIREBASE_API_KEY: ${{ secrets.firebase-api-key }}
+          STRIPE_API_KEY: ${{ secrets.stripe-api-key }}
+          RECAPTCHA_API_KEY: ${{ secrets.recaptcha-api-key }}
+          STELA_DOMAIN: ${{ secrets.stela-domain }}
+          MIXPANEL_TOKEN: ${{ secrets.mixpanel-token }}
+        run: npm run ${{ inputs.build-command }}
+
+      - name: Archive `dist`
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: dist
+          retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ on:
       mixpanel-token:
         description: "Mixpanel API key"
         required: true
+      fusionauth-host:
+        description: "FusionAuth host"
+        required: false
       fontawesome-token:
         description: "FontAwesome package token"
         required: true
@@ -61,6 +64,7 @@ jobs:
           RECAPTCHA_API_KEY: ${{ secrets.recaptcha-api-key }}
           STELA_DOMAIN: ${{ secrets.stela-domain }}
           MIXPANEL_TOKEN: ${{ secrets.mixpanel-token }}
+          FUSIONAUTH_HOST: ${{ secrets.fusionauth-host }}
         run: npm run ${{ inputs.build-command }}
 
       - name: Archive `dist`

--- a/.github/workflows/upload-code.yml
+++ b/.github/workflows/upload-code.yml
@@ -1,0 +1,46 @@
+name: Upload Built Artifacts
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Name of artifact to download'
+        required: true
+        type: string
+      s3-destination:
+        description: 'S3 upload destination'
+        required: true
+        type: string
+
+jobs:
+   upload-code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: dist
+
+      - name: Download storybook
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}-storybook
+          path: storybook
+
+      - name: Create a tar archive
+        run: |
+          cd ..
+          mkdir mdot
+          mv web-app/dist mdot/dist
+          mv web-app/storybook mdot/storybook
+          tar -czvf mdot.tar.gz mdot
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Copy package to S3
+        run: aws s3 cp ../mdot.tar.gz ${{ inputs.s3-destination }}

--- a/.github/workflows/upload-sourcemaps.yml
+++ b/.github/workflows/upload-sourcemaps.yml
@@ -1,0 +1,39 @@
+name: Upload Sourcemaps
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Name of artifact to download'
+        required: true
+        type: string
+
+jobs:
+  upload-sourcemaps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Sentry CLI
+        uses: mathieu-bour/setup-sentry-cli@v2
+        with:
+          token: ${{ secrets.SENTRY_TOKEN }}
+          organization: permanentorg
+          project: mdot
+
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: dist
+
+      - name: Upload sourcemaps
+        shell: bash
+        run: |
+          cp -r dist/mdot dist/app
+          cp -r dist/mdot dist/share
+          cp -r dist/mdot dist/p
+          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
+          sentry-cli releases set-commits $VERSION --auto --ignore-missing
+          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot


### PR DESCRIPTION
Extract out duplicated jobs from our dev/staging/prod build workflows into their own files, and then refactor our workflows to use these reusable jobs. I've added a new `FUSIONAUTH_HOST_DEV` secret for the dev/staging environments. Previously we could just omit the `FUSIONAUTH_HOST` secret and fallback on its default value, but we can't selectively omit secrets with a reusable job like this, so it's easier just to explicitly provide the value in dev/staging builds.

Now each environment's build process produces an artifact named after that environment [(which is apparently what we should have been doing for a while)](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). Since these artifacts are used immediately afterwards, I've made the retention period for these artifacts 5 days. We might have a use for manually downloading artifacts for debugging/logging purposes, but we don't need to retain them for that long since we can always just trigger a new deployment.

**Steps to test:**
1. Run a build and verify that it works correctly.
2. Deploy the build (done automatically for dev) and verify that things like secrets are passed correctly (do things like Stripe work?)