### PR TITLE
PER-9965-selecting-a-role-erases-text-search-bar

### DIFF
--- a/src/app/shared/components/archive-search-box/archive-search-box.component.spec.ts
+++ b/src/app/shared/components/archive-search-box/archive-search-box.component.spec.ts
@@ -219,7 +219,7 @@ describe('ArchiveSearchBoxComponent', () => {
     component.focused = false;
 
     component.onBlur();
-    
+
     expect(component.focused).toBe(false);
 
     tick(150);

--- a/src/app/shared/components/archive-search-box/archive-search-box.component.spec.ts
+++ b/src/app/shared/components/archive-search-box/archive-search-box.component.spec.ts
@@ -214,4 +214,14 @@ describe('ArchiveSearchBoxComponent', () => {
 
     expect(component.activeResultIndex).toBe(component.results.length - 1);
   }));
+
+  it('should set focused to true after a delay when onBlur is called', fakeAsync(() => {
+    component.focused = false;
+
+    component.onBlur();
+    expect(component.focused).toBe(false);
+
+    tick(150);
+    expect(component.focused).toBe(true);
+  }));
 });

--- a/src/app/shared/components/archive-search-box/archive-search-box.component.spec.ts
+++ b/src/app/shared/components/archive-search-box/archive-search-box.component.spec.ts
@@ -219,9 +219,11 @@ describe('ArchiveSearchBoxComponent', () => {
     component.focused = false;
 
     component.onBlur();
+    
     expect(component.focused).toBe(false);
 
     tick(150);
+
     expect(component.focused).toBe(true);
   }));
 });

--- a/src/app/shared/components/archive-search-box/archive-search-box.component.ts
+++ b/src/app/shared/components/archive-search-box/archive-search-box.component.ts
@@ -163,8 +163,7 @@ export class ArchiveSearchBoxComponent implements OnInit {
 
   onBlur() {
     setTimeout(() => {
-      this.focused = false;
-      this.control.reset();
+      this.focused = true;
     }, 150);
   }
 }

--- a/src/app/shared/components/archive-search-box/archive-search-box.component.ts
+++ b/src/app/shared/components/archive-search-box/archive-search-box.component.ts
@@ -158,6 +158,8 @@ export class ArchiveSearchBoxComponent implements OnInit {
 
   onFocus() {
     this.focused = true;
+    const previousValue = this.control.value;
+    this.control.setValue(previousValue, { emitEvent: true });
   }
 
   onBlur() {

--- a/src/app/shared/components/archive-search-box/archive-search-box.component.ts
+++ b/src/app/shared/components/archive-search-box/archive-search-box.component.ts
@@ -158,7 +158,6 @@ export class ArchiveSearchBoxComponent implements OnInit {
 
   onFocus() {
     this.focused = true;
-    this.control.setValue('', { emitEvent: true });
   }
 
   onBlur() {


### PR DESCRIPTION
Keep the archive search bar focussed on blur too, when a role is selected

Steps to test: 
1. Open the share dialog
2. type in an email
3. select a new role
4. the email should not get erased