### PR TITLE
Generate QA instructions for PRs

### DIFF
--- a/.github/workflows/qa-instructions.yml
+++ b/.github/workflows/qa-instructions.yml
@@ -1,0 +1,17 @@
+name: QA Instructions
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  pull-requests: write
+  models: read
+
+jobs:
+  qa-instructions:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'QA')
+    steps:
+      - uses: BadIdeaFactory/qa-instructions-action@v0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR sets up a new workflow that will generate QA instructions if the `QA` label is applied to a given PR.

Resolves #928