### PR TITLE
Per 10158 remove original file format for folders

### DIFF
--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -220,8 +220,11 @@
           <div class="sidebar-detail-content">.{{ originalFileExtension }}</div>
         </div>
         <div
-          *ngIf="!originalFileExtension || originalFileExtension === 'null'"
-          class="sidebar-detail"
+          *ngIf="
+            isRecord &&
+            (!originalFileExtension || originalFileExtension === 'null')
+          "
+          class="sidebar-detail unknown"
         >
           <label>Original Format</label>
           <div class="sidebar-detail-content">unknown</div>

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -136,4 +136,17 @@ describe('SidebarComponent', () => {
     expect(instance.canEdit).toBe(false);
     expect(instance.canShare).toBe(true);
   });
+
+  it('should hide the original format for folders', async () => {
+    const { instance, find, fixture } = await shallow.render();
+
+    instance.isRecord = false;
+
+    fixture.detectChanges();
+
+    const unknownTypeContainer =
+      fixture.nativeElement.querySelector('.unknown');
+
+    expect(unknownTypeContainer).toBeFalsy();
+  });
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -31,6 +31,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
   isLoading = false;
   isRootFolder = false;
   isPublicItem = false;
+  isRecord = false;
 
   currentArchive: ArchiveVO;
 
@@ -109,6 +110,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
         } else {
           this.originalFileExtension = '';
           this.permanentFileExtension = '';
+          this.isRecord = !this.selectedItem.isFolder;
         }
       }),
     );


### PR DESCRIPTION
This pull request hides the original format field for folders.

Steps to test:
Select a folder in any workspace
The original format field should not appear