### PR TITLE
Group `angular` dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
           - 'storybook'
           - 'eslint-plugin-storybook'
           - '@chromatic-com/storybook'
+      angular:
+        patterns:
+          - '@angular/*'
+          - 'angular-*'
       eslint:
         patterns:
           - '*eslint*'


### PR DESCRIPTION
This PR adds a dependabot grouping for angular dependencies, which often need to be upgraded together.