### PR TITLE
PER-9962 clicking search result in subfolder

### DIFF
--- a/src/app/public/components/public-search-bar-results/public-search-bar-results.component.spec.ts
+++ b/src/app/public/components/public-search-bar-results/public-search-bar-results.component.spec.ts
@@ -61,12 +61,13 @@ describe('PublicSearchBarResultsComponent', () => {
     const routerSpy = spyOn(component['router'], 'navigate');
     const testItem = {
       type: 'type.record.image',
-      archiveNbr: '789',
+      parentArchiveNbr: '789',
+      parentFolder_linkId: '20',
     };
 
     component.goToFile(new RecordVO(testItem));
 
-    expect(routerSpy).toHaveBeenCalledWith(['record', '789'], {
+    expect(routerSpy).toHaveBeenCalledWith(['789', '20'], {
       relativeTo: component['route'],
     });
   });

--- a/src/app/public/components/public-search-bar-results/public-search-bar-results.component.ts
+++ b/src/app/public/components/public-search-bar-results/public-search-bar-results.component.ts
@@ -34,7 +34,7 @@ export class PublicSearchBarResultsComponent {
         relativeTo: this.route,
       });
     } else {
-      this.router.navigate(['record', item.archiveNbr], {
+      this.router.navigate([item.parentArchiveNbr, item.parentFolder_linkId], {
         relativeTo: this.route,
       });
     }


### PR DESCRIPTION
Navigate to the folder when clicking a record, just like the workspace search. I chose this approach because the dataservice only searches through the files in the current folder that the user is in, so searching for a file in a different folder would crash the app.