### PR TITLE
[PER-10331] Move and copy buttons do not open modals

### DIFF
--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -108,7 +108,9 @@ interface EditServiceClipboard {
 	operation: EditServiceClipboardOperation;
 }
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class EditService {
 	private clipboard: EditServiceClipboard;
 

--- a/src/app/core/services/folder-picker/folder-picker.service.ts
+++ b/src/app/core/services/folder-picker/folder-picker.service.ts
@@ -5,7 +5,9 @@ import {
 } from '@core/components/folder-picker/folder-picker.component';
 import { FolderVO, RecordVO } from '@root/app/models';
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class FolderPickerService {
 	private component: FolderPickerComponent;
 

--- a/src/app/file-browser/file-browser.module.ts
+++ b/src/app/file-browser/file-browser.module.ts
@@ -10,13 +10,9 @@ import { FileListItemComponent } from '@fileBrowser/components/file-list-item/fi
 import { FileViewerComponent } from '@fileBrowser/components/file-viewer/file-viewer.component';
 import { VideoComponent } from '@shared/components/video/video.component';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { EditService } from '@core/services/edit/edit.service';
-import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
-import { ShareLinksApiService } from '../share-links/services/share-links-api.service';
 import { FileBrowserComponentsModule } from './file-browser-components.module';
 
 @NgModule({
-	providers: [EditService, FolderPickerService, ShareLinksApiService],
 	imports: [
 		CommonModule,
 		RouterModule,


### PR DESCRIPTION
https://permanent.atlassian.net/browse/PER-10331

While this bug is a regression from the unlisted share work, fixing it breaks unlisted shares because how the angular modules are interconnected in the app. The right way would have been to provide services in the root, in order to avoid inconsistent states for services. This change will provide the EditService and the FolderPickerService in the root and this way both the modals and the unlisted shares work.

But this change will affect the persistence of the service’s state, so we need to check a lot of places where they are used, in order to make sure everything works as expected.

I will provide a list of features that need to be looked at, so we can try to avoid any other regressions.


- All controls on top of file list(including copy and move)
- File preview and editing the fields
- Location on sidebar, Info  tab
- Editing fields on sidebar, Info tab
- Multiple selection of files
- Breadcrumbs
- Change photo/Change banner from archive profile