### PR TITLE
PER-10504: Show meaningful error

### DIFF
--- a/src/app/apps/components/connector/connector.component.ts
+++ b/src/app/apps/components/connector/connector.component.ts
@@ -200,7 +200,7 @@ export class ConnectorComponent implements OnInit {
 			this.waiting = false;
 			this.connector.status = 'status.connector.disconnected';
 			this.setStatus();
-			this.message.showError(response.getMessage());
+			this.message.showError({ message: response.getMessage() });
 		}
 	}
 

--- a/src/app/file-browser/components/publish/publish.component.ts
+++ b/src/app/file-browser/components/publish/publish.component.ts
@@ -115,7 +115,16 @@ export class PublishComponent {
 			});
 		} catch (err) {
 			if (err.getMessage) {
-				this.messageService.showError(err.getMessage());
+				if (err.getMessage() == 'warning.record.copy_status') {
+					this.messageService.showError({
+						message:
+							'Sorry, this record cannot be copied or published until processing completes.',
+					});
+				} else {
+					this.messageService.showError({
+						message: err.getMessage(),
+					});
+				}
 			}
 		} finally {
 			this.waiting = false;

--- a/src/app/file-browser/components/sharing/sharing.component.ts
+++ b/src/app/file-browser/components/sharing/sharing.component.ts
@@ -427,7 +427,7 @@ export class SharingComponent implements OnInit {
 					} catch (response) {
 						reject();
 						if (response.getMessage()) {
-							this.messageService.showError(response.getMessage());
+							this.messageService.showError({ message: response.getMessage() });
 						}
 					}
 				},


### PR DESCRIPTION
Fix the syntax for showing an error. Also add a human-meaningful error for the most common copy error. Otherwise, display the response from the backend.

To reproduce the original "empty error" bug, I uploaded a 28 MB video 3 times with only the default 100 MB of storage. Then I tried to publish one of the videos and got the error bar with no text. The message from the backend says `["warning.record.copy_status" ]`. It looks like this is actually a processing-related failure, so I could have just uploaded it once. Basically, upload something that is likely to take a long time to process (or fail entirely) and then immediately try to publish it. Alternatively, if you have database access, change the `status` of a record to something that isn't `status.generic.ok` and try to publish it (or copy it) and you should see the empty error bar without this fix. After this fix, you should see "Sorry, this record cannot be copied or published until processing completes." (Text to be confirmed by QA.)