### PR TITLE
Set output folder to fix deploy

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -14,7 +14,8 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": {
-              "base": "dist/mdot"
+              "base": "dist/mdot",
+              "browser": ""
             },
             "index": "src/index.html",
             "polyfills": [


### PR DESCRIPTION
Angular 18 changed the default output path to the /browser subdir, as explained [in this StackOverflow
post](https://stackoverflow.com/a/78546904). This change should move the output back to the `dist` directory, which is what our deploy setup expects.

I tested this on dev and confirmed that the upload-to-shares fix works there. It does look like the code is now appearing in both `mdot` and `browser`, which isn't ideal.