### PR TITLE
Lint github actions in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,15 @@ env:
   FONTAWESOME_PACKAGE_TOKEN: ${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - name: Lint GitHub Action workflows
+        uses: raven-actions/actionlint@v2
   eslint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/upload-sourcemaps.yml
+++ b/.github/workflows/upload-sourcemaps.yml
@@ -34,6 +34,7 @@ jobs:
           cp -r dist/mdot dist/app
           cp -r dist/mdot dist/share
           cp -r dist/mdot dist/p
-          declare -x VERSION=mdot@$(sentry-cli releases propose-version)
-          sentry-cli releases set-commits $VERSION --auto --ignore-missing
-          sentry-cli releases files $VERSION upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot
+          VERSION="mdot@$(sentry-cli releases propose-version)"
+          export VERSION
+          sentry-cli releases set-commits "$VERSION" --auto --ignore-missing
+          sentry-cli releases files "$VERSION" upload-sourcemaps --validate --log-level info --strip-common-prefix ./dist/ --ignore mdot


### PR DESCRIPTION
Our other projects use this tool as well; it lets us lint our github actions.  Unfortunately I don't know of a great way to run this locally, but running in CI is better than nothing.

Issue #623 Add ActionLint to our CI

This is a reopening of #625 to fix my merge mess.