### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      eslint:
+        patterns:
+          - "*eslint*"
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR enables dependabot updates for our actions and for our general npm dependencies.

Resolves #563 