### PR TITLE
Per 9589 milestone sort

### DIFF
--- a/constants/master_en.json
+++ b/constants/master_en.json
@@ -972,7 +972,8 @@
 		"archive": {
 			"no_email_found": "No Permanent Archive with that email address was found",
 			"no_remove_access_active": "Can not remove there access of active Permanent Archive.",
-			"no_remove_access_owner": "The owner can not remove there access."
+			"no_remove_access_owner": "The owner can not remove their access.",
+			"not_found": "Sorry, this archive was not found or you do not have permission to update it."
 		},
 		"auth": {
 			"access_denied": "You do not have sufficient privileges to perform this action or access this item.",

--- a/src/app/core/components/profile-edit/profile-edit.component.html
+++ b/src/app/core/components/profile-edit/profile-edit.component.html
@@ -455,7 +455,13 @@
 						<div class="profile-section">
 							<em
 								>Milestones capture any significant event in the history of this
-								archive, and are ordered from most recent to least recent.</em
+								archive, and by default are ordered from most recent to least
+								recent. This order can be changed in
+								<a
+									href="#"
+									(click)="openArchiveSettings(); $event.preventDefault()"
+									>archive settings</a
+								>.</em
 							>
 						</div>
 						<div class="profile-section">

--- a/src/app/core/components/profile-edit/profile-edit.component.ts
+++ b/src/app/core/components/profile-edit/profile-edit.component.ts
@@ -34,6 +34,7 @@ import { copyFromInputElement } from '@shared/utilities/forms';
 import { EventService } from '@shared/services/event/event.service';
 import { LocationPickerComponent } from '@fileBrowser/components/location-picker/location-picker.component';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { ArchiveSettingsDialogComponent } from '@core/components/archive-settings-dialog/archive-settings-dialog.component';
 import {
 	PROFILE_ONBOARDING_COOKIE,
 	ProfileEditFirstTimeDialogComponent,
@@ -259,6 +260,10 @@ export class ProfileEditComponent implements OnInit, AfterViewInit {
 			this.updateProgress();
 			this.trackProfileEdit(item);
 		}
+	}
+
+	openArchiveSettings() {
+		this.dialog.open(ArchiveSettingsDialogComponent);
 	}
 
 	async onShareClick() {

--- a/src/app/core/components/public-settings/public-settings.component.html
+++ b/src/app/core/components/public-settings/public-settings.component.html
@@ -66,4 +66,45 @@
 			<a href="{{ supportLink }}">contact support</a></small
 		>
 	}
+	<div class="settings-item">
+		<label>Milestone Sort Order</label>
+		<div class="form-check form-check-inline">
+			<input
+				class="form-check-input"
+				type="radio"
+				name="milestoneSortOrder"
+				id="milestoneSortOrderDesc"
+				value="reverse_chronological"
+				[disabled]="updating"
+				[(ngModel)]="milestoneSortOrder"
+				(ngModelChange)="onMilestoneSortOrderChange()"
+			/>
+			<label class="form-check-label" for="milestoneSortOrderDesc"
+				>Descending</label
+			>
+		</div>
+		<div class="form-check form-check-inline">
+			<input
+				class="form-check-input"
+				type="radio"
+				name="milestoneSortOrder"
+				id="milestoneSortOrderAsc"
+				value="chronological"
+				[disabled]="updating"
+				[(ngModel)]="milestoneSortOrder"
+				(ngModelChange)="onMilestoneSortOrderChange()"
+			/>
+			<label class="form-check-label" for="milestoneSortOrderAsc"
+				>Ascending</label
+			>
+		</div>
+	</div>
+	<small class="text-muted">
+		Select whether the most recent (descending) or most distant (ascending)
+		milestones appear at the top of the public profile.
+		<a
+			href="https://permanent.zohodesk.com/portal/en/kb/articles/public-profiles"
+			>Learn more</a
+		>.
+	</small>
 </div>

--- a/src/app/core/components/public-settings/public-settings.component.spec.ts
+++ b/src/app/core/components/public-settings/public-settings.component.spec.ts
@@ -39,7 +39,7 @@ const mockApiService = {
 			updatedValues: { milestoneSortOrder?: string },
 		) => {
 			if (patchArchiveThrowError) {
-				throw { error: { message: 'Test Error' } };
+				throw { error: { error: { message: 'Test Error' } } };
 			}
 			patchArchiveCalled = true;
 			patchArchiveCalledWith = { archiveId, updatedValues };

--- a/src/app/core/components/public-settings/public-settings.component.spec.ts
+++ b/src/app/core/components/public-settings/public-settings.component.spec.ts
@@ -18,6 +18,13 @@ let archive: ArchiveVO;
 let throwError: boolean = false;
 let updatedDownload: boolean = false;
 let updated: boolean = false;
+let patchArchiveThrowError: boolean = false;
+let patchArchiveCalled: boolean = false;
+let patchArchiveCalledWith: {
+	archiveId: string;
+	updatedValues: { milestoneSortOrder?: string };
+} | null = null;
+let showErrorCalled: boolean = false;
 const mockApiService = {
 	archive: {
 		update: async (data: any) => {
@@ -27,6 +34,16 @@ const mockApiService = {
 			updated = true;
 			updatedDownload = data.allowPublicDownload as boolean;
 		},
+		patchArchive: async (
+			archiveId: string,
+			updatedValues: { milestoneSortOrder?: string },
+		) => {
+			if (patchArchiveThrowError) {
+				throw { error: { message: 'Test Error' } };
+			}
+			patchArchiveCalled = true;
+			patchArchiveCalledWith = { archiveId, updatedValues };
+		},
 	},
 };
 
@@ -35,6 +52,10 @@ describe('PublicSettingsComponent', () => {
 		throwError = false;
 		updatedDownload = null;
 		updated = false;
+		patchArchiveThrowError = false;
+		patchArchiveCalled = false;
+		patchArchiveCalledWith = null;
+		showErrorCalled = false;
 		archive = {
 			allowPublicDownload: true,
 		} as ArchiveVO;
@@ -46,7 +67,9 @@ describe('PublicSettingsComponent', () => {
 			.provide({
 				provide: MessageService,
 				useValue: {
-					showError: () => {},
+					showError: () => {
+						showErrorCalled = true;
+					},
 				},
 			});
 	});
@@ -107,5 +130,99 @@ describe('PublicSettingsComponent', () => {
 		await instance.onAllowDownloadsChange();
 
 		expect(updated).toBeFalse();
+	});
+
+	describe('milestoneSortOrder initialization', () => {
+		it('should default to reverse_chronological when not set on archive', () => {
+			defaultRender({ allowPublicDownload: false } as ArchiveVO);
+			const instance = ngMocks.findInstance(PublicSettingsComponent);
+
+			expect(instance.milestoneSortOrder).toBe('reverse_chronological');
+		});
+
+		it('should initialize to chronological when archive has chronological', () => {
+			defaultRender({
+				allowPublicDownload: false,
+				milestoneSortOrder: 'chronological',
+			} as ArchiveVO);
+			const instance = ngMocks.findInstance(PublicSettingsComponent);
+
+			expect(instance.milestoneSortOrder).toBe('chronological');
+		});
+
+		it('should initialize to reverse_chronological when archive has reverse_chronological', () => {
+			defaultRender({
+				allowPublicDownload: false,
+				milestoneSortOrder: 'reverse_chronological',
+			} as ArchiveVO);
+			const instance = ngMocks.findInstance(PublicSettingsComponent);
+
+			expect(instance.milestoneSortOrder).toBe('reverse_chronological');
+		});
+	});
+
+	describe('onMilestoneSortOrderChange', () => {
+		it('should call patchArchive with the archive id and new sort order', async () => {
+			defaultRender({
+				allowPublicDownload: false,
+				archiveId: 'abc123',
+			} as ArchiveVO);
+			const instance = ngMocks.findInstance(PublicSettingsComponent);
+
+			instance.milestoneSortOrder = 'chronological';
+			await instance.onMilestoneSortOrderChange();
+
+			expect(patchArchiveCalled).toBeTrue();
+			expect(patchArchiveCalledWith).toEqual({
+				archiveId: 'abc123',
+				updatedValues: { milestoneSortOrder: 'chronological' },
+			});
+		});
+
+		it('should update archive.milestoneSortOrder', async () => {
+			const a = {
+				allowPublicDownload: false,
+				archiveId: 'abc123',
+				milestoneSortOrder: 'reverse_chronological',
+			} as ArchiveVO;
+			defaultRender(a);
+			const instance = ngMocks.findInstance(PublicSettingsComponent);
+
+			instance.milestoneSortOrder = 'chronological';
+			await instance.onMilestoneSortOrderChange();
+
+			expect(a.milestoneSortOrder).toBe('chronological');
+		});
+
+		it('should show an error when patchArchive throws', async () => {
+			defaultRender({
+				allowPublicDownload: false,
+				archiveId: 'abc123',
+			} as ArchiveVO);
+			const instance = ngMocks.findInstance(PublicSettingsComponent);
+
+			patchArchiveThrowError = true;
+			await instance.onMilestoneSortOrderChange();
+
+			expect(showErrorCalled).toBeTrue();
+		});
+
+		it('should set updating to true while saving and reset to false after', async () => {
+			defaultRender({
+				allowPublicDownload: false,
+				archiveId: 'abc123',
+			} as ArchiveVO);
+			const instance = ngMocks.findInstance(PublicSettingsComponent);
+
+			let updatingWhileSaving: boolean;
+			spyOn(mockApiService.archive, 'patchArchive').and.callFake(async () => {
+				updatingWhileSaving = instance.updating;
+			});
+
+			await instance.onMilestoneSortOrderChange();
+
+			expect(updatingWhileSaving).toBeTrue();
+			expect(instance.updating).toBeFalse();
+		});
 	});
 });

--- a/src/app/core/components/public-settings/public-settings.component.ts
+++ b/src/app/core/components/public-settings/public-settings.component.ts
@@ -57,8 +57,6 @@ export class PublicSettingsComponent implements OnInit {
 	}
 
 	public async onMilestoneSortOrderChange() {
-		const previousOrder =
-			this.archive.milestoneSortOrder ?? 'reverse_chronological';
 		this.updating = true;
 		try {
 			await this.api.archive.patchArchive(this.archive.archiveId, {
@@ -66,8 +64,10 @@ export class PublicSettingsComponent implements OnInit {
 			});
 			this.archive.milestoneSortOrder = this.milestoneSortOrder;
 		} catch (err) {
-			this.milestoneSortOrder = previousOrder;
-			this.msg.showError({ message: err.error?.message, translate: true });
+			this.msg.showError({
+				message: err.error?.error?.message ?? 'error.generic.update_fail',
+				translate: true,
+			});
 		} finally {
 			this.updating = false;
 		}

--- a/src/app/core/components/public-settings/public-settings.component.ts
+++ b/src/app/core/components/public-settings/public-settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ArchiveVO } from '@models/index';
 import { ApiService } from '@shared/services/api/api.service';
-import { ArchiveType } from '@models/archive-vo';
+import { ArchiveType, MilestoneSortOrder } from '@models/archive-vo';
 import { Observable } from 'rxjs';
 import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
 import { MessageService } from '@shared/services/message/message.service';
@@ -17,6 +17,7 @@ export class PublicSettingsComponent implements OnInit {
 	@Input() public archive: ArchiveVO;
 	public updating: boolean = false;
 	public allowDownloadsToggle: number = 0;
+	public milestoneSortOrder: MilestoneSortOrder = 'reverse_chronological';
 	public supportLink: string =
 		'https://permanent.zohodesk.com/portal/en/newticket';
 
@@ -47,10 +48,29 @@ export class PublicSettingsComponent implements OnInit {
 
 	ngOnInit(): void {
 		this.allowDownloadsToggle = +this.archive.allowPublicDownload;
+		this.milestoneSortOrder =
+			this.archive.milestoneSortOrder ?? 'reverse_chronological';
 		this.archiveType =
 			this.archive.type === 'type.archive.family'
 				? 'type.archive.group'
 				: this.archive.type;
+	}
+
+	public async onMilestoneSortOrderChange() {
+		const previousOrder =
+			this.archive.milestoneSortOrder ?? 'reverse_chronological';
+		this.updating = true;
+		try {
+			await this.api.archive.patchArchive(this.archive.archiveId, {
+				milestoneSortOrder: this.milestoneSortOrder,
+			});
+			this.archive.milestoneSortOrder = this.milestoneSortOrder;
+		} catch (err) {
+			this.milestoneSortOrder = previousOrder;
+			this.msg.showError({ message: err.error?.message, translate: true });
+		} finally {
+			this.updating = false;
+		}
 	}
 
 	public async onAllowDownloadsChange() {

--- a/src/app/models/archive-vo.ts
+++ b/src/app/models/archive-vo.ts
@@ -5,6 +5,8 @@ import { DataStatus } from '@models/data-status.enum';
 import { AccessRoleType } from './access-role';
 import { ItemVO } from '.';
 
+export type MilestoneSortOrder = 'chronological' | 'reverse_chronological';
+
 export type ArchiveType =
 	| 'type.archive.person'
 	| 'type.archive.group'
@@ -43,6 +45,7 @@ export class ArchiveVO extends BaseVO implements DynamicListChild {
 	public allowPublicDownload: boolean;
 	public payerAccountId: string;
 	public public: number;
+	public milestoneSortOrder: MilestoneSortOrder;
 
 	constructor(voData: any) {
 		super(voData);

--- a/src/app/public/components/public-profile/public-profile.component.spec.ts
+++ b/src/app/public/components/public-profile/public-profile.component.spec.ts
@@ -1,0 +1,73 @@
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArchiveVO } from '@models';
+import { ProfileItemVOData } from '@models/profile-item-vo';
+import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
+import { NewlineTextPipe } from '@shared/pipes/newline-text.pipe';
+import { PrLocationPipe } from '@shared/pipes/pr-location.pipe';
+import { first } from 'rxjs/operators';
+import { PublicProfileComponent } from './public-profile.component';
+
+describe('PublicProfileComponent', () => {
+	let component: PublicProfileComponent;
+	let fixture: ComponentFixture<PublicProfileComponent>;
+	let service: PublicProfileService;
+
+	const milestoneItems: ProfileItemVOData[] = [
+		{ fieldNameUI: 'profile.milestone', string1: 'Oldest', day1: '1990-01-01' },
+		{ fieldNameUI: 'profile.milestone', string1: 'Middle', day1: '2000-06-15' },
+		{ fieldNameUI: 'profile.milestone', string1: 'Newest', day1: '2010-12-31' },
+	];
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [PublicProfileComponent, PrLocationPipe, NewlineTextPipe],
+			imports: [CommonModule],
+			providers: [PublicProfileService],
+		}).compileComponents();
+
+		service = TestBed.inject(PublicProfileService);
+		fixture = TestBed.createComponent(PublicProfileComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+
+	it('should sort milestones newest first when milestoneSortOrder is reverse_chronological', (done) => {
+		service.setArchive(
+			new ArchiveVO({ milestoneSortOrder: 'reverse_chronological' }),
+		);
+		service.setProfileItems(milestoneItems);
+
+		component.milestones$.pipe(first()).subscribe((milestones) => {
+			expect(milestones[0].string1).toBe('Newest');
+			expect(milestones[2].string1).toBe('Oldest');
+			done();
+		});
+	});
+
+	it('should sort milestones oldest first when milestoneSortOrder is chronological', (done) => {
+		service.setArchive(new ArchiveVO({ milestoneSortOrder: 'chronological' }));
+		service.setProfileItems(milestoneItems);
+
+		component.milestones$.pipe(first()).subscribe((milestones) => {
+			expect(milestones[0].string1).toBe('Oldest');
+			expect(milestones[2].string1).toBe('Newest');
+			done();
+		});
+	});
+
+	it('should default to newest first when milestoneSortOrder is not set', (done) => {
+		service.setArchive(new ArchiveVO({}));
+		service.setProfileItems(milestoneItems);
+
+		component.milestones$.pipe(first()).subscribe((milestones) => {
+			expect(milestones[0].string1).toBe('Newest');
+			expect(milestones[2].string1).toBe('Oldest');
+			done();
+		});
+	});
+});

--- a/src/app/public/components/public-profile/public-profile.component.ts
+++ b/src/app/public/components/public-profile/public-profile.component.ts
@@ -5,7 +5,7 @@ import {
 	ProfileItemVOData,
 } from '@models/profile-item-vo';
 import { PublicProfileService } from '@public/services/public-profile/public-profile.service';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subscription, combineLatest } from 'rxjs';
 import {
 	HasSubscriptions,
 	unsubscribeAll,
@@ -39,14 +39,19 @@ export class PublicProfileComponent
 				.subscribe((items) => (this.profileItems = items)),
 		);
 
-		this.milestones$ = this.publicProfile.profileItemsDictionary$().pipe(
-			map((profileItems) => {
+		this.milestones$ = combineLatest([
+			this.publicProfile.archive$(),
+			this.publicProfile.profileItemsDictionary$(),
+		]).pipe(
+			map(([archive, profileItems]) => {
 				const milestones = concat(
 					profileItems.job || [],
 					profileItems.home || [],
 					profileItems.milestone || [],
 				);
-				return orderBy(milestones, (i) => i.day1, 'desc');
+				const order =
+					archive?.milestoneSortOrder === 'chronological' ? 'asc' : 'desc';
+				return orderBy(milestones, (i) => i.day1, order);
 			}),
 		);
 	}

--- a/src/app/shared/services/api/archive.repo.ts
+++ b/src/app/shared/services/api/archive.repo.ts
@@ -272,6 +272,15 @@ export class ArchiveRepo extends BaseRepo {
 		).toPromise();
 	}
 
+	public async patchArchive(
+		archiveId: string,
+		updatedValues: Partial<Pick<ArchiveVO, 'milestoneSortOrder'>>,
+	): Promise<void> {
+		await this.httpV2
+			.patch(`v2/archive/${archiveId}`, updatedValues)
+			.toPromise();
+	}
+
 	public async getPublicArchiveTags(archiveId: string) {
 		return await this.httpV2
 			.get<TagVOData>(`v2/archive/${archiveId}/tags/public`)

--- a/src/app/shared/services/message/message.service.ts
+++ b/src/app/shared/services/message/message.service.ts
@@ -37,8 +37,8 @@ export class MessageService {
 
 		if (translate) {
 			this.component.display({
-				message: this.constants.translate(data.message),
 				...data,
+				message: this.constants.translate(data.message),
 			});
 		} else {
 			this.component.display(data);


### PR DESCRIPTION
Allow users to display milestones on the public profile either chronologically or reverse chronologically.

~I could use some help with making it obvious to the user (1) that this is a button and (2) what the button does. I don't know how to make sure that they understand that they are reordering the milestones on a different screen than the one they are looking at.~

I have changed this in response to feedback to let users change the order in archive settings. I also point to that setting from the profile editor where members create milestones. 