### PR TITLE
Fix Angular templates to support migration

### DIFF
--- a/src/app/core/components/profile-edit/profile-edit.component.html
+++ b/src/app/core/components/profile-edit/profile-edit.component.html
@@ -424,11 +424,7 @@
 							</div>
 						</div>
 					</div>
-					<div
-						class="profile-section-header"
-						prScrollSection="milestones"
-						[ngSwitch]="archive.type"
-					>
+					<div class="profile-section-header" prScrollSection="milestones">
 						Milestones
 					</div>
 					<div class="profile-section">

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -27,7 +27,7 @@
 				[bgSrc]="record.thumbURL200"
 				*ngIf="isQueued(i)"
 			></div>
-			<div *ngIf="currentRecord === record" class="full" [ngSwitch]="">
+			<div *ngIf="currentRecord === record" class="full">
 				<pr-zooming-image-viewer
 					[item]="currentRecord"
 					(disableSwipe)="toggleSwipe($event)"

--- a/src/app/file-browser/components/publish/publish.component.html
+++ b/src/app/file-browser/components/publish/publish.component.html
@@ -43,58 +43,60 @@
 				Publish
 			</button>
 		</div>
-		<ng-container *ngIf="publicItem" [ngSwitch]="publishIa">
+		<ng-container *ngIf="publicItem">
 			<hr />
 			<img
 				src="assets/img/internetarchive/IALogo.png"
 				alt="Internet Archive"
 				class="internet-archive-logo"
 			/>
-			<div class="public-link-button" *ngSwitchCase="null">
-				<p>
-					This item can also be published to the Internet Archive.
-					<a
-						href="https://desk.zoho.com/portal/permanent/en/kb/articles/publishing-to-the-internet-archive"
-						target="_blank"
-						>Learn more about publishing to the Internet Archive.</a
-					>
-				</p>
-				<button
-					class="btn btn-primary publish-to-archive"
-					(click)="publishItemToInternetArchive()"
-					[disabled]="waiting || !isAtleastManager"
-				>
-					Publish to Internet Archive
-				</button>
-			</div>
-			<div class="public-link" *ngSwitchDefault>
-				<p>
-					When processed, you can view this item on the Internet Archive with
-					the link provided. Processing may take several minutes.
-				</p>
-				<input
-					type="text"
-					class="form-control"
-					readonly
-					[value]="publishIa.permalink"
-					#iaLinkInput
-				/>
-				<div class="buttons">
+			<ng-container [ngSwitch]="publishIa">
+				<div class="public-link-button" *ngSwitchCase="null">
+					<p>
+						This item can also be published to the Internet Archive.
+						<a
+							href="https://desk.zoho.com/portal/permanent/en/kb/articles/publishing-to-the-internet-archive"
+							target="_blank"
+							>Learn more about publishing to the Internet Archive.</a
+						>
+					</p>
 					<button
-						class="btn btn-primary"
-						[disabled]="iaLinkCopied"
-						(click)="copyInternetArchiveLink()"
+						class="btn btn-primary publish-to-archive"
+						(click)="publishItemToInternetArchive()"
+						[disabled]="waiting || !isAtleastManager"
 					>
-						{{ iaLinkCopied ? 'Link copied' : 'Copy link' }}
+						Publish to Internet Archive
 					</button>
-					<a
-						class="btn btn-primary"
-						[href]="publishIa.permalink"
-						target="_blank"
-						>View on web</a
-					>
 				</div>
-			</div>
+				<div class="public-link" *ngSwitchDefault>
+					<p>
+						When processed, you can view this item on the Internet Archive with
+						the link provided. Processing may take several minutes.
+					</p>
+					<input
+						type="text"
+						class="form-control"
+						readonly
+						[value]="publishIa.permalink"
+						#iaLinkInput
+					/>
+					<div class="buttons">
+						<button
+							class="btn btn-primary"
+							[disabled]="iaLinkCopied"
+							(click)="copyInternetArchiveLink()"
+						>
+							{{ iaLinkCopied ? 'Link copied' : 'Copy link' }}
+						</button>
+						<a
+							class="btn btn-primary"
+							[href]="publishIa.permalink"
+							target="_blank"
+							>View on web</a
+						>
+					</div>
+				</div>
+			</ng-container>
 			<hr />
 		</ng-container>
 	</div>

--- a/src/app/share-preview/components/share-preview/share-preview.component.html
+++ b/src/app/share-preview/components/share-preview/share-preview.component.html
@@ -321,14 +321,14 @@
 					[disabled]="waiting || hasRequested"
 					*ngIf="isLinkShare"
 				>
-					<ng-container *ngIf="hasRequested; else accessText"
+					<ng-container *ngIf="hasRequested; else accessTextFooter"
 						>Access Requested</ng-container
 					>
-					<ng-template #accessText>
-						<ng-container *ngIf="isAutoApprove; else requestAccess"
+					<ng-template #accessTextFooter>
+						<ng-container *ngIf="isAutoApprove; else requestAccessFooter"
 							>Accept Share</ng-container
 						>
-						<ng-template #requestAccess>Request Access</ng-template>
+						<ng-template #requestAccessFooter>Request Access</ng-template>
 					</ng-template>
 				</button>
 			</div>

--- a/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
+++ b/src/app/shared/components/inline-value-edit/inline-value-edit.component.html
@@ -279,14 +279,14 @@
 			</div>
 		</div>
 	</ng-container>
-	<ng-template #inlineControls>
-		<div class="inline-value-controls" *ngIf="isEditing" @ngIfScaleAnimation>
-			<button class="btn btn-primary btn-sm" (click)="save()" type="submit">
-				Save
-			</button>
-			<button class="btn btn-secondary btn-sm" (click)="cancel()" type="button">
-				Cancel
-			</button>
-		</div>
-	</ng-template>
 </ng-container>
+<ng-template #inlineControls>
+	<div class="inline-value-controls" *ngIf="isEditing" @ngIfScaleAnimation>
+		<button class="btn btn-primary btn-sm" (click)="save()" type="submit">
+			Save
+		</button>
+		<button class="btn btn-secondary btn-sm" (click)="cancel()" type="button">
+			Cancel
+		</button>
+	</div>
+</ng-template>


### PR DESCRIPTION
This PR fixes a few of our templates which had invalid Angular commands.

These fixes will make the migration to Angular 21 a bit smoother.

Related to #869 