### PR TITLE
Update properties in v2 record/update call

### DIFF
--- a/src/app/shared/services/api/record.repo.spec.ts
+++ b/src/app/shared/services/api/record.repo.spec.ts
@@ -1,20 +1,12 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { environment } from '@root/environments/environment';
-
-import { TEST_DATA, TEST_DATA_2 } from '@core/core.module.spec';
-import { HttpService, Observable } from '@shared/services/http/http.service';
-import { RecordRepo, RecordResponse } from '@shared/services/api/record.repo';
-import {
-  SimpleVO,
-  AccountPasswordVO,
-  AccountVO,
-  ArchiveVO,
-  RecordVO,
-} from '@root/app/models';
+import { HttpService } from '@shared/services/http/http.service';
+import { RecordRepo } from '@shared/services/api/record.repo';
+import { RecordVO } from '@root/app/models';
 import { HttpV2Service } from '../http-v2/http-v2.service';
 
 describe('RecordRepo', () => {
@@ -71,12 +63,40 @@ describe('RecordRepo', () => {
   });
 
   it('should send a POST request for update', (done) => {
-    const testRecord = new RecordVO({
+    const testData = {
       recordId: 1,
       displayName: 'Updated Test',
       parentFolderId: 2,
       uploadFileName: 'updated.jpg',
       size: 4321,
+    };
+    const testRecord = new RecordVO(testData);
+    const archiveId = 10;
+
+    repo
+      .update([testRecord], archiveId)
+      .then((_) => {
+        done();
+      })
+      .catch(done.fail);
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/record/update`);
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
+    for (const property in testData) {
+      expect(req.request.body[property]).toBe(testData[property]);
+    }
+
+    expect(req.request.body.archiveId).toBe(archiveId);
+
+    req.flush(testRecord);
+  });
+
+  it('should adjust property names properly for v2 update', (done) => {
+    const testRecord = new RecordVO({
+      recordId: 1,
+      displayDT: '2025-01-01T00:00:00.000Z',
     });
     const archiveId = 10;
 
@@ -91,10 +111,7 @@ describe('RecordRepo', () => {
 
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Request-Version')).toBe('2');
-    expect(req.request.body).toEqual({
-      ...testRecord,
-      archiveId,
-    });
+    expect(req.request.body.displayDt).toBe('2025-01-01T00:00:00.000Z');
 
     req.flush(testRecord);
   });

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -159,8 +159,26 @@ export class RecordRepo extends BaseRepo {
 
   public async update(recordVOs: RecordVO[], archiveId: number) {
     return await firstValueFrom(
-      this.httpV2.post('/record/update', { ...recordVOs[0], archiveId }, null),
+      this.httpV2.post(
+        '/record/update',
+        this.prepareUpdateRecordRequest(recordVOs, archiveId),
+        null,
+      ),
     );
+  }
+
+  private prepareUpdateRecordRequest(recordVOs: RecordVO[], archiveId: number) {
+    const record: any = Object.assign({}, recordVOs[0]);
+    record.displayDt = record.displayDT;
+    record.displayEndDt = record.displayEndDT;
+    record.publicDt = record.publicDT;
+    delete record.displayDT;
+    delete record.displayEndDT;
+    delete record.publicDT;
+    return {
+      ...record,
+      archiveId,
+    };
   }
 
   public delete(recordVOs: RecordVO[]): Promise<RecordResponse> {


### PR DESCRIPTION
`displayDT`, `displayEndDT`, and `publicDT` all have case changes in the V2 version of `record/update`. Update the request body to match the new expected values.

**Steps to test:**
1. Verify that changing a record's date works properly.
2. Verify that changing other properties does not erase a record's date.
3. Verify that dates are still fetched properly.