### PR TITLE
Adjust dependabot cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
     groups:
       storybook:
         patterns:
@@ -35,4 +39,8 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This PR updates dependabot to lower the cadence of PRs to monthly and to add a 7-day cooldown period before a given dependency update would be considered.

Since this is a change we want to make across several repositories I did not make an issue to capture the improvement, but we talked about it in Slack!