### PR TITLE
Fix Legacy Lab Promo Link

### DIFF
--- a/src/app/auth/components/auth/auth.component.scss
+++ b/src/app/auth/components/auth/auth.component.scss
@@ -204,6 +204,8 @@
 }
 
 .legacy-lab-container {
+  position: relative;
+  z-index: 1;
   margin-left: 50px;
   margin-top: 20px;
   display: flex;


### PR DESCRIPTION
The link wasn't clickable due to the fact that it was underneath another layer. Move up its z-index so that it's clickable.

**Steps to test:**
1. Check if the link on the sign up screen works