### PR TITLE
[PER-10348] Fix public gallery link for records

### DIFF
--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -103,6 +103,7 @@ export class RecordVO
 	public parentFolder_linkId;
 	public ParentFolderVOs;
 	public parentArchiveNbr: string;
+	public parentFolderArchiveNumber: string;
 	public parentDisplayName: string;
 	public pathAsArchiveNbr;
 	public files: PermanentFile[];
@@ -217,6 +218,7 @@ export interface RecordVOData extends BaseVOData {
 	pathAsFolder_linkId?: any;
 	pathAsText?: any;
 	parentFolder_linkId?: any;
+	parentFolderArchiveNumber?: any;
 	ParentFolderVOs?: any;
 	parentArchiveNbr?: any;
 	parentDisplayName?: string;

--- a/src/app/shared/pipes/public-route.pipe.spec.ts
+++ b/src/app/shared/pipes/public-route.pipe.spec.ts
@@ -54,6 +54,27 @@ describe('PublicRoutePipe', () => {
 		]);
 	});
 
+	it('returns correct link for record with no ParentFolderVOs defined', () => {
+		const record = new RecordVO({
+			parentFolder_linkId: 1234,
+			parentFolderArchiveNumber: '0001-meow',
+			folder_linkId: 1001,
+			archiveNbr: '0001-00gp',
+		});
+		const route = pipe.transform(record);
+
+		expect(route).toBeDefined();
+		expect(route).toEqual([
+			'/p',
+			'archive',
+			'0001-0000',
+			'0001-meow',
+			1234,
+			'record',
+			record.archiveNbr,
+		]);
+	});
+
 	it('returns correct link for record in the public root folder', () => {
 		const record = new RecordVO({
 			ParentFolderVOs: [
@@ -73,6 +94,34 @@ describe('PublicRoutePipe', () => {
 			'/p',
 			'archive',
 			'1234-0000',
+			'record',
+			'1234-5678',
+		]);
+	});
+
+	it('returns link for record in the public root folder, even if there is no ParentFolderVOs defined', () => {
+		const record = new RecordVO({
+			ParentFolderVOs: [
+				new FolderVO({
+					archiveNbr: 'do-not-use',
+					folder_linkId: -1,
+					folder_linkType: 'type.folder_link.root.public',
+					type: 'type.folder.root.public',
+				}),
+			],
+			parentFolderArchiveNumber: '1234-000d',
+			parentFolder_linkId: 987,
+			folder_linkId: 1001,
+			archiveNbr: '1234-5678',
+		});
+		const route = pipe.transform(record);
+
+		expect(route).toEqual([
+			'/p',
+			'archive',
+			'1234-0000',
+			'1234-000d',
+			987,
 			'record',
 			'1234-5678',
 		]);

--- a/src/app/shared/pipes/public-route.pipe.ts
+++ b/src/app/shared/pipes/public-route.pipe.ts
@@ -16,6 +16,12 @@ export class PublicRoutePipe implements PipeTransform {
 					parentFolder.archiveNbr,
 					parentFolder.folder_linkId.toString(),
 				);
+			} else if (
+				value.parentFolderArchiveNumber &&
+				value.parentFolder_linkId &&
+				rootArchive !== value.parentFolderArchiveNumber
+			) {
+				route.push(value.parentFolderArchiveNumber, value.parentFolder_linkId);
 			}
 			route.push('record', value.archiveNbr);
 			return route;


### PR DESCRIPTION
The public gallery links were not generating correctly, because the endpoint for getting the record has changed and the property used to create it, ParentFolderVOs, is not present anymore. Ideally we would fix the backend, but for now this will do the job. One exception is, the link for records that are in the root folder will have 2 extra parameters, but they will work.

Check the issue bellow for more details on how this should be tackled on BE.

Issue: [PER-10348 Get public gallery link not working for individual records](https://permanent.atlassian.net/browse/PER-10348)

STEPS TO TEST:
**Root record**
1. Create a new account or log in to an existing one
2. Upload a file or click an existing one
3. Publish the file
4. Go to public files and click the record you just published
5. Click Get link
EXPECTED: A modal with a generated link will appear
6. Click copy link from the modal
7. Paste the link in a new tab/window
EXPECTED: 
- The record preview should load
- You should be able to see all the details
- You should be able to see the left and right arrows if there are multiple records in the root folder

**Folder**
1. Create a new account or log in to an existing one
2. Create a folder or use an existing one
3. Upload files in the folder or use existing ones
4. Publish the folder
5. Go to public files and click the folder you just published
6. Click Get link
EXPECTED: A modal with a generated link will appear
7. Click copy link from the modal
8. Paste the link in a new tab/window
EXPECTED: 
- The folder preview should load
- You should be able to click the files and preview them
- You should be able to see the left and right arrows if there are multiple files in the folder


**Record in folder**
1. Create a new account or log in to an existing one
2. Create a folder or use an existing one
3. Upload files in the folder or use existing ones
4. Publish the folder
5. Go to public files and click the folder you just published
6. Click one of the files in the folder
7. Click Get link
EXPECTED: A modal with a generated link will appear
8. Click copy link from the modal
9. Paste the link in a new tab/window
EXPECTED: 
- The record preview should load
- You should be able to see all the details
- You should be able to see the left and right arrows if there are multiple records in the parent folder
- You should be able to hit the back arrow and get to the preview of the parent folder
