### PR TITLE
PER-10307: Show thumbnails correctly for public folders

### DIFF
--- a/src/app/models/get-thumbnail.ts
+++ b/src/app/models/get-thumbnail.ts
@@ -4,10 +4,14 @@ interface ThumbnailData {
 }
 export interface HasThumbnails {
 	thumbURL200?: string;
+	thumbUrl200?: string;
 	thumbnail256?: string;
 	thumbURL500?: string;
+	thumbUrl500?: string;
 	thumbURL1000?: string;
+	thumbUrl1000?: string;
 	thumbURL2000?: string;
+	thumbUrl2000?: string;
 }
 
 export function GetThumbnailInfo(
@@ -15,11 +19,11 @@ export function GetThumbnailInfo(
 	minimumSize: number,
 ): ThumbnailData | undefined {
 	const thumbnails: ThumbnailData[] = [
-		{ size: 200, url: item.thumbURL200 },
+		{ size: 200, url: item.thumbUrl200 ?? item.thumbURL200 },
 		{ size: 256, url: item.thumbnail256 },
-		{ size: 500, url: item.thumbURL500 },
-		{ size: 1000, url: item.thumbURL1000 },
-		{ size: 2000, url: item.thumbURL2000 },
+		{ size: 500, url: item.thumbUrl500 ?? item.thumbURL500 },
+		{ size: 1000, url: item.thumbUrl1000 ?? item.thumbURL1000 },
+		{ size: 2000, url: item.thumbUrl2000 ?? item.thumbURL2000 },
 	].filter((thumb) => thumb.url);
 	const biggestAvailableThumbnail = thumbnails[thumbnails.length - 1];
 	if (minimumSize > biggestAvailableThumbnail?.size) {


### PR DESCRIPTION
Quick followup to #720 and #669. We accidentally broke public folder thumbnails in the transition to getting records and folders from stela. These use a child thumbnail. 

Note the question about the right approach in the commit message! I just wanted to get something in since that felt simpler than explaining the whole code path in words.

To test:
1. Have a public folder with multiple record children in it (images are easiest but videos, presentations, and pdfs also work).
2. Open the public archive view (i.e., what a visitor to the public gallery would see, *not* the public workspace in the app). Check that the folder has a thumbnail which is one of its child record images (with a small folder icon)

The broken case is a "folder" icon as the thumbnail instead of one of the images.