### PR TITLE
Fix the storybook build

### DIFF
--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -5,7 +5,7 @@
 		"allowSyntheticDefaultImports": true,
 		"resolveJsonModule": true
 	},
-	"exclude": ["../src/test.ts", "../src/**/*.spec.ts"],
+	"exclude": ["../src/test.ts", "../src/**/*.spec.ts", "../src/test/**/*"],
 	"include": ["../src/**/*", "./preview.ts"],
 	"files": ["./typings.d.ts"]
 }


### PR DESCRIPTION
This PR fixes an issue where our test files were being included in the storybook build.  This wasn't causing issues before, but some new tooling caused an issue that raised the need to ignore it.

Resolves #901