### PR TITLE
Add links to new user checklist

### DIFF
--- a/src/app/core/components/account-settings-dialog/account-settings-dialog.component.ts
+++ b/src/app/core/components/account-settings-dialog/account-settings-dialog.component.ts
@@ -1,4 +1,3 @@
-/* @format */
 import { Component, Inject } from '@angular/core';
 import { AccountService } from '@shared/services/account/account.service';
 import { AccountResponse } from '@shared/services/api/index.repo';
@@ -7,16 +6,18 @@ import { ApiService } from '@shared/services/api/api.service';
 import { ActivatedRoute } from '@angular/router';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 
-export type SettingsTab =
-  | 'storage'
-  | 'account'
-  | 'notification'
-  | 'billing'
-  | 'legacy-contact'
-  | 'delete'
-  | 'advanced-settings'
-  | 'security';
+const settingsTabs = [
+  'storage',
+  'account',
+  'notification',
+  'billing',
+  'legacy-contact',
+  'delete',
+  'advanced-settings',
+  'security',
+] as const;
 
+export type SettingsTab = (typeof settingsTabs)[number];
 @Component({
   selector: 'pr-account-settings-dialog',
   templateUrl: './account-settings-dialog.component.html',
@@ -39,6 +40,9 @@ export class AccountSettingsDialogComponent {
   ) {
     if (data.tab) {
       this.activeTab = data.tab;
+    }
+    if (([...settingsTabs] as string[]).includes(route.snapshot.fragment)) {
+      this.activeTab = route.snapshot.fragment as SettingsTab;
     }
   }
 

--- a/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
+++ b/src/app/core/components/archive-settings-dialog/archive-settings-dialog.component.ts
@@ -1,4 +1,3 @@
-/* @format*/
 import { Component, OnInit } from '@angular/core';
 import { ApiService } from '@shared/services/api/api.service';
 import { AccountService } from '@shared/services/account/account.service';
@@ -6,15 +5,17 @@ import { TagsService } from '@core/services/tags/tags.service';
 import { TagVO } from '@models/tag-vo';
 import { ArchiveVO } from '@models/index';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs';
 import { DialogRef } from '@angular/cdk/dialog';
 import { AccountVO } from '../../../models/account-vo';
 
-type ArchiveSettingsDialogTab =
-  | 'manage-keywords'
-  | 'manage-metadata'
-  | 'public-settings'
-  | 'legacy-planning';
+const archiveSettingsTabs = [
+  'manage-keywords',
+  'manage-metadata',
+  'public-settings',
+  'legacy-planning',
+] as const;
+
+type ArchiveSettingsDialogTab = (typeof archiveSettingsTabs)[number];
 
 @Component({
   selector: 'pr-archive-settings-dialog',
@@ -39,7 +40,13 @@ export class ArchiveSettingsDialogComponent implements OnInit {
     private account: AccountService,
     private tagsService: TagsService,
     public route: ActivatedRoute,
-  ) {}
+  ) {
+    if (
+      ([...archiveSettingsTabs] as string[]).includes(route.snapshot.fragment)
+    ) {
+      this.activeTab = route.snapshot.fragment as ArchiveSettingsDialogTab;
+    }
+  }
 
   public ngOnInit(): void {
     const accessRole = this.account.getArchive().accessRole;

--- a/src/app/core/components/storage-dialog/storage-dialog.component.spec.ts
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.spec.ts
@@ -23,6 +23,7 @@ describe('StorageDialogComponent', () => {
     mockActivatedRoute = {
       paramMap: paramMap.asObservable(),
       queryParamMap: queryParamMap.asObservable(),
+      snapshot: { fragment: null },
     };
     shallow = new Shallow(StorageDialogComponent, CoreModule)
       .provideMock({ provide: DialogRef, useClass: MockDialogRef })
@@ -35,23 +36,18 @@ describe('StorageDialogComponent', () => {
     expect(element).not.toBeNull();
   });
 
-  it('should handle route and query parameter changes', async () => {
+  it('should set the tab if the URL fragment matches a tab', async () => {
+    mockActivatedRoute.snapshot.fragment = 'promo';
     const { instance } = await shallow.render();
-
-    paramMap.next(convertToParamMap({ path: 'promo' }));
-
-    queryParamMap.next(convertToParamMap({ promoCode: 'potato' }));
 
     expect(instance.activeTab).toBe('promo');
-    expect(instance.promoCode).toEqual('potato');
   });
 
-  it('should handle route changes', async () => {
+  it('should not set the tab if the URL fragment is invalid', async () => {
+    mockActivatedRoute.snapshot.fragment = 'not-a-real-tab';
     const { instance } = await shallow.render();
 
-    paramMap.next(convertToParamMap({ path: 'add' }));
-
-    expect(instance.activeTab).toBe('add');
+    expect(instance.activeTab).not.toBe(mockActivatedRoute.snapshot.fragment);
   });
 
   it('can close the dialog', async () => {

--- a/src/app/core/components/storage-dialog/storage-dialog.component.ts
+++ b/src/app/core/components/storage-dialog/storage-dialog.component.ts
@@ -1,4 +1,3 @@
-/* @format */
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -6,7 +5,9 @@ import { unsubscribeAll } from '@shared/utilities/hasSubscriptions';
 import { EventService } from '@shared/services/event/event.service';
 import { DialogRef } from '@angular/cdk/dialog';
 
-type StorageDialogTab = 'add' | 'file' | 'transaction' | 'promo' | 'gift';
+const dialogTabs = ['add', 'file', 'transaction', 'promo', 'gift'] as const;
+
+type StorageDialogTab = (typeof dialogTabs)[number];
 @Component({
   selector: 'pr-storage-dialog',
   templateUrl: './storage-dialog.component.html',
@@ -22,20 +23,14 @@ export class StorageDialogComponent implements OnInit, OnDestroy {
     private dialogRef: DialogRef,
     private route: ActivatedRoute,
     private event: EventService,
-  ) {}
+  ) {
+    if (([...dialogTabs] as string[]).includes(route.snapshot.fragment)) {
+      this.activeTab = route.snapshot.fragment as StorageDialogTab;
+    }
+  }
 
   public ngOnInit(): void {
     this.subscriptions.push(
-      this.route.paramMap.subscribe((params: ParamMap) => {
-        const path = params.get('path') as StorageDialogTab;
-
-        if (path && this.tabs.includes(path)) {
-          this.activeTab = path;
-        } else {
-          this.activeTab = 'add';
-        }
-      }),
-
       this.route.queryParamMap.subscribe((params) => {
         const param = params.get('promoCode');
         if (this.activeTab === 'promo' && param) {

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.html
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.html
@@ -44,6 +44,7 @@
               @if ((item.id | taskLink).external) {
                 <a
                   href="{{ (item.id | taskLink).routerLink }}"
+                  target="_blank"
                   [class]="{ 'task-name': true, completed: item.completed }"
                   >{{ item.title }}</a
                 >

--- a/src/app/user-checklist/components/user-checklist/user-checklist.component.html
+++ b/src/app/user-checklist/components/user-checklist/user-checklist.component.html
@@ -40,11 +40,28 @@
               role="img"
               [attr.aria-labeledby]="'label-' + item.id"
             ></pr-task-icon>
-            <span
-              [id]="'label-' + item.id"
-              [class]="{ 'task-name': true, completed: item.completed }"
-              >{{ item.title }}</span
-            >
+            @if (item.id | taskLink) {
+              @if ((item.id | taskLink).external) {
+                <a
+                  href="{{ (item.id | taskLink).routerLink }}"
+                  [class]="{ 'task-name': true, completed: item.completed }"
+                  >{{ item.title }}</a
+                >
+              } @else {
+                <a
+                  [routerLink]="(item.id | taskLink).routerLink"
+                  fragment="{{ (item.id | taskLink).fragment }}"
+                  [class]="{ 'task-name': true, completed: item.completed }"
+                  >{{ item.title }}</a
+                >
+              }
+            } @else {
+              <span
+                [id]="'label-' + item.id"
+                [class]="{ 'task-name': true, completed: item.completed }"
+                >{{ item.title }}</span
+              >
+            }
             <div
               [class]="{ 'fake-checkbox': true, checked: item.completed }"
               [ariaLabel]="item.completed ? 'Complete' : 'Incomplete'"

--- a/src/app/user-checklist/pipes/task-link.pipe.spec.ts
+++ b/src/app/user-checklist/pipes/task-link.pipe.spec.ts
@@ -1,0 +1,17 @@
+import { TaskLinkPipe } from './task-link.pipe';
+
+describe('TaskLinkPipe', () => {
+  let pipe: TaskLinkPipe;
+
+  beforeEach(() => {
+    pipe = new TaskLinkPipe();
+  });
+
+  it('should return null for an undefined task', () => {
+    expect(pipe.transform('not-a-valid-task-ever')).toBeUndefined();
+  });
+
+  it('should return a route for a defined task', () => {
+    expect(pipe.transform('storageRedeemed')).not.toBeUndefined();
+  });
+});

--- a/src/app/user-checklist/pipes/task-link.pipe.ts
+++ b/src/app/user-checklist/pipes/task-link.pipe.ts
@@ -1,0 +1,46 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+export interface TaskRouterLink {
+  routerLink: (string | { outlets: { dialog: string[] } })[] | string;
+  fragment?: string;
+  external?: boolean;
+}
+
+@Pipe({
+  name: 'taskLink',
+})
+export class TaskLinkPipe implements PipeTransform {
+  private readonly links: Record<string, TaskRouterLink> = {
+    storageRedeemed: {
+      routerLink: [{ outlets: { dialog: ['storage', 'add'] } }],
+      fragment: 'promo',
+    },
+    legacyContact: {
+      routerLink: [{ outlets: { dialog: ['account'] } }],
+      fragment: 'legacy-contact',
+    },
+    archiveSteward: {
+      routerLink: [{ outlets: { dialog: ['settings'] } }],
+      fragment: 'legacy-planning',
+    },
+    archiveProfile: {
+      routerLink: [{ outlets: { dialog: ['profile'] } }],
+    },
+    firstUpload: {
+      routerLink:
+        'https://permanent.zohodesk.com/portal/en/kb/articles/upload-your-first-file',
+      external: true,
+    },
+    publishContent: {
+      routerLink:
+        'https://permanent.zohodesk.com/portal/en/kb/articles/upload-your-first-file',
+      external: true,
+    },
+  };
+
+  transform(value: string, ..._: unknown[]): TaskRouterLink | undefined {
+    if (this.links[value]) {
+      return this.links[value];
+    }
+  }
+}

--- a/src/app/user-checklist/pipes/task-link.pipe.ts
+++ b/src/app/user-checklist/pipes/task-link.pipe.ts
@@ -33,12 +33,12 @@ export class TaskLinkPipe implements PipeTransform {
     },
     publishContent: {
       routerLink:
-        'https://permanent.zohodesk.com/portal/en/kb/articles/upload-your-first-file',
+        'https://permanent.zohodesk.com/portal/en/kb/articles/how-to-publish',
       external: true,
     },
   };
 
-  transform(value: string, ..._: unknown[]): TaskRouterLink | undefined {
+  public transform(value: string, ..._: unknown[]): TaskRouterLink | undefined {
     if (this.links[value]) {
       return this.links[value];
     }

--- a/src/app/user-checklist/user-checklist.module.ts
+++ b/src/app/user-checklist/user-checklist.module.ts
@@ -1,8 +1,8 @@
-/* @format */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '@shared/shared.module';
 import { EventService } from '@shared/services/event/event.service';
+import { RouterModule } from '@angular/router';
 import { UserChecklistComponent } from './components/user-checklist/user-checklist.component';
 import { ChecklistIconComponent } from './components/checklist-icon/checklist-icon.component';
 import { TaskIconComponent } from './components/task-icon/task-icon.component';
@@ -10,6 +10,7 @@ import { MinimizeIconComponent } from './components/minimize-icon/minimize-icon.
 import { CHECKLIST_API } from './types/checklist-api';
 import { UserChecklistService } from './services/user-checklist.service';
 import { ChecklistEventObserverService } from './services/checklist-event-observer.service';
+import { TaskLinkPipe } from './pipes/task-link.pipe';
 
 @NgModule({
   declarations: [
@@ -17,9 +18,10 @@ import { ChecklistEventObserverService } from './services/checklist-event-observ
     ChecklistIconComponent,
     TaskIconComponent,
     MinimizeIconComponent,
+    TaskLinkPipe,
   ],
   exports: [UserChecklistComponent],
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, RouterModule],
   providers: [
     {
       provide: CHECKLIST_API,


### PR DESCRIPTION
Add links to the currently defined tasks in the new user checklist. This also adds functionality to link to specific sections of the account settings, archive settings, and storage dialogs using the URL fragment. This deletes some of the previous code that handled this with query parameter subscriptions.

**Steps to test:**
1. Create a new account or access an account with the checklist active
2. Verify that the tasks with links defined do have links
3. Verify that the links work as expected
    - In-app links should open the correct dialog without any weird issues
    - External links should open in a new tab/window

**After this is merged and deployed:**
Because of these changes, the link to the "redeem gift code" dialog used in our emails should be changed to the following: `https://www.permanent.org/app/(private//dialog:storage/add)#promo`