### PR TITLE
PER-10160: Format negative storage amounts

### DIFF
--- a/constants/master_en.json
+++ b/constants/master_en.json
@@ -595,6 +595,7 @@
 		"billing": {
 			"transfer": {
 				"account_to_creditcard": "Refund",
+				"admin_adjustment": "Adjustment applied by Permanent.org",
 				"creditcard_to_account": "Purchase",
 				"pledge_to_account": "Donation",
 				"account_to_pledge": "Donation failed",

--- a/src/app/shared/pipes/filesize.pipe.ts
+++ b/src/app/shared/pipes/filesize.pipe.ts
@@ -24,7 +24,7 @@ export class FileSizePipe implements PipeTransform {
 		} else {
 			let unit = 0;
 
-			while (bytes >= 1024) {
+			while (bytes >= 1024 || bytes <= -1024) {
 				bytes /= 1024;
 				unit += 1;
 			}


### PR DESCRIPTION
In the Transaction History and a few other places, we show bytes formatted into KB, GB, etc. This rounding only worked on positive numbers, which became obvious while reviewing
https://github.com/PermanentOrg/stela/pull/588. Also, add a human-friendly term for the admin adjustment.

Added @liam-lloyd as a reviewer since this was inspired by your change over in stela.