### PR TITLE
Adjust sign in/sign up page to support announcements

### DIFF
--- a/src/app/auth/components/auth/auth.component.html
+++ b/src/app/auth/components/auth/auth.component.html
@@ -1,33 +1,33 @@
-<!-- @format -->
-<div class="auth-container">
-  <div class="image">
-    <div class="testimony">
-      <p class="text">
-        At Permanent, we celebrate our members’ hard work through our Public
-        Gallery and archive spotlights. Explore our gallery and, when you’re
-        ready, publish or share your own public archive!
-      </p>
-      <br />
-      <a class="link" href="https://permanent.org/gallery"
-        >Start Exploring Now.</a
-      >
-      <p class="text archive-data">
-        Haadsma Dairy Truck | The Haadsma Dairy Archive
-      </p>
-    </div>
-    <img
-      src="assets/img/sign_in_image.png"
-      alt='Black and white photo of a child with a bicycle stopped in front of a black milk truck with a man standing by the door. The milk truck reads "Haadsma&#39;s Dairy." The photo appears to be from the 1950s.'
-    />
-  </div>
-  <div class="auth">
-    <div class="permanent-logo">
-      <img src="assets/svg/app-icon-glam.svg" alt="Permanent.org logo" />
-    </div>
-    <router-outlet></router-outlet>
-  </div>
-</div>
-<pr-mobile-banner></pr-mobile-banner>
 <pr-announcement></pr-announcement>
-<pr-android-app-notify></pr-android-app-notify>
-<pr-prompt></pr-prompt>
+<div class="auth-root">
+  <div class="auth-container">
+    <div
+      class="image"
+      aria-description='Black and white photo of a child with a bicycle stopped in front of a black milk truck with a man standing by the door. The milk truck reads "Haadsma&#39;s Dairy." The photo appears to be from the 1950s.'
+    >
+      <div class="testimony">
+        <p class="text">
+          At Permanent, we celebrate our members’ hard work through our Public
+          Gallery and archive spotlights. Explore our gallery and, when you’re
+          ready, publish or share your own public archive!
+        </p>
+        <br />
+        <a class="link" href="https://permanent.org/gallery"
+          >Start Exploring Now.</a
+        >
+        <p class="text archive-data">
+          Haadsma Dairy Truck | The Haadsma Dairy Archive
+        </p>
+      </div>
+    </div>
+    <div class="auth">
+      <div class="permanent-logo">
+        <img src="assets/svg/app-icon-glam.svg" alt="Permanent.org logo" />
+      </div>
+      <router-outlet></router-outlet>
+    </div>
+  </div>
+  <pr-mobile-banner></pr-mobile-banner>
+  <pr-android-app-notify></pr-android-app-notify>
+  <pr-prompt></pr-prompt>
+</div>

--- a/src/app/auth/components/auth/auth.component.scss
+++ b/src/app/auth/components/auth/auth.component.scss
@@ -1,11 +1,20 @@
 @import 'variables';
 
 :host {
+  width: 100%;
+  min-height: 100vh;
+  flex-direction: column;
+  display: flex;
+  justify-content: stretch;
   background: $linear-gradient-background;
+}
+
+.auth-root {
   width: 100vw;
-  height: 100vh;
   display: flex;
   padding: 0px 64px;
+  flex-grow: 1;
+  flex-shrink: 1;
 
   @media screen {
     padding: 20px 0px;
@@ -49,14 +58,11 @@
 .image {
   position: relative;
   height: 100%;
-
-  & > img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    color: white;
-    border-radius: 16px;
-  }
+  background: url('/assets/img/sign_in_image.png');
+  background-size: cover;
+  background-position: center center;
+  flex-grow: 1;
+  border-radius: 1em;
 
   margin-left: 20px;
 

--- a/src/app/auth/components/auth/auth.component.scss
+++ b/src/app/auth/components/auth/auth.component.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 
 :host {
-  width: 100%;
+  width: 100vw;
   min-height: 100vh;
   flex-direction: column;
   display: flex;
@@ -58,7 +58,7 @@
 .image {
   position: relative;
   height: 100%;
-  background: url('/assets/img/sign_in_image.png');
+  background: url('../../../../assets/img/sign_in_image.png');
   background-size: cover;
   background-position: center center;
   flex-grow: 1;


### PR DESCRIPTION
We want to display a downtime banner soon, but the new "glam" auth page does not support showing the banner. Well, it does, but it doesn't account for it in the layout and some flexbox nightmares manifest and ruin the whole layout of the page.

Adjust the page so that it can handle the announcement box without disrupting the layout of the screen. The specific challenge in this is making the rest of the page responsive to its presence in a way that does not cause scrollbars to appear.

This reworks how the image appears on signup right now. Previously it was an `<img>` tag. Now it is a background image again, this time with an `aria-description` that describes the text instead of an `img` tag with an `alt` attribute.

**Steps to test:**
1. Open the sign in/sign up pages with the alert banner present.
    - If you have access to this branch locally, you can create a test announcement in `src/app/announcement/data/events.ts` with a start time of `0` and end time of `Infinity` so that it's always present while testing.
    - If you are testing this in a deployed environment (dev/staging), then you can run the following script in the developer console once the page loads to simulate announcements:
<details>
<summary>[Code to paste into developer console]</summary>

```js
const n = document.createElement("div");
n.style = "height: 100px; background-color: white; display: flex; justify-content: center; align-items: center; font-weight: bold;"
n.innerText = "Pretend that the alert banner is here it's too hard to actually trigger it only in testing environments right now lol"
document.querySelector("pr-auth").prepend(n);
```
</details>


2. Verify that the page displays correctly, including at various screen widths/heights.