### PR TITLE
Fetch tags on SearchService construction

### DIFF
--- a/src/app/search/services/search.service.spec.ts
+++ b/src/app/search/services/search.service.spec.ts
@@ -35,6 +35,10 @@ class MockTagsService {
   private tags: TagVOData[] = [];
   private tagsSubject = new Subject<TagVOData[]>();
 
+  public getTags(): TagVOData[] {
+    return this.tags;
+  }
+
   public getTags$(): Subject<TagVOData[]> {
     return this.tagsSubject;
   }

--- a/src/app/search/services/search.service.ts
+++ b/src/app/search/services/search.service.ts
@@ -33,6 +33,8 @@ export class SearchService {
       this.indexCurrentFolder();
     });
 
+    this.indexTags(this.tags.getTags());
+
     this.tags.getTags$().subscribe((newTags) => {
       this.indexTags(newTags);
     });


### PR DESCRIPTION
For some reason this suddenly started causing a bug. I'm not sure how that happened, but the SearchService might just not be constructed until after the initial `getTags$()` event is published. Get the loaded tags in the current tags service for the time being.

PER-10099: Keywords and custom metadata does not filter

**Stepz 2 test:**
1. Make sure you have tags in your archive
2. Click a folder/record and give try to give it a preexisting tag
3. Verify that it appears in the tag editor when you start typing its name