### PR TITLE
PER-10549: Convert double slashes to fix prod routing

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import {
 	NavigationEnd,
 	ActivatedRoute,
 	NavigationStart,
+	UrlSerializer,
 } from '@angular/router';
 import {
 	HttpErrorResponse,
@@ -50,6 +51,7 @@ import { EventService } from '@shared/services/event/event.service';
 import { DataService } from '@shared/services/data/data.service';
 import { OverlayContainer, OVERLAY_DEFAULT_CONFIG } from '@angular/cdk/overlay';
 import { DEFAULT_DIALOG_CONFIG, DialogConfig } from '@angular/cdk/dialog';
+import { DoubleSlashUrlSerializer } from './double-slash-url-serializer';
 import { RouteHistoryModule } from './route-history/route-history.module';
 import { CustomOverlayContainer } from './dialog-cdk/custom-overlay-container';
 import { FeatureFlagModule } from './feature-flag/feature-flag.module';
@@ -195,6 +197,10 @@ export class PermErrorHandler implements ErrorHandler {
 		{
 			provide: APP_BASE_HREF,
 			useValue: '/',
+		},
+		{
+			provide: UrlSerializer,
+			useClass: DoubleSlashUrlSerializer,
 		},
 		provideHttpClient(withInterceptorsFromDi(), withJsonpSupport()),
 	],

--- a/src/app/double-slash-url-serializer.spec.ts
+++ b/src/app/double-slash-url-serializer.spec.ts
@@ -1,0 +1,62 @@
+import { DoubleSlashUrlSerializer } from './double-slash-url-serializer';
+
+describe('DoubleSlashUrlSerializer', () => {
+	let serializer: DoubleSlashUrlSerializer;
+
+	beforeEach(() => {
+		serializer = new DoubleSlashUrlSerializer();
+	});
+
+	describe('serialize', () => {
+		it('encodes // as /__/ in auxiliary outlet URLs', () => {
+			const tree = serializer.parse('/app/(private//dialog:storage/add)');
+
+			expect(serializer.serialize(tree)).toBe(
+				'/app/(private/__/dialog:storage/add)',
+			);
+		});
+
+		it('leaves URLs without auxiliary outlets unchanged', () => {
+			const tree = serializer.parse('/app/private');
+
+			expect(serializer.serialize(tree)).toBe('/app/private');
+		});
+
+		it('does not encode // in query parameter values', () => {
+			const tree = serializer.parse('/app/private?redirect=http://example.com');
+
+			expect(serializer.serialize(tree)).not.toContain('/__/');
+		});
+	});
+
+	describe('parse', () => {
+		it('decodes /__/ back to // before parsing', () => {
+			const withEncoded = serializer.parse(
+				'/app/(private/__/dialog:storage/add)',
+			);
+			const withRaw = serializer.parse('/app/(private//dialog:storage/add)');
+
+			expect(serializer.serialize(withEncoded)).toBe(
+				serializer.serialize(withRaw),
+			);
+		});
+
+		it('leaves URLs without /__/ unchanged', () => {
+			const tree = serializer.parse('/app/private');
+
+			expect(serializer.serialize(tree)).toBe('/app/private');
+		});
+	});
+
+	describe('round-trip', () => {
+		it('parse(serialize(tree)) produces an equivalent tree', () => {
+			const original =
+				'/app/(private//dialog:storage/add)?promoCode=TellYourStory';
+			const tree = serializer.parse(original);
+			const serialized = serializer.serialize(tree);
+			const reparsed = serializer.parse(serialized);
+
+			expect(serializer.serialize(reparsed)).toBe(serialized);
+		});
+	});
+});

--- a/src/app/double-slash-url-serializer.ts
+++ b/src/app/double-slash-url-serializer.ts
@@ -1,0 +1,15 @@
+import { DefaultUrlSerializer, UrlTree } from '@angular/router';
+
+// Angular serializes auxiliary outlet routes with //, e.g. /app/(primary//dialog:path).
+// Some servers (e.g. WP Engine redirect rules) normalize // to / before matching,
+// breaking 301 redirects. This serializer encodes // as /__/ in the URL so it
+// survives server-side normalization, and decodes it back when parsing.
+export class DoubleSlashUrlSerializer extends DefaultUrlSerializer {
+	override parse(url: string): UrlTree {
+		return super.parse(url.replace(/\/__\/(\w+:)/g, '//$1'));
+	}
+
+	override serialize(tree: UrlTree): string {
+		return super.serialize(tree).replace(/\/\/(\w+:)/g, '/__/$1');
+	}
+}


### PR DESCRIPTION
We use double slashes in Angular routing which WPEngine is collapsing with nginx's `merge_slashes` setting, making some urls unreachable. Notably, this affects the "redeem your promo code" link we send in our welcome email. This is a heavily Claude-guided remediation effort, so please tell me about any better way to do this, @aasandei-vsp!