### PR TITLE
Remove `ngx-bootstrap` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
 				"moment": "^2.30.1",
 				"ng-in-viewport": "^16.1.0",
 				"ng-recaptcha-2": "^16.0.1",
-				"ngx-bootstrap": "^5.6.1",
 				"ngx-cookie-service": "^20.1.0",
 				"ngx-countup": "^13.2.0",
 				"openseadragon": "^5.0.1",
@@ -24654,16 +24653,6 @@
 			},
 			"peerDependencies": {
 				"@angular/core": "^20.0.1"
-			}
-		},
-		"node_modules/ngx-bootstrap": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-5.6.2.tgz",
-			"integrity": "sha512-6YHXtdXkGH3w0NQoaUgNYAcrj064Lv5RTO284ha/hvpNTrh55yQz2cVh0VvwBk3MjyY2tdmLH4SuCJDszYdYiw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@angular/common": ">=7.0.0",
-				"@angular/core": ">=7.0.0"
 			}
 		},
 		"node_modules/ngx-cookie-service": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
 		"moment": "^2.30.1",
 		"ng-in-viewport": "^16.1.0",
 		"ng-recaptcha-2": "^16.0.1",
-		"ngx-bootstrap": "^5.6.1",
 		"ngx-cookie-service": "^20.1.0",
 		"ngx-countup": "^13.2.0",
 		"openseadragon": "^5.0.1",


### PR DESCRIPTION
This PR removes an unused dependency (this would remove the need for #726)