### PR TITLE
Group jest dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       vis:
         patterns:
           - 'vis-*'
+      jest:
+        patterns:
+          - '*jest*'
     ignore:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION
This PR adds a dependency grouping for jest -- These will often be updated in relation to one another, and by grouping them we will consider those updates together (and in ways that prevent peer dependency mismatches)