### PR TITLE
Do not send Mixpanel events if auth token is unset

### DIFF
--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -305,4 +305,14 @@ describe('HttpV2Service', () => {
 
     request.flush('OK', { status: 200, statusText: 'OK' });
   });
+
+  it('should be able to test if the auth token is defined', () => {
+    service.setAuthToken('potato');
+
+    expect(service.isAuthTokenSet()).toBeTruthy();
+
+    service.clearAuthToken();
+
+    expect(service.isAuthTokenSet()).toBeFalsy();
+  });
 });

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -59,6 +59,10 @@ export class HttpV2Service {
     this.authToken = this.storage.local.get(AUTH_KEY) ?? '';
   }
 
+  public isAuthTokenSet(): boolean {
+    return this.authToken && this.authToken.length > 0;
+  }
+
   public post<T>(
     endpoint: string,
     data: any = {},


### PR DESCRIPTION
The `event` endpoint expects a valid auth token. Trying to send an event when not logged in causes an error to happen which refreshes the page. On pages like the public gallery, this creates an endless loop of refreshes.

**Steps to test:**
1. View the public gallery page when logged out and verify that the page doesn't auto-refresh endlessly.
2. Run the following line in the developer console and verify that the page refreshes a maximum of one time: `localStorage.setItem('AUTH_TOKEN', 'test');`