### PR TITLE
Ignore major `eslint` versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'


### PR DESCRIPTION
This PR ignores major eslint versions, which should help us avoid peer dependency conflicts during transition periods.