### PR TITLE
Fix extra call to `archive/accept` in Glam onboarding

### DIFF
--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
@@ -210,7 +210,9 @@ export class CreateNewArchiveComponent implements OnInit {
         let response;
 
         if (this.pendingArchive) {
-          await this.api.archive.accept(this.pendingArchive);
+          if (!this.isGlam) {
+            await this.api.archive.accept(this.pendingArchive);
+          }
         } else {
           response = await this.api.archive.create(archive);
           createdArchive = response.getArchiveVO();


### PR DESCRIPTION
The original onboarding flow was designed to not accept an archive invitation until the end of the flow in case the user wanted to change which archive they accept. In the new "Glam" onboarding flow, the user can accept as many archives as they want in addition to creating an archive. Accepting archive invites also happens as soon as the user clicks accept on the first page, rather than at the end of onboarding.

Since the Glam onboarding flow is still built on top of the older onboarding components, this final archive accepting stage still runs despite the fact that the invitations have been accepted. This causes a brief error message to appear before the user is directed to their archive. Only run this acceptance logic during the legacy onboarding flow so that this doesn't happen.

**Steps to test:**
1. Accept an archive invitation in glam onboarding and verify that no error message pops up once completing onboarding
2. Verify that the "classic" onboarding still works

This can also be tested in Storybook by comparing the mocked calls to `archive/accept`, though this is more of a test for developers.