### PR TITLE
[PER-10489] Fix unlisted share thumbnail display

### DIFF
--- a/src/app/file-browser/components/file-list-item/file-list-item.component.html
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.html
@@ -47,7 +47,7 @@
 			</div>
 		}
 		@if (!item.isFolder && !isZip) {
-			<div prBgImage [bgSrc]="item | getThumbnail" [cover]="inGridView"></div>
+			<div prBgImage [bgSrc]="recordThumbnailUrl" [cover]="inGridView"></div>
 		}
 	</ng-container>
 	@if (inGridView && item.isFolder ? item.view : true) {

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.spec.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ElementRef, Pipe, PipeTransform } from '@angular/core';
 import { of } from 'rxjs';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { ActivatedRoute, Router, provideRouter } from '@angular/router';
 
 import { DataService } from '@shared/services/data/data.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
@@ -310,5 +310,36 @@ describe('FileListItemComponent', () => {
 		component.onMouseLeaveName();
 
 		expect(component.isNameHovered).toBeFalse();
+	});
+
+	it('should set random preview thumbnail for non-unlisted share records', async () => {
+		const router = TestBed.inject(Router);
+		(router.routerState.snapshot as any).url = '/share/test';
+
+		const shareLinksService = TestBed.inject(ShareLinksService);
+		spyOn(shareLinksService, 'isUnlistedShare').and.returnValue(
+			Promise.resolve(false),
+		);
+		component.item.isRecord = true;
+		component.item.type = 'type.record.image';
+
+		await component.ngOnInit();
+
+		expect(component.recordThumbnailUrl).toBeDefined();
+		expect(component.recordThumbnailUrl).toMatch(
+			/^assets\/img\/preview\/preview-\d+\.jpg$/,
+		);
+
+		(router.routerState.snapshot as any).url = '/';
+	});
+
+	it('should always set real thumbnail URL on init', async () => {
+		component.item.isRecord = true;
+		component.item.type = 'type.record.image';
+		component.item.thumbURL200 = 'https://example.com/thumb.jpg';
+
+		await component.ngOnInit();
+
+		expect(component.recordThumbnailUrl).toBe('https://example.com/thumb.jpg');
 	});
 });

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -204,9 +204,16 @@ export class FileListItemComponent
 	public isZip = false;
 	public date: string = '';
 	public isUnlistedShare = false;
+	public recordThumbnailUrl: string | undefined;
 
 	private folderThumb: string;
 	private folderContentsType: FolderContentsType = FolderContentsType.NORMAL;
+
+	private getRandomPreviewImage(): string {
+		const previewCount = 10;
+		const randomIndex = Math.floor(Math.random() * previewCount) + 1;
+		return `assets/img/preview/preview-${randomIndex}.jpg`;
+	}
 
 	private isInShares: boolean;
 	private isInApps: boolean;
@@ -243,6 +250,7 @@ export class FileListItemComponent
 	) {}
 
 	async ngOnInit() {
+		this.recordThumbnailUrl = GetThumbnail(this.item);
 		const date = new Date(this.item.displayDT);
 		this.date = getFormattedDate(date);
 
@@ -259,6 +267,9 @@ export class FileListItemComponent
 		}
 
 		if (this.router.routerState.snapshot.url.includes('/share/')) {
+			if (!this.isUnlistedShare) {
+				this.recordThumbnailUrl = this.getRandomPreviewImage();
+			}
 			this.allowActions = false;
 			this.isInSharePreview = true;
 		}


### PR DESCRIPTION
STEPS FOR TESTING

**Restricted share and not logged in**
1. Log in or create an account
2. Upload a single record
3. Create a share link with the link type restricted for the uploaded record
4. Copy the share link
5. Open a new window using the incognito mode
6. Paste the share link
EXPECTED: The thumbnail of the shared single record should be a random one, not the record's real image.

**Restricted share and logged in**
1. Log in or create an account
2. Upload a single record
3. Create a share link with the link type restricted for the uploaded record
4. Copy the share link
5. Open a new window
6. Log in or create a new account
7. Paste the share link
EXPECTED: The thumbnail of the shared single record should be a random one, not the record's real image.
8. Accept the share
EXPECTED: The thumbnail of the shared single record in the shared workspace should be the record's real image.

**Unlisted share and not logged in**
1. Log in or create an account
2. Upload a single record
3. Create a share link with the link type anyone-can-view for the uploaded record
4. Copy the share link
5. Open a new window using the incognito mode
6. Paste the share link
EXPECTED: The thumbnail of the shared single record should be the record's real image.

**Unlisted share and logged in**
1. Log in or create an account
2. Upload a single record
3. Create a share link with the link type anyone-can-view for the uploaded record
4. Copy the share link
5. Open a new window
6. Log in or create a new account
7. Paste the share link
EXPECTED: The thumbnail of the shared single record should be the record's real image.

Issue: PER-10489