### PR TITLE
Remove react dependencies from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,8 +121,6 @@
 				"karma-verbose-reporter": "^0.0.8",
 				"patch-package": "^8.0.0",
 				"prettier": "^3.6.2",
-				"react": "^18.2.0",
-				"react-dom": "^18.2.0",
 				"storybook": "9.1.3",
 				"ts-jest": "^29.1.1",
 				"ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -142,8 +142,6 @@
 		"karma-verbose-reporter": "^0.0.8",
 		"patch-package": "^8.0.0",
 		"prettier": "^3.6.2",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
 		"storybook": "9.1.3",
 		"ts-jest": "^29.1.1",
 		"ts-node": "^10.9.1",


### PR DESCRIPTION
We don't use react -- there are some dependencies which rely on react under the hood, but that doesn't make them *our* dependencies.

Once run this will make #687 obsolete.