### PR TITLE
PER-9959: Fix public search

### DIFF
--- a/src/app/shared/services/api/search.repo.spec.ts
+++ b/src/app/shared/services/api/search.repo.spec.ts
@@ -56,6 +56,8 @@ describe('SearchRepo', () => {
     const archiveId = '1';
     const limit = 5;
 
+    const tagString = `tags%5B0%5D%5BtagId%5D=1&tags%5B1%5D%5BtagId%5D=2`;
+
     repo
       .itemsByNameInPublicArchiveObservable(query, tags, archiveId, limit)
       .toPromise()
@@ -68,12 +70,10 @@ describe('SearchRepo', () => {
     );
 
     expect(req.request.method).toBe('GET');
-    expect(req.request.urlWithParams).toContain(
-      `tags%5B0%5D%5BtagId%5D=1&tags%5B1%5D%5BtagId%5D=2`,
-    );
+    expect(req.request.urlWithParams).toContain(tagString);
 
     expect(req.request.urlWithParams).toContain(
-      `query=${query}&archiveId=${archiveId}&publicOnly=true&numberOfResults=${limit}`,
+      `query=${query}&archiveId=${archiveId}&publicOnly=true&${tagString}&numberOfResults=${limit}`,
     );
 
     req.flush({});
@@ -99,6 +99,29 @@ describe('SearchRepo', () => {
     expect(req.request.urlWithParams).not.toContain('tags');
     expect(req.request.urlWithParams).toContain(
       `query=${query}&archiveId=${archiveId}&publicOnly=true&numberOfResults=${limit}`,
+    );
+
+    req.flush({});
+  });
+
+  it('should exclude numberOfResults from the query string when no limit is provided', () => {
+    const query = 'exampleQuery';
+    const archiveId = '1';
+
+    repo
+      .itemsByNameInPublicArchiveObservable(query, [], archiveId)
+      .toPromise()
+      .then((response: SearchResponse) => {
+        expect(response).toBeTruthy();
+      });
+
+    const req = httpMock.expectOne((req) =>
+      req.url.includes('/search/folderAndRecord'),
+    );
+
+    expect(req.request.method).toBe('GET');
+    expect(req.request.urlWithParams).toContain(
+      `query=${query}&archiveId=${archiveId}&publicOnly=true`,
     );
 
     req.flush({});

--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -77,9 +77,12 @@ export class SearchRepo extends BaseRepo {
       query,
       archiveId,
       publicOnly: true,
-      numberOfResults: limit,
       ...tagsDict,
     };
+
+    if (limit) {
+      data['numberOfResults'] = limit;
+    }
 
     return getFirst(
       this.httpV2.get<SearchResponse>('/search/folderAndRecord', data, null, {

--- a/src/app/shared/services/api/search.repo.ts
+++ b/src/app/shared/services/api/search.repo.ts
@@ -73,7 +73,13 @@ export class SearchRepo extends BaseRepo {
       return obj;
     }, {});
 
-    const data = {
+    const data: {
+      query: string;
+      archiveId: string | number;
+      publicOnly: boolean;
+      tagsDict?: Record<string, string>;
+      numberOfResults?: number;
+    } = {
       query,
       archiveId,
       publicOnly: true,
@@ -81,7 +87,7 @@ export class SearchRepo extends BaseRepo {
     };
 
     if (limit) {
-      data['numberOfResults'] = limit;
+      data.numberOfResults = limit;
     }
 
     return getFirst(


### PR DESCRIPTION
Fix the search by adding the limit only if it is defined

Steps to test:
Search for a substring in the public search bar
Click view all results
it should display all the records and folders accordingly