### PR TITLE
Per 9985 entering 2fa incorrect code works

### DIFF
--- a/src/app/core/components/two-factor-auth/two-factor-auth.component.spec.ts
+++ b/src/app/core/components/two-factor-auth/two-factor-auth.component.spec.ts
@@ -170,4 +170,30 @@ describe('TwoFactorAuthComponent', () => {
 
     expect(codeContainer.length).toBe(0);
   });
+
+  it('should retrieve all the methods after a method has been deleted', async () => {
+    const { instance } = await shallow.render();
+
+    instance.methods = [
+      { methodId: 'email', method: 'email', value: 'janedoe@example.com' },
+    ];
+    instance.selectedMethodToDelete = {
+      methodId: 'email',
+      method: 'email',
+      value: 'janedoe@example.com',
+    };
+
+    spyOn(mockApiService.idpuser, 'disableTwoFactor').and.returnValue(
+      Promise.resolve(),
+    );
+    spyOn(mockApiService.idpuser, 'getTwoFactorMethods').and.returnValue(
+      Promise.resolve([
+        { methodId: 'sms', method: 'sms', value: '(123) 456-7890' },
+      ]),
+    );
+
+    await instance.submitRemoveMethod();
+
+    expect(mockApiService.idpuser.getTwoFactorMethods).toHaveBeenCalled();
+  });
 });

--- a/src/app/core/components/two-factor-auth/two-factor-auth.component.spec.ts
+++ b/src/app/core/components/two-factor-auth/two-factor-auth.component.spec.ts
@@ -93,7 +93,7 @@ describe('TwoFactorAuthComponent', () => {
     const event = {
       preventDefault: () => {},
     };
-    instance.sendCode(event);
+    await instance.sendCode(event);
 
     expect(instance.codeSent).toBe(true);
   });

--- a/src/app/core/components/two-factor-auth/two-factor-auth.component.ts
+++ b/src/app/core/components/two-factor-auth/two-factor-auth.component.ts
@@ -5,8 +5,8 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
 
 interface Method {
   methodId: string;
@@ -35,6 +35,7 @@ export class TwoFactorAuthComponent implements OnInit {
   constructor(
     private fb: UntypedFormBuilder,
     private api: ApiService,
+    private message: MessageService,
   ) {
     this.form = fb.group({
       code: ['', Validators.required],
@@ -171,9 +172,7 @@ export class TwoFactorAuthComponent implements OnInit {
       );
     } catch (error) {
     } finally {
-      this.methods = this.methods.filter(
-        (m) => m.methodId !== this.selectedMethodToDelete.methodId,
-      );
+      this.methods = await this.api.idpuser.getTwoFactorMethods();
       this.selectedMethodToDelete = null;
       this.codeSent = false;
       this.method = null;

--- a/src/app/core/components/two-factor-auth/two-factor-auth.component.ts
+++ b/src/app/core/components/two-factor-auth/two-factor-auth.component.ts
@@ -116,7 +116,7 @@ export class TwoFactorAuthComponent implements OnInit {
           this.selectedMethodToDelete.methodId,
         );
       } else {
-        this.api.idpuser.sendEnableCode(
+        await this.api.idpuser.sendEnableCode(
           this.method,
           this.form.get('contactInfo').value,
         );

--- a/src/app/shared/services/api/idpuser.repo.ts
+++ b/src/app/shared/services/api/idpuser.repo.ts
@@ -14,29 +14,53 @@ export class IdPuser extends BaseRepo {
 
   public sendEnableCode(method: string, value: string) {
     return firstValueFrom(
-      this.httpV2.post('/v2/idpuser/send-enable-code', { method, value }),
+      this.httpV2.post(
+        '/v2/idpuser/send-enable-code',
+        { method, value },
+        undefined,
+        {},
+        'text',
+      ),
     );
   }
 
   public enableTwoFactor(method: string, value: string, code: string) {
     return firstValueFrom(
-      this.httpV2.post('/v2/idpuser/enable-two-factor', {
-        method,
-        value,
-        code,
-      }),
+      this.httpV2.post(
+        '/v2/idpuser/enable-two-factor',
+        {
+          method,
+          value,
+          code,
+        },
+        undefined,
+        {},
+        'text',
+      ),
     );
   }
 
   public sendDisableCode(methodId: string) {
     return firstValueFrom(
-      this.httpV2.post('/v2/idpuser/send-disable-code', { methodId }),
+      this.httpV2.post(
+        '/v2/idpuser/send-disable-code',
+        { methodId },
+        undefined,
+        {},
+        'text',
+      ),
     );
   }
 
   public disableTwoFactor(methodId: string, code: string) {
     return firstValueFrom(
-      this.httpV2.post('/v2/idpuser/disable-two-factor', { code, methodId }),
+      this.httpV2.post(
+        '/v2/idpuser/disable-two-factor',
+        { code, methodId },
+        undefined,
+        {},
+        'text',
+      ),
     );
   }
 }

--- a/src/app/shared/services/api/idpuser.repo.ts
+++ b/src/app/shared/services/api/idpuser.repo.ts
@@ -18,8 +18,9 @@ export class IdPuser extends BaseRepo {
         '/v2/idpuser/send-enable-code',
         { method, value },
         undefined,
-        {},
-        'text',
+        {
+          responseType: 'text',
+        },
       ),
     );
   }
@@ -34,8 +35,9 @@ export class IdPuser extends BaseRepo {
           code,
         },
         undefined,
-        {},
-        'text',
+        {
+          responseType: 'text',
+        },
       ),
     );
   }
@@ -46,8 +48,7 @@ export class IdPuser extends BaseRepo {
         '/v2/idpuser/send-disable-code',
         { methodId },
         undefined,
-        {},
-        'text',
+        { responseType: 'text' },
       ),
     );
   }
@@ -58,8 +59,9 @@ export class IdPuser extends BaseRepo {
         '/v2/idpuser/disable-two-factor',
         { code, methodId },
         undefined,
-        {},
-        'text',
+        {
+          responseType: 'text',
+        },
       ),
     );
   }

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -287,7 +287,9 @@ describe('HttpV2Service', () => {
 
   it('should correctly handle responseType: text', (done) => {
     service
-      .post('/api/v2/health', {}, undefined, {}, 'text')
+      .post('/api/v2/health', {}, undefined, {
+        responseType: 'text',
+      })
       .toPromise()
       .then((response) => {
         expect(typeof response[0]).toBe('string');

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -284,4 +284,23 @@ describe('HttpV2Service', () => {
       'https://local.permanent.org/api/v2/health',
     );
   });
+
+  it('should correctly handle responseType: text', (done) => {
+    service
+      .post('/api/v2/health', {}, undefined, {}, 'text')
+      .toPromise()
+      .then((response) => {
+        expect(typeof response[0]).toBe('string'); 
+        expect(response[0]).toBe('OK'); 
+        done();
+      })
+      .catch(done.fail);
+
+    const request = httpTestingController.expectOne(apiUrl('/api/v2/health'));
+
+    expect(request.request.method).toBe('POST');
+    expect(request.request.headers.get('Request-Version')).toBe('2');
+
+    request.flush('OK', { status: 200, statusText: 'OK' });
+  });
 });

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -290,8 +290,8 @@ describe('HttpV2Service', () => {
       .post('/api/v2/health', {}, undefined, {}, 'text')
       .toPromise()
       .then((response) => {
-        expect(typeof response[0]).toBe('string'); 
-        expect(response[0]).toBe('OK'); 
+        expect(typeof response[0]).toBe('string');
+        expect(response[0]).toBe('OK');
         done();
       })
       .catch(done.fail);

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -14,8 +14,6 @@ const AUTH_KEY = 'AUTH_TOKEN';
 type HttpMethod = 'post' | 'get' | 'put' | 'delete';
 type ResponseClass<T> = new (data: any) => T;
 
-type ResType = 'json' | 'text';
-
 interface RequestOptions {
   csrf?: boolean;
   authToken?: boolean;


### PR DESCRIPTION
This pull request fixes the bug that occurs when entering an incorrect code when removing a multi factor method

Steps to test:
1. Choose any method you want to remove
2. Send a code
3. Enter any code but NOT the one that you received
4. The method should not be removed
@meisekimiu Do you think this implementation will do? Or should we change the backend as I mentioned on Slack?