### PR TITLE
Create "v3" section of the app

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -142,6 +142,10 @@ const routes: RoutesWithData = [
       { path: 'm/embed', redirectTo: 'app/embed' },
       { path: 'm/pledge', redirectTo: 'app/pledge' },
       {
+        path: 'app/v3',
+        loadChildren: () => import('./v3/v3.module').then((m) => m.V3Module),
+      },
+      {
         path: '',
         loadChildren: () =>
           import('./core/core.module').then((m) => m.CoreModule),

--- a/src/app/v3/components/v3-root/v3-root.component.html
+++ b/src/app/v3/components/v3-root/v3-root.component.html
@@ -1,0 +1,1 @@
+<p>v3-root works!</p>

--- a/src/app/v3/components/v3-root/v3-root.component.spec.ts
+++ b/src/app/v3/components/v3-root/v3-root.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { V3RootComponent } from './v3-root.component';
+
+describe('V3RootComponent', () => {
+  let component: V3RootComponent;
+  let fixture: ComponentFixture<V3RootComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [V3RootComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(V3RootComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/v3/components/v3-root/v3-root.component.ts
+++ b/src/app/v3/components/v3-root/v3-root.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'pr-v3-root',
+  templateUrl: './v3-root.component.html',
+  styleUrl: './v3-root.component.scss',
+})
+export class V3RootComponent {}

--- a/src/app/v3/v3.module.ts
+++ b/src/app/v3/v3.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { V3RootComponent } from './components/v3-root/v3-root.component';
+import { V3RoutingModule } from './v3.routes';
+
+@NgModule({
+  declarations: [V3RootComponent],
+  exports: [V3RootComponent],
+  imports: [CommonModule, V3RoutingModule],
+})
+export class V3Module {}

--- a/src/app/v3/v3.routes.ts
+++ b/src/app/v3/v3.routes.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { V3RootComponent } from './components/v3-root/v3-root.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: V3RootComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class V3RoutingModule {}


### PR DESCRIPTION
Create a new Angular module with a basic placeholder root component. Set up routing and let it be lazy-loaded. This module should be mostly isolated from other modules in the project.

I experimented with figuring out if we want to add Stencil to this project. Right now it does not seem practical so development will continue in Angular for now.

**Steps to test:**
1. Navigate to `/app/v3` manually
2. Verify that you see a white page with "v3-root works!"