### PR TITLE
Add edge cases for Public Route generation

### DIFF
--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -45,6 +45,7 @@ export class FolderVO
 
   public folderId;
   public archiveNbr;
+  public archiveArchiveNbr: string | undefined;
   public archiveId;
   public displayName;
   public displayDT;

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -44,6 +44,7 @@ export class RecordVO
   public recordId;
   public archiveId;
   public archiveNbr;
+  public archiveArchiveNbr: string | undefined;
   public publicDT;
   public note;
   public displayName;

--- a/src/app/shared/pipes/public-route.pipe.spec.ts
+++ b/src/app/shared/pipes/public-route.pipe.spec.ts
@@ -2,14 +2,17 @@ import { FolderVO, RecordVO } from '@models';
 import { PublicRoutePipe } from './public-route.pipe';
 
 describe('PublicRoutePipe', () => {
-  it('create an instance', () => {
-    const pipe = new PublicRoutePipe();
+  let pipe: PublicRoutePipe;
 
+  beforeEach(() => {
+    pipe = new PublicRoutePipe();
+  });
+
+  it('create an instance', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('returns correct link for folder', () => {
-    const pipe = new PublicRoutePipe();
+  it('returns correct link for folder with no archiveArchiveNbrs defined', () => {
     const folder = new FolderVO({
       folder_linkId: 100,
       archiveNbr: '0001-00gh',
@@ -26,8 +29,7 @@ describe('PublicRoutePipe', () => {
     ]);
   });
 
-  it('returns correct link for record', () => {
-    const pipe = new PublicRoutePipe();
+  it('returns correct link for record with no archiveArchiveNbrs defined', () => {
     const record = new RecordVO({
       ParentFolderVOs: [
         new RecordVO({
@@ -50,5 +52,53 @@ describe('PublicRoutePipe', () => {
       'record',
       record.archiveNbr,
     ]);
+  });
+
+  it('returns correct link for record in the public root folder', () => {
+    const record = new RecordVO({
+      ParentFolderVOs: [
+        new FolderVO({
+          archiveNbr: 'do-not-use',
+          folder_linkId: -1,
+          folder_linkType: 'type.folder_link.root.public',
+          type: 'type.folder.root.public',
+        }),
+      ],
+      folder_linkId: 1001,
+      archiveNbr: '1234-5678',
+    });
+    const route = pipe.transform(record);
+
+    expect(route).toEqual([
+      '/p',
+      'archive',
+      '1234-0000',
+      'record',
+      '1234-5678',
+    ]);
+  });
+
+  it('uses the archiveArchiveNbr field to get the archive an item is located in', () => {
+    const route = pipe.transform(
+      new FolderVO({
+        archiveArchiveNbr: '1234-0000',
+        archiveNbr: 'abcd-efgh',
+        folder_linkId: 1234,
+      }),
+    );
+
+    expect(route).toEqual(['/p', 'archive', '1234-0000', 'abcd-efgh', 1234]);
+  });
+
+  it("uses the parent folder's `archiveArchiveNbr` if the target does not have it defined", () => {
+    const route = pipe.transform(
+      new FolderVO({
+        ParentFolderVOs: [new FolderVO({ archiveArchiveNbr: '1234-0000' })],
+        archiveNbr: 'abcd-efgh',
+        folder_linkId: 1234,
+      }),
+    );
+
+    expect(route).toEqual(['/p', 'archive', '1234-0000', 'abcd-efgh', 1234]);
   });
 });

--- a/src/app/shared/pipes/public-route.pipe.ts
+++ b/src/app/shared/pipes/public-route.pipe.ts
@@ -7,13 +7,12 @@ import { FolderVO, RecordVO } from '@models';
 export class PublicRoutePipe implements PipeTransform {
   constructor() {}
 
-  transform(value: RecordVO | FolderVO, args?: any): any[] {
-    const rootArchive = value.archiveNbr.split('-')[0] + '-0000';
+  transform(value: RecordVO | FolderVO, _?: any): any[] {
+    const rootArchive = this.getPublicArchiveNbr(value);
     if (value instanceof RecordVO) {
       const route = ['/p', 'archive', rootArchive];
-      const parentFolders = value.ParentFolderVOs as FolderVO[];
-      if (parentFolders && parentFolders.length > 0) {
-        const parentFolder = parentFolders[0];
+      const parentFolder = this.getFirstParentFolder(value);
+      if (parentFolder && this.isNotPublicRoot(parentFolder)) {
         route.push(
           parentFolder.archiveNbr,
           parentFolder.folder_linkId.toString(),
@@ -30,5 +29,32 @@ export class PublicRoutePipe implements PipeTransform {
         value.folder_linkId,
       ];
     }
+  }
+
+  private getFirstParentFolder(
+    object: RecordVO | FolderVO,
+  ): FolderVO | undefined {
+    const parentFolders = object.ParentFolderVOs as FolderVO[];
+    if (parentFolders && parentFolders.length > 0) {
+      return parentFolders[0];
+    }
+  }
+
+  private getPublicArchiveNbr(value: RecordVO | FolderVO): string {
+    if (value.archiveArchiveNbr) {
+      return value.archiveArchiveNbr;
+    }
+    const parentFolder = this.getFirstParentFolder(value);
+    if (parentFolder && parentFolder.archiveArchiveNbr) {
+      return parentFolder.archiveArchiveNbr;
+    }
+    return value.archiveNbr.split('-')[0] + '-0000';
+  }
+
+  private isNotPublicRoot(folder: FolderVO): boolean {
+    return (
+      folder.folder_linkType !== 'type.folder_link.root.public' &&
+      folder.type !== 'type.folder.root.public'
+    );
   }
 }


### PR DESCRIPTION
There are a few edge cases in the PublicRoutePipe that are not addressed and so they cause some incorrect URLs to be generated.

First, make it so that public objects in the public root do not need to feature their parent folder's archiveNbr and folder_linkId. This makes URLs match those that are found in the actual public gallery.

Second, address issues when it comes to mismatches in a record/folder's archiveNbr and the archiveNbr of the archive the item is contained in. In theory these numbers should always match, and the original (and new fallback) implementation utilizes this assumption. In practice, there are records in the public gallery in production that have archiveNbr mismatches. This is concerning and we should figure out what's causing it on the back-end, but we also need to adjust the link generation code to handle these existing records.

Use the `archiveArchiveNbr` on the record as the canonical source of the parent archive's ArchiveNbr. That is what this field is for so we should read it instead of trying to reverse-engineer it ourselves. However, in the case of the errant record on production, this alone does not fix URL generation since it's actually null. As a fallback, check the parent folder's `archiveArchiveNbr` as this value is properly set in the production bug we've found. Finally use the old algorithm if everything else fails.

**Steps to test:**
1. Verify that the "Get Link" link on public records that are not nested in folders works
2. Verify that the links work for other records and folders as well

I don't really know how to test the buggiest edge cases in dev/staging/production, so it might just be safe to verify with the automated tests.