### PR TITLE
hide any tooltip if no value is being selected.

### DIFF
--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.scss
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.scss
@@ -179,7 +179,6 @@ pr-folder-view-toggle {
   align-items: center;
   background-color: white;
   padding-left: 5px;
-  opacity: 0;
 
   &.visible {
     opacity: 1;

--- a/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
+++ b/src/app/file-browser/components/file-list-controls/file-list-controls.component.ts
@@ -464,6 +464,7 @@ export class FileListControlsComponent implements OnDestroy, HasSubscriptions {
     const basePath = 'fileList.actions';
     const actionAllowed = this.can[action];
     const multiSelected = this.selectedItems?.length > 1;
+    const noneSelected = this.selectedItems?.length === 0;
 
     if (action === 'publish' && this.isPublic) {
       action = 'getLink' as keyof FileListActions;
@@ -479,6 +480,8 @@ export class FileListControlsComponent implements OnDestroy, HasSubscriptions {
       return `${basePath}.${tooltipKey}.enabled`;
     } else if (multiSelected && (action === 'share' || action === 'publish')) {
       return `${basePath}.${tooltipKey}.disabledMulti`;
+    } else if (noneSelected) {
+      return '';
     } else {
       return `${basePath}.${tooltipKey}.disabled`;
     }


### PR DESCRIPTION
This pull request displays the file controls, but greyes them out if no item is selected.