### PR TITLE
[PER-10451] Functional improvements to archive switcher

### DIFF
--- a/src/app/share-preview/components/share-preview/share-preview.component.ts
+++ b/src/app/share-preview/components/share-preview/share-preview.component.ts
@@ -21,7 +21,7 @@ import { APP_CONFIG } from '@root/app/app.config';
 import { trimWhitespace, copyFromInputElement } from '@shared/utilities/forms';
 import { AuthResponse } from '@shared/services/api/index.repo';
 import { DeviceService } from '@shared/services/device/device.service';
-import { Subscription, Subject } from 'rxjs';
+import { Subscription, Subject, firstValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { GoogleAnalyticsService } from '@shared/services/google-analytics/google-analytics.service';
 import { EVENTS } from '@shared/services/google-analytics/events';
@@ -462,22 +462,27 @@ export class SharePreviewComponent implements OnInit, OnDestroy {
 	}
 
 	async onRequestAccessClick() {
-		let dialogRef;
 		try {
 			this.waiting = true;
 			if (!this.archiveConfirmed) {
-				dialogRef = await this.accountService.promptForArchiveChange(
+				const dialogRef = await this.accountService.promptForArchiveChange(
 					this.chooseArchiveText,
 				);
-				this.archiveConfirmed = true;
-			}
-			if (dialogRef) {
-				dialogRef.closed.subscribe(async () => {
+				if (dialogRef) {
+					const result = await firstValueFrom(dialogRef.closed);
+					if (result === 'cancel') {
+						this.showCover = false;
+						return;
+					}
+					this.archiveConfirmed = true;
 					await this.requestShareAccess();
-				});
-			} else {
-				await this.requestShareAccess();
+					if (result === 'switched') {
+						this.router.navigate(['/app', 'shares']);
+					}
+					return;
+				}
 			}
+			await this.requestShareAccess();
 		} catch (err) {
 			if (err instanceof ShareResponse) {
 				if (err.messageIncludesPhrase('share.already_exists')) {

--- a/src/app/shared/components/archive-small/archive-small.component.html
+++ b/src/app/shared/components/archive-small/archive-small.component.html
@@ -29,11 +29,19 @@
 				<br />Access: {{ accessRoleDisplay }}
 			</span>
 		}
-		@if (clickable && isCurrent) {
+		@if (accessRole && isCurrent && clickable) {
+			<span class="archive-subtitle">
+				<br />Access: {{ accessRoleDisplay }} &bull; Current archive
+			</span>
+		}
+		@if (!accessRole && clickable && isCurrent) {
 			<span class="archive-subtitle"> <br />Current Archive </span>
 		}
 	</div>
-	@if (showDefault && isDefaultArchive()) {
+	@if (clickable && !isCurrent) {
+		<i class="material-icons archive-chevron">chevron_right</i>
+	}
+	@if (showDefault && isDefaultArchive() && !clickable) {
 		<div
 			class="archive-default"
 			[ngbTooltip]="'This archive is the default archive for your account.'"

--- a/src/app/shared/components/archive-small/archive-small.component.scss
+++ b/src/app/shared/components/archive-small/archive-small.component.scss
@@ -5,8 +5,14 @@
 	align-items: center;
 
 	&:hover {
-		background-color: darken(white, 4%);
+		background-color: $gray-100;
 	}
+}
+
+.archive-chevron {
+	color: $gray-400;
+	flex: 0 0 auto;
+	margin-left: 4px;
 }
 
 .archive {

--- a/src/app/shared/components/archive-switcher/archive-switcher.component.html
+++ b/src/app/shared/components/archive-switcher/archive-switcher.component.html
@@ -1,13 +1,26 @@
 <div class="archive-list-wrapper">
 	<div class="archive-list">
-		<div class="archive-list-title">Select archive to request access:</div>
+		<div class="archive-list-title">
+			<span>Select archive to request access</span>
+			<button class="archive-list-close" (click)="cancelClick()">
+				<i class="material-icons archive-list-close-button">close</i>
+			</button>
+		</div>
 		@for (archive of archives; track archive) {
-			<pr-archive-small
-				[archive]="archive"
-				[accessRole]="archive.accessRole"
-				(click)="archiveClick(archive)"
+			<div
+				class="archive-list-row"
+				[class.archive-list-row--current]="
+					archive.archiveId === currentArchive?.archiveId
+				"
 			>
-			</pr-archive-small>
+				<pr-archive-small
+					[archive]="archive"
+					[accessRole]="archive.accessRole"
+					[clickable]="true"
+					(click)="archiveClick(archive)"
+				>
+				</pr-archive-small>
+			</div>
 		}
 		@if (!archivesLoading && !archives.length) {
 			<div class="archives-empty">You have no other archives</div>
@@ -20,8 +33,9 @@
 <div class="archive-list-button">
 	<button class="btn btn-primary" (click)="createArchiveClick()">
 		Create new archive
+		<i class="material-icons archive-list-button-approve-icon">inventory_2</i>
 	</button>
-	<button class="btn btn-primary" (click)="backButtonClick()">
-		Current Archive
+	<button class="btn btn-link cancel-button" (click)="cancelClick()">
+		Cancel
 	</button>
 </div>

--- a/src/app/shared/components/archive-switcher/archive-switcher.component.scss
+++ b/src/app/shared/components/archive-switcher/archive-switcher.component.scss
@@ -12,7 +12,7 @@
 	z-index: 4;
 	background-color: white;
 	text-align: center;
-	padding: 10px 10px 0px;
+	padding: 10px 0 0;
 
 	@include mainContentScrollDesktop;
 	@include desktop {
@@ -22,9 +22,32 @@
 }
 
 .archive-list-title {
-	padding: 10px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 16px;
 	margin-bottom: 10px;
 	font-weight: 600;
+	font-size: 17px;
+}
+
+.archive-list-close {
+	background: none;
+	border: none;
+	padding: 0;
+	padding-bottom: 1px;
+	cursor: pointer;
+	color: $gray-600;
+	display: flex;
+	align-items: center;
+
+	.archive-list-close-button {
+		font-size: 20px;
+	}
+
+	&:hover {
+		color: $gray-900;
+	}
 }
 
 .archive-list-wrapper {
@@ -42,16 +65,59 @@
 }
 
 .archive-list {
-	padding: 20px;
-	pr-archive-small {
-		margin-bottom: 20px;
+	padding-top: 8px;
+}
+
+.archive-list-row {
+	border-bottom: 1px solid $gray-200;
+	cursor: pointer;
+
+	&:first-of-type {
+		border-top: 1px solid $gray-200;
+	}
+
+	::ng-deep pr-archive-small {
+		padding: 12px 16px;
+	}
+
+	::ng-deep pr-archive-small:hover {
+		background-color: $gray-100;
+	}
+
+	&--current {
+		background-color: $PR-orange-lightest;
+
+		::ng-deep pr-archive-small:hover {
+			background-color: darken($PR-orange-lightest, 4%);
+		}
 	}
 }
 
 .archives-empty {
 	margin-top: 20px;
+	padding: 0 16px;
 }
 
 .archive-list-button {
-	width: 100%;
+	width: 90%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	.archive-list-button-approve-icon {
+		vertical-align: top;
+		font-size: 20px;
+		padding-left: 5px;
+	}
+}
+
+.cancel-button {
+	font-size: 16px;
+	color: $text-muted;
+	text-decoration: none;
+	margin: 0 0 10px 0;
+
+	&:hover {
+		text-decoration: underline;
+	}
 }

--- a/src/app/shared/components/archive-switcher/archive-switcher.component.spec.ts
+++ b/src/app/shared/components/archive-switcher/archive-switcher.component.spec.ts
@@ -6,12 +6,10 @@ import {
 } from '@angular/core/testing';
 import { AccountService } from '@shared/services/account/account.service';
 import { ApiService } from '@shared/services/api/api.service';
-import { DataService } from '@shared/services/data/data.service';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
 import { MessageService } from '@shared/services/message/message.service';
-import { Router } from '@angular/router';
-import { ArchiveVO, FolderVO } from '@root/app/models';
+import { ArchiveVO } from '@root/app/models';
 import { Component } from '@angular/core';
 import { DialogRef } from '@angular/cdk/dialog';
 import { ArchiveSwitcherComponent } from './archive-switcher.component';
@@ -19,7 +17,7 @@ import { ArchiveSwitcherComponent } from './archive-switcher.component';
 @Component({
 	selector: 'pr-archive-small',
 	template: '',
-	standalone: true, // ✅ This makes it standalone
+	standalone: true,
 })
 class MockArchiveSmallComponent {}
 
@@ -30,77 +28,77 @@ class MockArchiveSmallComponent {}
 })
 class MockLoadingSpinnerComponent {}
 
+const currentArchiveData = { archiveId: '123', fullName: 'Current Archive' };
+const otherArchiveData = { archiveId: '456', fullName: 'Other Archive' };
+
 describe('ArchiveSwitcherComponent', () => {
 	let component: ArchiveSwitcherComponent;
 	let fixture: ComponentFixture<ArchiveSwitcherComponent>;
-
-	const mockAccountService = {
-		getArchive: jasmine
-			.createSpy()
-			.and.returnValue(
-				new ArchiveVO({ archiveId: '123', fullName: 'Current Archive' }),
-			),
-		refreshArchives: jasmine.createSpy().and.returnValue(
-			Promise.resolve([
-				{ archiveId: '123', fullName: 'Current Archive' },
-				{ archiveId: '456', fullName: 'Other Archive' },
-			]),
-		),
-		setArchive: jasmine.createSpy(),
-		changeArchive: jasmine.createSpy().and.returnValue(Promise.resolve()),
-	};
-
-	const mockDialogRef = {
-		close: jasmine.createSpy(),
-	};
-
-	const mockApiService = {
-		archive: {
-			get: jasmine.createSpy().and.returnValue(
-				Promise.resolve({
-					getArchiveVO: () =>
-						new ArchiveVO({ archiveId: '789', fullName: 'New Archive' }),
-				}),
-			),
-			accept: jasmine.createSpy().and.returnValue(Promise.resolve()),
-			create: jasmine.createSpy().and.returnValue(
-				Promise.resolve({
-					getArchiveVO: () =>
-						new ArchiveVO({ archiveId: '789', fullName: 'New Archive' }),
-				}),
-			),
-		},
-	};
-
-	const mockDataService = {
-		setCurrentFolder: jasmine.createSpy(),
-	};
-
-	const mockPromptService = {
-		promptButtons: jasmine
-			.createSpy()
-			.and.returnValue(Promise.resolve('switch')),
-		prompt: jasmine.createSpy().and.returnValue(
-			Promise.resolve({
-				fullName: 'New Archive',
-				type: 'type.archive.person',
-			}),
-		),
-	};
-
-	const mockMessageService = {
-		showError: jasmine.createSpy(),
-	};
-
-	const mockRouter = {
-		navigate: jasmine.createSpy(),
-	};
-
-	const mockPrConstants = {
-		translate: jasmine.createSpy().and.returnValue('Translated Role'),
-	};
+	let mockAccountService: jasmine.SpyObj<AccountService>;
+	let mockDialogRef: { close: jasmine.Spy };
+	let mockApiService: any;
+	let mockPromptService: { promptButtons: jasmine.Spy; prompt: jasmine.Spy };
+	let mockMessageService: { showError: jasmine.Spy };
+	let mockPrConstants: { translate: jasmine.Spy };
 
 	beforeEach(async () => {
+		mockAccountService = jasmine.createSpyObj('AccountService', [
+			'getArchive',
+			'refreshArchives',
+			'setArchive',
+			'changeArchive',
+		]);
+		mockAccountService.getArchive.and.returnValue(
+			new ArchiveVO(currentArchiveData),
+		);
+		mockAccountService.refreshArchives.and.returnValue(
+			Promise.resolve([
+				new ArchiveVO(currentArchiveData),
+				new ArchiveVO(otherArchiveData),
+			]),
+		);
+		mockAccountService.setArchive.and.stub();
+		mockAccountService.changeArchive.and.returnValue(
+			Promise.resolve(new ArchiveVO(otherArchiveData)),
+		);
+
+		mockDialogRef = { close: jasmine.createSpy('close') };
+
+		mockApiService = {
+			archive: {
+				get: jasmine.createSpy('get').and.returnValue(
+					Promise.resolve({
+						getArchiveVO: () =>
+							new ArchiveVO({ archiveId: '789', fullName: 'New Archive' }),
+					}),
+				),
+				accept: jasmine.createSpy('accept').and.returnValue(Promise.resolve()),
+				create: jasmine.createSpy('create').and.returnValue(
+					Promise.resolve({
+						getArchiveVO: () =>
+							new ArchiveVO({ archiveId: '789', fullName: 'New Archive' }),
+					}),
+				),
+			},
+		};
+
+		mockPromptService = {
+			promptButtons: jasmine
+				.createSpy('promptButtons')
+				.and.returnValue(Promise.resolve('switch')),
+			prompt: jasmine.createSpy('prompt').and.returnValue(
+				Promise.resolve({
+					fullName: 'New Archive',
+					type: 'type.archive.person',
+				}),
+			),
+		};
+
+		mockMessageService = { showError: jasmine.createSpy('showError') };
+		mockPrConstants = {
+			translate: jasmine.createSpy('translate').and.returnValue('Owner'),
+		};
+
 		await TestBed.configureTestingModule({
 			declarations: [ArchiveSwitcherComponent],
 			imports: [MockArchiveSmallComponent, MockLoadingSpinnerComponent],
@@ -108,11 +106,9 @@ describe('ArchiveSwitcherComponent', () => {
 				{ provide: AccountService, useValue: mockAccountService },
 				{ provide: DialogRef, useValue: mockDialogRef },
 				{ provide: ApiService, useValue: mockApiService },
-				{ provide: DataService, useValue: mockDataService },
 				{ provide: PrConstantsService, useValue: mockPrConstants },
 				{ provide: PromptService, useValue: mockPromptService },
 				{ provide: MessageService, useValue: mockMessageService },
-				{ provide: Router, useValue: mockRouter },
 			],
 		}).compileComponents();
 
@@ -124,114 +120,250 @@ describe('ArchiveSwitcherComponent', () => {
 		expect(component).toBeTruthy();
 	});
 
-	it('should initialize and load archives', fakeAsync(() => {
-		component.ngOnInit();
-		tick();
+	describe('ngOnInit', () => {
+		it('should load all archives including the current one', fakeAsync(() => {
+			component.ngOnInit();
+			tick();
 
-		expect(mockDataService.setCurrentFolder).toHaveBeenCalledWith(
-			jasmine.any(FolderVO),
-		);
+			expect(mockAccountService.refreshArchives).toHaveBeenCalled();
+			expect(component.archives.length).toBe(2);
+			expect(component.archivesLoading).toBeFalse();
+		}));
 
-		expect(mockAccountService.refreshArchives).toHaveBeenCalled();
-		expect(component.archives.length).toBe(1);
-		expect(component.archivesLoading).toBeFalse();
-	}));
+		it('should update and re-set the current archive from the fetched list', fakeAsync(() => {
+			component.ngOnInit();
+			tick();
 
-	it('should trigger animation in ngAfterViewInit', () => {
-		const mockNodeList: NodeListOf<Element> = {
-			length: 1,
-			item: () => document.createElement('div'),
-			0: document.createElement('div'),
-			forEach: (callback) =>
-				callback(document.createElement('div'), 0, mockNodeList),
-		} as unknown as NodeListOf<Element>;
+			expect(mockAccountService.setArchive).toHaveBeenCalledWith(
+				component.currentArchive,
+			);
+		}));
 
-		spyOn(document, 'querySelectorAll').and.returnValue(mockNodeList);
-		component.ngAfterViewInit();
+		it('should not call setArchive when current archive is not in the fetched list', fakeAsync(() => {
+			mockAccountService.getArchive.and.returnValue(
+				new ArchiveVO({ archiveId: '999', fullName: 'Unknown' }),
+			);
+			component.ngOnInit();
+			tick();
 
-		expect(document.querySelectorAll).toHaveBeenCalledWith(
-			'.archive-list pr-archive-small',
-		);
+			expect(mockAccountService.setArchive).not.toHaveBeenCalled();
+		}));
+
+		it('should not call DataService.setCurrentFolder', fakeAsync(() => {
+			const dataServiceSpy = jasmine.createSpyObj('DataService', [
+				'setCurrentFolder',
+			]);
+			component.ngOnInit();
+			tick();
+
+			expect(dataServiceSpy.setCurrentFolder).not.toHaveBeenCalled();
+		}));
 	});
 
-	it('should handle archiveClick and switch archive', fakeAsync(() => {
-		const archive = new ArchiveVO({
-			archiveId: '456',
-			fullName: 'Other Archive',
+	describe('archiveClick', () => {
+		it('should close the dialog without a value when clicking the current archive', () => {
+			const currentArchive = new ArchiveVO(currentArchiveData);
+			component.currentArchive = currentArchive;
+
+			component.archiveClick(currentArchive);
+
+			expect(mockDialogRef.close).toHaveBeenCalledWith();
+			expect(mockPromptService.promptButtons).not.toHaveBeenCalled();
 		});
-		spyOn(archive, 'isPending').and.returnValue(false);
 
-		component.archiveClick(archive);
-		tick();
+		it('should show a confirmation prompt when clicking a different archive', fakeAsync(() => {
+			component.currentArchive = new ArchiveVO(currentArchiveData);
+			const otherArchive = new ArchiveVO(otherArchiveData);
+			spyOn(otherArchive, 'isPending').and.returnValue(false);
 
-		expect(mockPromptService.promptButtons).toHaveBeenCalled();
-		expect(mockAccountService.changeArchive).toHaveBeenCalledWith(archive);
-		expect(mockDialogRef.close).toHaveBeenCalled();
-		expect(mockRouter.navigate).toHaveBeenCalledWith(['/private']);
-	}));
+			component.archiveClick(otherArchive);
+			tick();
 
-	it('should handle createArchiveClick and push new archive', fakeAsync(() => {
-		spyOn(component, 'archiveClick');
-		component.createArchiveClick();
-		tick();
+			expect(mockPromptService.promptButtons).toHaveBeenCalled();
+		}));
 
-		expect(mockPromptService.prompt).toHaveBeenCalled();
-		expect(mockApiService.archive.create).toHaveBeenCalled();
-		expect(component.archives.length).toBe(1);
-		expect(component.archiveClick).toHaveBeenCalled();
-	}));
+		it('should call changeArchive and close with "switched" on confirm', fakeAsync(() => {
+			component.currentArchive = new ArchiveVO(currentArchiveData);
+			const otherArchive = new ArchiveVO(otherArchiveData);
+			spyOn(otherArchive, 'isPending').and.returnValue(false);
+			mockPromptService.promptButtons.and.returnValue(
+				Promise.resolve('switch'),
+			);
 
-	it('should show empty message when no archives and not loading', () => {
-		component.archives = [];
-		component.archivesLoading = false;
-		fixture.detectChanges();
+			component.archiveClick(otherArchive);
+			tick();
 
-		const emptyMessage = fixture.nativeElement.querySelector('.archives-empty');
+			expect(mockAccountService.changeArchive).toHaveBeenCalledWith(
+				otherArchive,
+			);
 
-		expect(emptyMessage).toBeTruthy();
-		expect(emptyMessage.textContent).toContain('You have no other archives');
+			expect(mockDialogRef.close).toHaveBeenCalledWith('switched');
+		}));
+
+		it('should not call changeArchive when the confirmation prompt is cancelled', fakeAsync(() => {
+			component.currentArchive = new ArchiveVO(currentArchiveData);
+			const otherArchive = new ArchiveVO(otherArchiveData);
+			spyOn(otherArchive, 'isPending').and.returnValue(false);
+			mockPromptService.promptButtons.and.returnValue(
+				Promise.resolve('cancel'),
+			);
+
+			component.archiveClick(otherArchive);
+			tick();
+
+			expect(mockAccountService.changeArchive).not.toHaveBeenCalled();
+			expect(mockDialogRef.close).not.toHaveBeenCalled();
+		}));
+
+		it('should call accept before changeArchive for a pending archive', fakeAsync(() => {
+			component.currentArchive = new ArchiveVO(currentArchiveData);
+			const pendingArchive = new ArchiveVO({
+				archiveId: '789',
+				fullName: 'Pending Archive',
+			});
+			spyOn(pendingArchive, 'isPending').and.returnValue(true);
+			mockPromptService.promptButtons.and.returnValue(
+				Promise.resolve('switch'),
+			);
+
+			component.archiveClick(pendingArchive);
+			tick();
+
+			expect(mockApiService.archive.accept).toHaveBeenCalledWith(
+				pendingArchive,
+			);
+
+			expect(mockAccountService.changeArchive).toHaveBeenCalledWith(
+				pendingArchive,
+			);
+
+			expect(mockDialogRef.close).toHaveBeenCalledWith('switched');
+		}));
+
+		it('should show an error message when changeArchive fails', fakeAsync(() => {
+			component.currentArchive = new ArchiveVO(currentArchiveData);
+			const otherArchive = new ArchiveVO(otherArchiveData);
+			spyOn(otherArchive, 'isPending').and.returnValue(false);
+			mockPromptService.promptButtons.and.returnValue(
+				Promise.resolve('switch'),
+			);
+			mockAccountService.changeArchive.and.returnValue(
+				Promise.reject({
+					getMessage: () => 'Switch failed',
+				}) as Promise<ArchiveVO>,
+			);
+
+			component.archiveClick(otherArchive);
+			tick();
+
+			expect(mockMessageService.showError).toHaveBeenCalledWith({
+				message: 'Switch failed',
+				translate: true,
+			});
+
+			expect(mockDialogRef.close).not.toHaveBeenCalled();
+		}));
 	});
 
-	it('should show loading spinner when archivesLoading is true', () => {
-		component.archivesLoading = true;
-		fixture.detectChanges();
+	describe('cancelClick', () => {
+		it('should close the dialog with "cancel"', () => {
+			component.cancelClick();
 
-		const spinner = fixture.nativeElement.querySelector(
-			'pr-basic-loading-spinner',
-		);
+			expect(mockDialogRef.close).toHaveBeenCalledWith('cancel');
+		});
 
-		expect(spinner).toBeTruthy();
+		it('should trigger cancelClick when the close button is clicked', () => {
+			spyOn(component, 'cancelClick');
+			fixture.detectChanges();
+
+			const closeButton = fixture.nativeElement.querySelector(
+				'.archive-list-close',
+			);
+			closeButton.click();
+
+			expect(component.cancelClick).toHaveBeenCalled();
+		});
+
+		it('should trigger cancelClick when the Cancel text button is clicked', () => {
+			spyOn(component, 'cancelClick');
+			fixture.detectChanges();
+
+			const cancelButton =
+				fixture.nativeElement.querySelector('.cancel-button');
+			cancelButton.click();
+
+			expect(component.cancelClick).toHaveBeenCalled();
+		});
 	});
 
-	it('should render archive items when archives are present', fakeAsync(() => {
-		component.archives = [
-			new ArchiveVO({ archiveId: '1', fullName: 'Archive One' }),
-			new ArchiveVO({ archiveId: '2', fullName: 'Archive Two' }),
-		];
-		component.archivesLoading = false;
-		fixture.detectChanges();
+	describe('template', () => {
+		it('should show loading spinner when archivesLoading is true', () => {
+			component.archivesLoading = true;
+			fixture.detectChanges();
 
-		const archiveItems =
-			fixture.nativeElement.querySelectorAll('pr-archive-small');
+			const spinner = fixture.nativeElement.querySelector(
+				'pr-basic-loading-spinner',
+			);
 
-		expect(archiveItems.length).toBe(2);
-	}));
+			expect(spinner).toBeTruthy();
+		});
 
-	it('should call createArchiveClick on button click', () => {
-		spyOn(component, 'createArchiveClick');
-		fixture.detectChanges();
+		it('should show empty message when no archives and not loading', () => {
+			component.archives = [];
+			component.archivesLoading = false;
+			fixture.detectChanges();
 
-		const buttons = fixture.nativeElement.querySelectorAll(
-			'.archive-list-button button',
-		);
-		buttons[0].click();
+			const emptyMessage =
+				fixture.nativeElement.querySelector('.archives-empty');
 
-		expect(component.createArchiveClick).toHaveBeenCalled();
-	});
+			expect(emptyMessage.textContent).toContain('You have no other archives');
+		});
 
-	it('should close the dialog when backButtonClick is called', () => {
-		component.backButtonClick();
+		it('should render one row per archive', () => {
+			component.archives = [
+				new ArchiveVO({ archiveId: '1', fullName: 'Archive One' }),
+				new ArchiveVO({ archiveId: '2', fullName: 'Archive Two' }),
+			];
+			component.archivesLoading = false;
+			fixture.detectChanges();
 
-		expect(mockDialogRef.close).toHaveBeenCalled();
+			const rows = fixture.nativeElement.querySelectorAll('.archive-list-row');
+
+			expect(rows.length).toBe(2);
+		});
+
+		it('should apply archive-list-row--current to the current archive row', () => {
+			const currentArchiveId = mockAccountService.getArchive().archiveId;
+			component.currentArchive = new ArchiveVO({
+				archiveId: currentArchiveId,
+				fullName: 'Current Archive',
+			});
+			component.archives = [
+				new ArchiveVO({
+					archiveId: currentArchiveId,
+					fullName: 'Current Archive',
+				}),
+				new ArchiveVO({ archiveId: '456', fullName: 'Other Archive' }),
+			];
+			component.archivesLoading = false;
+			fixture.detectChanges();
+
+			const rows = fixture.nativeElement.querySelectorAll('.archive-list-row');
+
+			expect(rows[0].classList).toContain('archive-list-row--current');
+			expect(rows[1].classList).not.toContain('archive-list-row--current');
+		});
+
+		it('should call createArchiveClick when the create button is clicked', () => {
+			spyOn(component, 'createArchiveClick');
+			fixture.detectChanges();
+
+			const buttons = fixture.nativeElement.querySelectorAll(
+				'.archive-list-button button',
+			);
+			buttons[0].click();
+
+			expect(component.createArchiveClick).toHaveBeenCalled();
+		});
 	});
 });

--- a/src/app/shared/components/archive-switcher/archive-switcher.component.ts
+++ b/src/app/shared/components/archive-switcher/archive-switcher.component.ts
@@ -1,7 +1,7 @@
 import { Component, AfterViewInit, OnInit } from '@angular/core';
 import { Validators } from '@angular/forms';
 
-import { remove, orderBy } from 'lodash';
+import { orderBy } from 'lodash';
 import { gsap } from 'gsap';
 
 import { AccountService } from '@shared/services/account/account.service';
@@ -12,14 +12,12 @@ import {
 } from '@shared/services/prompt/prompt.service';
 import { MessageService } from '@shared/services/message/message.service';
 
-import { ArchiveVO, FolderVO } from '@root/app/models';
+import { ArchiveVO } from '@root/app/models';
 import { BaseResponse } from '@shared/services/api/base';
 import { ApiService } from '@shared/services/api/api.service';
 import { ArchiveResponse } from '@shared/services/api/index.repo';
 import { PrConstantsService } from '@shared/services/pr-constants/pr-constants.service';
 import { RELATIONSHIP_FIELD } from '@shared/components/prompt/prompt-fields';
-import { DataService } from '@shared/services/data/data.service';
-import { Router } from '@angular/router';
 import { DialogRef } from '@angular/cdk/dialog';
 
 @Component({
@@ -37,36 +35,30 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
 		private accountService: AccountService,
 		private dialogRef: DialogRef,
 		private api: ApiService,
-		private data: DataService,
 		private prConstants: PrConstantsService,
 		private prompt: PromptService,
 		private message: MessageService,
-		private router: Router,
 	) {}
 
 	async ngOnInit() {
-		this.data.setCurrentFolder(
-			new FolderVO({
-				displayName: 'Archives',
-				pathAsText: ['Archives'],
-				type: 'page',
-			}),
-		);
 		this.currentArchive = this.accountService.getArchive();
 
 		const archivesData = await this.accountService.refreshArchives();
 		const archives = orderBy(
 			archivesData.map((archiveData) => new ArchiveVO(archiveData)),
 			'fullName',
+		) as ArchiveVO[];
+
+		const currentArchiveFetched = archives.find(
+			(a) => a.archiveId === this.currentArchive.archiveId,
 		);
-		const currentArchiveFetched = remove(archives, {
-			archiveId: this.currentArchive.archiveId,
-		})[0] as ArchiveVO;
 
-		this.currentArchive.update(currentArchiveFetched);
-		this.accountService.setArchive(this.currentArchive);
+		if (currentArchiveFetched) {
+			this.currentArchive.update(currentArchiveFetched);
+			this.accountService.setArchive(this.currentArchive);
+		}
 
-		this.archives = archives as ArchiveVO[];
+		this.archives = archives;
 		this.archivesLoading = false;
 	}
 
@@ -85,6 +77,11 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
 	}
 
 	archiveClick(archive: ArchiveVO) {
+		if (archive.archiveId === this.currentArchive.archiveId) {
+			this.dialogRef.close();
+			return;
+		}
+
 		const { promise, resolve } = Promise.withResolvers();
 
 		const buttons: PromptButton[] = [
@@ -123,8 +120,7 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
 					.then(async () => await this.accountService.changeArchive(archive))
 					.then(() => {
 						resolve(undefined);
-						this.dialogRef.close();
-						this.router.navigate(['/private']);
+						this.dialogRef.close('switched');
 					})
 					.catch((response: BaseResponse) => {
 						resolve(undefined);
@@ -207,7 +203,7 @@ export class ArchiveSwitcherComponent implements OnInit, AfterViewInit {
 			});
 	}
 
-	backButtonClick() {
-		this.dialogRef.close();
+	cancelClick() {
+		this.dialogRef.close('cancel');
 	}
 }


### PR DESCRIPTION
STEPS TO TEST:

**See the new design of the add to archive modal**
1. Log in to an existing account or create a new one
2. Upload a new file or add a new folder
3. Click the new file or folder and from the sidebar, open the share modal
4. Create a share link and select the restricted link type option
5. Copy the newly created link
6. In a different browser window, log in to another account or create a new one
7. After logging in, click on the email and from the dropdown choose Archives
8. Create multiple new archives
9. In the current browser window, paste the restricted share link
10. Click the "Accept share" button from the sticky footer.
EXPECTED: A modal will appear: 
 - The title: "Select archive to request access"
 - The list of all archives from the current account
 - The currently selected archive will have an orange background
 - There will be a "Create new archive" button
 - There will be a Cancel button
 
 **Click the cancel button**
 
 1. Follow the previous steps from **See the new design of the add to archive modal**
 2. Click the cancel button
 EXPECTED: The modal will disappear and the sticky footer with the "Accept share" button will appear again
 
 **Accept share in the current archive**
 1. Follow the previous steps from **See the new design of the add to archive modal**
 2. Click the current archive, the one with the orange background.
 EXPECTED: The modal will close and the user will be redirected to his share workspace, of his currently selected archive.
 
  **Accept share in a different archive**
 1. Follow the previous steps from **See the new design of the add to archive modal**
 2. Click any archive from the list, except the current one, that has an orange background.
 EXPECTED: A small modal appears on top of the archives one, with the buttons "Switch archive" and cancel.
 3. Click the "Switch archive" button
 EXPECTED: The modal will close and the user will be redirected to his share workspace, of the archive that has been selected in the modal.
 
  **Accept share in a newly created archive**
1. Follow the previous steps from **See the new design of the add to archive modal**
2. Click the "Create new archive" button
EXPECTED: The create new archive modal will appear.
3. Fill the form.
4. Click "Create archive"
EXPECTED: The "Switch archive" modal will appear.
5. Click the "Switch archive" button
EXPECTED: The modal will close and the user will be redirected to his share workspace, of the archive that has been created.
 
 