### PR TITLE
Return failure status on lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"coverage": "npm run secrets && ng test --source-map --no-watch --code-coverage",
 		"coverage:ci": "npm run coverage -- --browsers chrome_headless_no_sandbox",
 		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:tsc",
-		"lint:eslint": "eslint ./src --ext .ts",
+		"lint:eslint": "eslint ./src --ext .ts --max-warnings=0",
 		"lint:prettier": "prettier . --check",
 		"lint:tsc": "tsc --noEmit",
 		"format": "npm run format:prettier && npm run format:eslint",

--- a/src/app/share-links/services/share-links-api.service.ts
+++ b/src/app/share-links/services/share-links-api.service.ts
@@ -26,7 +26,7 @@ export class ShareLinksApiService {
 		const response = await firstValueFrom(
 			this.http.get<{ items: ShareLink[] }>(
 				'v2/share-links',
-				{ shareTokens: shareTokens },
+				{ shareTokens },
 				null,
 				{
 					authToken: false,


### PR DESCRIPTION
This PR prevents CI passage if there are lint warnings.

It also fixes our sole lint warning.

Resolves #758