### PR TITLE
Create account from restricted share link completes share

### DIFF
--- a/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
+++ b/src/app/onboarding/components/create-new-archive/create-new-archive.component.ts
@@ -205,6 +205,13 @@ export class CreateNewArchiveComponent implements OnInit {
 					response = await this.api.archive.create(archive);
 					createdArchive = response.getArchiveVO();
 				}
+
+				const shareToken =
+					localStorage.getItem('shareToken') ||
+					localStorage.getItem('shareTokenFromCopy');
+				if (shareToken) {
+					await this.api.share.requestShareAccess(shareToken);
+				}
 			} catch (archiveError) {
 				this.errorOccurred.emit('An error occurred. Please try again.');
 			}


### PR DESCRIPTION
When a user is accessing a restricted share link without an account, a create account modal will appear. After the user follows the whole onboarding flow, when he navigates to shares, he will see the accepted share.

ISSUE: [PER-10446](https://permanent.atlassian.net/browse/PER-10446)


STEPS TO TEST:

**Restricted -->  auto approve on**

1. From an existing account, create a restricted share link;
2. View the share link from a browser window where you are not logged in;
3. From the share preview, click on create account in the pop up modal;
4. Complete the signup form, click on “create archive for me” in the first onboarding screen, and skip the questionnaires to reach the final onboarding screen where your new archive name is confirmed;
6. After confirming your new archive, navigate to Shared Files Workspace;

EXPECTED: The shared folder is visible;

**Restricted -->  auto approve off**

1. From an existing account, create a restricted share link, make auto-approve off;
2. View the share link from a browser window where you are not logged in;
3. From the share preview, click on create account in the pop up modal;
4. Complete the signup form, click on “create archive for me” in the first onboarding screen, and skip the questionnaires to reach the final onboarding screen where your new archive name is confirmed;
6. After confirming your new archive, navigate to Shared Files Workspace;

EXPECTED: The shared folder is NOT visible;

7. From the previous account, approve the share request;
8. Refresh the browser window where the new account was created, in the Shared Files Workspace;

EXPECTED: The shared folder is visible;
