### PR TITLE
Add support for arrays in Stela GET requests

### DIFF
--- a/src/app/shared/services/api/search.repo.spec.ts
+++ b/src/app/shared/services/api/search.repo.spec.ts
@@ -56,7 +56,7 @@ describe('SearchRepo', () => {
     const archiveId = '1';
     const limit = 5;
 
-    const tagString = `tags%5B0%5D%5BtagId%5D=1&tags%5B1%5D%5BtagId%5D=2`;
+    const tagString = `tags[0]%5BtagId%5D=1&tags[1]%5BtagId%5D=2`;
 
     repo
       .itemsByNameInPublicArchiveObservable(query, tags, archiveId, limit)

--- a/src/app/shared/services/http-v2/http-v2-encoder.ts
+++ b/src/app/shared/services/http-v2/http-v2-encoder.ts
@@ -1,0 +1,19 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
+export class HttpV2Encoder implements HttpParameterCodec {
+  public encodeKey(key: string): string {
+    return encodeURIComponent(key).replace('%5B', '[').replace('%5D', ']');
+  }
+
+  public encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
+
+  public decodeKey(key: string): string {
+    return decodeURIComponent(key);
+  }
+
+  public decodeValue(value: string): string {
+    return decodeURIComponent(value);
+  }
+}

--- a/src/app/shared/services/http-v2/http-v2.service.spec.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { environment } from '@root/environments/environment';
+import { firstValueFrom } from 'rxjs';
 import { StorageService } from '../storage/storage.service';
 import { SecretsService } from '../secrets/secrets.service';
 import { getFirst, HttpV2Service } from './http-v2.service';
@@ -314,5 +315,20 @@ describe('HttpV2Service', () => {
     service.clearAuthToken();
 
     expect(service.isAuthTokenSet()).toBeFalsy();
+  });
+
+  it('should be able to add array parameters to GET requests', (done) => {
+    firstValueFrom(service.get('v2/health', { arrayVals: [1, 2, 3] })).finally(
+      () => done(),
+    );
+
+    const req = httpTestingController.expectOne(
+      apiUrl('/v2/health?arrayVals[]=1&arrayVals[]=2&arrayVals[]=3'),
+    );
+
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Request-Version')).toBe('2');
+
+    req.flush('OK', { status: 200, statusText: 'OK' });
   });
 });

--- a/src/app/shared/services/http-v2/http-v2.service.ts
+++ b/src/app/shared/services/http-v2/http-v2.service.ts
@@ -7,6 +7,7 @@ import { catchError, map } from 'rxjs/operators';
 import { Location } from '@angular/common';
 import { StorageService } from '../storage/storage.service';
 import { SecretsService } from '../secrets/secrets.service';
+import { HttpV2Encoder } from './http-v2-encoder';
 
 const CSRF_KEY = 'CSRF';
 const AUTH_KEY = 'AUTH_TOKEN';
@@ -137,8 +138,22 @@ export class HttpV2Service {
     return Object.assign({}, defaultOptions, opts);
   }
 
+  protected updateArrayParamNames(data: unknown = {}): any {
+    const workingData = Object.assign({}, data);
+    const keys = Object.keys(data);
+    for (const key of keys) {
+      if (Array.isArray(data[key])) {
+        workingData[`${key}[]`] = workingData[key];
+        delete workingData[key];
+      }
+    }
+    return workingData;
+  }
+
   protected getEndpointWithData(endpoint: string, data: any = {}): string {
-    const params = new HttpParams().appendAll(data);
+    const params = new HttpParams({ encoder: new HttpV2Encoder() }).appendAll(
+      this.updateArrayParamNames(data),
+    );
     if (params.toString().length === 0) {
       return endpoint;
     }


### PR DESCRIPTION
Stela takes in a specific syntax for arrays in GET request query parameters. We don't want to have logic to do this at every call site that needs this syntax, so build it into the HttpV2Service.