### PR TITLE
Add FusionAuth downtime announcement banner

### DIFF
--- a/src/app/announcement/data/events.ts
+++ b/src/app/announcement/data/events.ts
@@ -2,6 +2,12 @@ import { AnnouncementEvent } from '../models/announcement-event';
 
 export const ANNOUNCEMENT_EVENTS: AnnouncementEvent[] = [
   {
+    start: new Date('2025-01-29T00:00:00-07:00').getTime(),
+    end: new Date('2025-01-31T03:00:00-07:00').getTime(),
+    message:
+      'The Permanent.org platform may be briefly unavailable on <strong>January 30th at 9:00 PM MST</strong> for routine maintenance. Thank you for your patience.',
+  },
+  {
     start: new Date('2023-01-31T20:00:00-05:00').getTime(),
     end: new Date('2023-02-15T23:59:00-05:00').getTime(),
     message:


### PR DESCRIPTION
Add the banner as specified by the experience team.

I set it to be active at midnight on January 29th MST (picked arbitrarily since the maintenance window from FusionAuth is given in MST) and it will go away 6 hours after the maintenance window when we're sure that they'll be done.

There's no real way to test this without adjusting your computer's time, so mainly just verify that the input string is valid HTML and contains no errors or typos.