### PR TITLE
Fix account dropdown

### DIFF
--- a/src/app/shared/components/account-dropdown/account-dropdown.component.scss
+++ b/src/app/shared/components/account-dropdown/account-dropdown.component.scss
@@ -24,6 +24,12 @@ button {
 	max-width: pxToGrid(360px);
 	overflow: hidden;
 	text-overflow: ellipsis;
+	--bs-btn-color: #{$PR-orange};
+	--bs-btn-hover-color: #{$PR-orange};
+	--bs-btn-active-color: #{$PR-orange};
+	--bs-btn-border-color: transparent;
+	--bs-btn-hover-border-color: transparent;
+	--bs-btn-active-border-color: transparent;
 
 	> span {
 		margin-right: $grid-unit * 0.25;

--- a/src/styles/_ui.scss
+++ b/src/styles/_ui.scss
@@ -181,6 +181,12 @@ a {
 .btn-wordpress,
 .btn-wordpress-alternate {
 	$size: 34px;
+	--bs-btn-color: #{$PR-orange};
+	--bs-btn-hover-color: #{$PR-orange};
+	--bs-btn-active-color: #{$PR-orange};
+	--bs-btn-bg: #{rgba(white, 0.2)};
+	--bs-btn-hover-bg: #{white};
+	--bs-btn-active-bg: #{white};
 	background: rgba(white, 0.2);
 	height: $size;
 	border-radius: $size * 0.5;
@@ -191,12 +197,19 @@ a {
 	font-size: 0.7em;
 	display: inline-flex;
 	align-items: center;
+	width: auto;
 
 	&:hover {
 		background: white;
 	}
 
 	&.btn-wordpress-alternate {
+		--bs-btn-color: #{white};
+		--bs-btn-hover-color: #{white};
+		--bs-btn-active-color: #{white};
+		--bs-btn-bg: #{$PR-purple};
+		--bs-btn-hover-bg: #{$PR-orange};
+		--bs-btn-active-bg: #{$PR-orange};
 		background: $PR-purple;
 		color: white;
 


### PR DESCRIPTION
This PR fixes a styling bug introduced by the latest Bootstrap update, particularly related to the account dropdown.

To test you should click the account dropdown in the upper right, and you should see your account name stay orange even on hover / when active.

Resolves https://permanent.atlassian.net/browse/PER-10445