### PR TITLE
[PER-10365] Fix tags not appearing in share sidebar

### DIFF
--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -231,12 +231,10 @@ export class EditTagsComponent
 		this.itemTagsById.clear();
 
 		this.itemTags = this.filterTagsByType(
-			(this.item?.TagVOs || [])
-				.map((tag) => this.allTags?.find((t) => t.tagId === tag.tagId))
-				.filter(
-					// Filter out tags that are now null from deletion
-					(tag) => tag?.name,
-				),
+			(this.item?.TagVOs || []).filter(
+				// Filter out tags that are now null from deletion
+				(tag) => tag?.name,
+			),
 		);
 
 		if (!this.item?.TagVOs?.length) {


### PR DESCRIPTION
In the edit tags component, the item tags were mapped and filtered to only match tags that were present on the current archive. This seems to be redundant for items that are in the private workspace, because the tags on the item and the tags on the archive have the same type TagVOData.
However, the mapping and filtering would eliminate all tags for the shared items, because none of them would be present in the archive's tags.
In conclusion, eliminating the mapping/filtering would not affect the private workspace and will fix the shared workspace tags.

Issue: PER-10365 Keywords and metadata should show in the sidebar for Share Files section


TEST CASES:
**!!! Separate tests for file and folder**
1. Create an account or use an existing one (account A)
2. Upload a record/create a folder
3. Add keywords and metadata on record/folder
4. Create a share link for the record/folder with at least editing rights
6. Open a new window
7. Create a new account or log in with a different one(account B)
8. Paste the share link
9. Accept the share and view the record/folder in the shared workspace
10. Click the record/folder
EXPECTATIONS: The keywords and metadata added should be visible in the sidebar.
11. Add a new keyword and new metadata from the sidebar.
12. Go back to the first window and refresh(account A)
13. Click record/folder that has been shared from this archive
EXPECTATIONS: The keywords and metadata, including the one added by account B should be visible in the sidebar.

Also search tags might be worth testing!

OBSERVATION: These are the cases I thought of, but please add more if I am missing functionality that should be tested.