### PR TITLE
PER-10060-text-does-not-wrap-desc-field

### DIFF
--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.scss
@@ -120,6 +120,7 @@ select {
 .inline-value-textarea {
   min-height: 6 * 1.5rem;
   overflow-wrap: break-word;
+  white-space: pre-wrap;
 
   &.showing-empty-message {
     color: $text-muted;


### PR DESCRIPTION
Add text wrap to the description field in the inline value edit component