### PR TITLE
[PER-10324] Fix "My archive" button not working on unlisted share link

### DIFF
--- a/src/app/share-preview/components/share-preview/share-preview.component.spec.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.spec.ts
@@ -330,4 +330,11 @@ describe('SharePreviewComponent', () => {
 		expect(component.hasRequested).toBeTrue();
 		expect(component.showCover).toBeFalse();
 	}));
+
+	it('should redirect to archive when clicking on the "My Archive" button', () => {
+		component.onMyAccountClick();
+
+		expect(router.navigate).toHaveBeenCalled();
+		expect(mockShareLinksService.currentShareToken).toBeUndefined();
+	});
 });

--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -422,6 +422,7 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
 	}
 
 	async onMyAccountClick() {
+		this.shareLinksService.currentShareToken = undefined;
 		return await this.router.navigate(['/app', 'private']);
 	}
 


### PR DESCRIPTION
STEPS TO TEST:

**Unlisted share**

1. Create a new account or log in to an existing one
2. Create a share link for a folder or file
3. Select the "Anyone can view" option from the Link Type dropdown
4. Copy the created share link
5. Open an incognito tab or a new browser window
6. Log in with a different account or create a new one
7. Paste the created share link
EXPECTED: The file or folder preview should be visible and a "My archive" button should be present on top/right of the screen
8. Click the "My archive" button
EXPECTED: It should redirect to the private folder of the user's selected archive

OTHERS SCENARIOS TO TEST:

**Restricted share**

1. Create a new account or log in to an existing one
2. Create a share link for a folder or file
3. Select the "Restricted" option from the Link Type dropdown
4. Copy the created share link
5. Open an incognito tab or a new browser window
6. Log in with a different account or create a new one
7. Paste the created share link
EXPECTED: The file or folder preview should be visible, together with the sticky footer for accepting the share  and a "My archive" button should be present on top/right of the screen
8. Click the "My archive" button
EXPECTED: It should redirect to the private folder of the user's selected archive

Issue: [PER-10324 Share archive button not working](https://permanent.atlassian.net/browse/PER-10324)