### PR TITLE
Fix the Info Pane

### DIFF
--- a/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.spec.ts
@@ -82,6 +82,7 @@ describe('EditTagsComponent', () => {
 				{
 					provide: DataService,
 					useValue: {
+						currentFolderChange: of(null),
 						fetchFullItems: async (items: ItemVO[]) =>
 							await Promise.resolve([]),
 					},

--- a/src/app/file-browser/components/edit-tags/edit-tags.component.ts
+++ b/src/app/file-browser/components/edit-tags/edit-tags.component.ts
@@ -34,7 +34,7 @@ export type TagType = 'keyword' | 'customMetadata';
 	templateUrl: './edit-tags.component.html',
 	styleUrls: ['./edit-tags.component.scss'],
 	animations: [ngIfScaleAnimation],
-	providers: [SearchService, DataService],
+	providers: [SearchService],
 	standalone: false,
 })
 export class EditTagsComponent


### PR DESCRIPTION
This PR fixes a bug that was causing the info pane to fail to load after a recent change to the way we loaded NewRelic (which, apparently, is unrelated to NewRelic itself)

An analysis of the situation, ala Claude:

---

Why NewRelic Exposed the Bug                                                                                                                                                                                             
                                                                                                                                                                                                                           
  The root cause was always a circular dependency between EditTagsComponent → DataService → (via EditService) → EditTagsComponent. This was a latent bug that existed before PR #887 but never manifested.                 
                                                                                                                                                                                                                           
  The Chain of Events                                                                                                                                                                                                      
                                                                                                                                                                                                                           
  Before PR #887:                                                                                                                                                                                                          
  - NewRelic was loaded inline in index.html as a <script> tag                                                                                                                                                             
  - It executed completely before Angular's bundle loaded                                                                                                                                                                  
  - The bundler (Webpack/Vite) had a specific module evaluation order                                                                                                                                                      
  - By coincidence, data.service.ts was always fully evaluated before edit-tags.component.ts                                                                                                                               
                                                                                                                                                                                                                           
  After PR #887:                                                                                                                                                                                                           
  // main.ts - BEFORE Angular imports                                                                                                                                                                                      
  import { BrowserAgent } from '@newrelic/browser-agent/loaders/browser-agent';                                                                                                                                            
  import { AppModule } from './app/app.module';  // Angular loads after                                                                                                                                                    
                                                                                                                                                                                                                           
  Adding @newrelic/browser-agent as a static import at the top of main.ts caused the bundler to:                                                                                                                           
  1. Re-analyze the entire dependency graph                                                                                                                                                                                
  2. Reorganize which modules go into which chunks                                                                                                                                                                         
  3. Change the module evaluation order                                                                                                                                                                                    
                                                                                                                                                                                                                           
  The new order happened to evaluate edit-tags.component.ts before data.service.ts was fully initialized, causing DataService to be undefined when Angular tried to process the providers array.                           
                                                                                                                                                                                                                           
  Why Removing NewRelic Didn't Fix It                                                                                                                                                                                      
                                                                                                                                                                                                                           
  Once the bundler configuration changed (new index.html, new main.ts structure), the module evaluation order was permanently altered. NewRelic was just the trigger - removing it didn't restore the old order.           
                                                                                                                                                                                                                           
  The Actual Fix                                                                                                                                                                                                           
                                                                                                                                                                                                                           
  Removing DataService from EditTagsComponent's component-level providers eliminated the need for DataService to be defined at module decoration time, breaking the circular dependency.  