### PR TITLE
Fix type includes for build

### DIFF
--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -12,7 +12,7 @@
     "secrets.ts"
   ],
   "include": [
-    "/src/**/*.d.ts"
+    "**/*.d.ts"
   ],
   "exclude": [
     "**/*.stories.*"


### PR DESCRIPTION
With some recent lint changes we needed to add some expanded type definitions for `Window`.  These were included for things like linting, but not included for the build step which resulted in a broken build.

This fixes the tsconfig used by the build step.