### PR TITLE
Remove direct `@es-joy/jsdoccomment` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,6 @@
 				"@angular/compiler-cli": "20.3.2",
 				"@angular/language-service": "20.3.2",
 				"@chromatic-com/storybook": "^4.1.1",
-				"@es-joy/jsdoccomment": "^0.52.0",
 				"@eslint/compat": "^1.4.0",
 				"@eslint/eslintrc": "^3.3.1",
 				"@eslint/js": "^9.36.0",
@@ -6292,23 +6291,6 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.52.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.52.0.tgz",
-			"integrity": "sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.8",
-				"@typescript-eslint/types": "^8.34.1",
-				"comment-parser": "1.4.1",
-				"esquery": "^1.6.0",
-				"jsdoc-type-pratt-parser": "~4.1.0"
-			},
-			"engines": {
-				"node": ">=20.11.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -22540,16 +22522,6 @@
 			"bin": {
 				"jsdoc": "jsdoc.js"
 			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-			"integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
-			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
 		"@angular/compiler-cli": "20.3.2",
 		"@angular/language-service": "20.3.2",
 		"@chromatic-com/storybook": "^4.1.1",
-		"@es-joy/jsdoccomment": "^0.52.0",
 		"@eslint/compat": "^1.4.0",
 		"@eslint/eslintrc": "^3.3.1",
 		"@eslint/js": "^9.36.0",


### PR DESCRIPTION
This PR takes out a lint related dependency that we no longer need to directly include in our dependencies.

(This change will mean https://github.com/PermanentOrg/web-app/pull/740/ becomes unnecessary)

This isn't really something that needs to be tested -- CI passing seems like evidence that the dependency wasn't actually necessary for our linting.