### PR TITLE
[PER-10415] New date editing full screen

### DIFF
--- a/src/app/core/services/edit/edit.service.spec.ts
+++ b/src/app/core/services/edit/edit.service.spec.ts
@@ -445,6 +445,77 @@ describe('EditService', () => {
 		expect(apiService.folder.getStelaFolderVOs).not.toHaveBeenCalled();
 	});
 
+	it('should revert property and show error when updateStelaRecord fails', async () => {
+		const messageService = TestBed.inject(MessageService);
+		spyOn(messageService, 'showError');
+
+		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
+		const httpError = {
+			error: { message: 'Invalid date format' },
+			message: 'Http failure',
+		};
+
+		(apiService.record.updateStelaRecord as jasmine.Spy).and.returnValue(
+			Promise.reject(httpError),
+		);
+		(apiService.record.update as jasmine.Spy).and.returnValue(
+			Promise.resolve([]),
+		);
+
+		await service.saveItemVoProperty(record, 'displayTime', 'new-value');
+
+		expect(record.displayTime).toBe('original-value');
+		expect(messageService.showError).toHaveBeenCalledWith({
+			message: 'Invalid date format',
+		});
+	});
+
+	it('should show fallback error when updateStelaRecord fails without error body', async () => {
+		const messageService = TestBed.inject(MessageService);
+		spyOn(messageService, 'showError');
+
+		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
+
+		(apiService.record.updateStelaRecord as jasmine.Spy).and.returnValue(
+			Promise.reject({}),
+		);
+		(apiService.record.update as jasmine.Spy).and.returnValue(
+			Promise.resolve([]),
+		);
+
+		await service.saveItemVoProperty(record, 'displayTime', 'new-value');
+
+		expect(record.displayTime).toBe('original-value');
+		expect(messageService.showError).toHaveBeenCalledWith({
+			message: 'Failed to save changes',
+		});
+	});
+
+	it('should revert property and show error when updateStelaFolder fails', async () => {
+		const messageService = TestBed.inject(MessageService);
+		spyOn(messageService, 'showError');
+
+		const folder = new FolderVO({ folderId: 1, displayTime: 'original-value' });
+		const httpError = { error: { error: 'Invalid EDTF string' } };
+
+		(apiService.folder.updateStelaFolder as jasmine.Spy).and.returnValue(
+			Promise.reject(httpError),
+		);
+		(apiService.folder.update as jasmine.Spy).and.returnValue(
+			Promise.resolve({}),
+		);
+		(apiService.folder.getStelaFolderVOs as jasmine.Spy).and.returnValue(
+			Promise.resolve({ getFolderVOs: () => [] }),
+		);
+
+		await service.saveItemVoProperty(folder, 'displayTime', 'new-value');
+
+		expect(folder.displayTime).toBe('original-value');
+		expect(messageService.showError).toHaveBeenCalledWith({
+			message: 'Invalid EDTF string',
+		});
+	});
+
 	describe('openShareDialog', () => {
 		const mockShareLink: ShareLink = {
 			id: 'link1',

--- a/src/app/core/services/edit/edit.service.spec.ts
+++ b/src/app/core/services/edit/edit.service.spec.ts
@@ -445,9 +445,10 @@ describe('EditService', () => {
 		expect(apiService.folder.getStelaFolderVOs).not.toHaveBeenCalled();
 	});
 
-	it('should revert property and show error when updateStelaRecord fails', async () => {
+	it('should revert property and show a translatable generic error when updateStelaRecord fails', async () => {
 		const messageService = TestBed.inject(MessageService);
 		spyOn(messageService, 'showError');
+		const consoleErrorSpy = spyOn(console, 'error');
 
 		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
 		const httpError = {
@@ -466,13 +467,20 @@ describe('EditService', () => {
 
 		expect(record.displayTime).toBe('original-value');
 		expect(messageService.showError).toHaveBeenCalledWith({
-			message: 'Invalid date format',
+			message: 'error.generic.update_fail',
+			translate: true,
 		});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Failed to save item property',
+			httpError,
+		);
 	});
 
-	it('should show fallback error when updateStelaRecord fails without error body', async () => {
+	it('should show a translatable generic error when updateStelaRecord fails without error body', async () => {
 		const messageService = TestBed.inject(MessageService);
 		spyOn(messageService, 'showError');
+		spyOn(console, 'error');
 
 		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
 
@@ -487,13 +495,15 @@ describe('EditService', () => {
 
 		expect(record.displayTime).toBe('original-value');
 		expect(messageService.showError).toHaveBeenCalledWith({
-			message: 'Failed to save changes',
+			message: 'error.generic.update_fail',
+			translate: true,
 		});
 	});
 
-	it('should revert property and show error when updateStelaFolder fails', async () => {
+	it('should revert property and show a translatable generic error when updateStelaFolder fails', async () => {
 		const messageService = TestBed.inject(MessageService);
 		spyOn(messageService, 'showError');
+		spyOn(console, 'error');
 
 		const folder = new FolderVO({ folderId: 1, displayTime: 'original-value' });
 		const httpError = { error: { error: 'Invalid EDTF string' } };
@@ -512,7 +522,8 @@ describe('EditService', () => {
 
 		expect(folder.displayTime).toBe('original-value');
 		expect(messageService.showError).toHaveBeenCalledWith({
-			message: 'Invalid EDTF string',
+			message: 'error.generic.update_fail',
+			translate: true,
 		});
 	});
 

--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -366,12 +366,10 @@ export class EditService {
 						translate: true,
 					});
 				} else {
+					console.error('Failed to save item property', err);
 					this.message.showError({
-						message:
-							err?.error?.message ||
-							err?.error?.error ||
-							err?.message ||
-							'Failed to save changes',
+						message: 'error.generic.update_fail',
+						translate: true,
 					});
 				}
 			}

--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -356,10 +356,23 @@ export class EditService {
 				item.update(newData);
 				await this.updateItems([item], [property]);
 			} catch (err) {
+				const revertData: Partial<ItemVO> = {};
+				revertData[property] = originalValue;
+				item.update(revertData);
+
 				if (err instanceof FolderResponse || err instanceof RecordResponse) {
-					const revertData: Partial<ItemVO> = {};
-					revertData[property] = originalValue;
-					item.update(revertData);
+					this.message.showError({
+						message: err.getMessage(),
+						translate: true,
+					});
+				} else {
+					this.message.showError({
+						message:
+							err?.error?.message ||
+							err?.error?.error ||
+							err?.message ||
+							'Failed to save changes',
+					});
 				}
 			}
 		}

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.html
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.html
@@ -1,0 +1,179 @@
+<div class="pr-edit-date-time-dialog">
+	<div class="pr-dialog-header">
+		<h2>Edit date and time</h2>
+		<button class="pr-close-button" (click)="onCancel()">
+			<i class="material-icons">close</i>
+		</button>
+	</div>
+
+	<div class="pr-dialog-content">
+		<div class="pr-date-card">
+			<div class="pr-card-header">
+				<span class="pr-card-label">Start date:</span>
+
+				<div class="pr-qualifiers-row">
+					<div class="pr-qualifier-option">
+						<span>Approximate</span>
+						<label class="pr-toggle">
+							<input
+								type="checkbox"
+								[checked]="qualifiers().approximate"
+								[disabled]="startFieldsDisabled()"
+								(change)="onQualifierChange(DateQualifier.Approximate, false)"
+							/>
+							<span class="pr-toggle-slider"></span>
+						</label>
+					</div>
+
+					<div class="pr-qualifier-option">
+						<span>Uncertain</span>
+						<label class="pr-toggle">
+							<input
+								type="checkbox"
+								[checked]="qualifiers().uncertain"
+								[disabled]="startFieldsDisabled()"
+								(change)="onQualifierChange(DateQualifier.Uncertain, false)"
+							/>
+							<span class="pr-toggle-slider"></span>
+						</label>
+					</div>
+
+					<div class="pr-qualifier-option">
+						<span>Unknown</span>
+						<label class="pr-toggle">
+							<input
+								type="checkbox"
+								[checked]="qualifiers().unknown"
+								(change)="onQualifierChange(DateQualifier.Unknown, false)"
+							/>
+							<span class="pr-toggle-slider"></span>
+						</label>
+					</div>
+				</div>
+			</div>
+
+			<div class="pr-datetime-row" [class.disabled]="startFieldsDisabled()">
+				<pr-datepicker-input
+					[date]="date()"
+					[disabled]="startFieldsDisabled()"
+					(dateChange)="date.set($event)"
+				/>
+
+				<pr-timepicker-input
+					[time]="time()"
+					[disabled]="startFieldsDisabled()"
+					(timeChange)="onTimeChange($event, time)"
+				/>
+			</div>
+
+			<button class="pr-clear-link" (click)="clearStart()">
+				<i class="material-icons">backspace</i>
+				<span>Clear start date and time</span>
+			</button>
+		</div>
+
+		@if (useDateRange()) {
+			<div class="pr-date-card">
+				<div class="pr-card-header">
+					<span class="pr-card-label">End date:</span>
+
+					<div class="pr-qualifiers-row">
+						<div class="pr-qualifier-option">
+							<span>Approximate</span>
+							<label class="pr-toggle">
+								<input
+									type="checkbox"
+									[checked]="endQualifiers().approximate"
+									[disabled]="endFieldsDisabled()"
+									(change)="onQualifierChange(DateQualifier.Approximate, true)"
+								/>
+								<span class="pr-toggle-slider"></span>
+							</label>
+						</div>
+
+						<div class="pr-qualifier-option">
+							<span>Uncertain</span>
+							<label class="pr-toggle">
+								<input
+									type="checkbox"
+									[checked]="endQualifiers().uncertain"
+									[disabled]="endFieldsDisabled()"
+									(change)="onQualifierChange(DateQualifier.Uncertain, true)"
+								/>
+								<span class="pr-toggle-slider"></span>
+							</label>
+						</div>
+
+						<div class="pr-qualifier-option">
+							<span>Unknown</span>
+							<label class="pr-toggle">
+								<input
+									type="checkbox"
+									[checked]="endQualifiers().unknown"
+									(change)="onQualifierChange(DateQualifier.Unknown, true)"
+								/>
+								<span class="pr-toggle-slider"></span>
+							</label>
+						</div>
+					</div>
+				</div>
+
+				<div class="pr-datetime-row" [class.disabled]="endFieldsDisabled()">
+					<pr-datepicker-input
+						[date]="endDate()"
+						[disabled]="endFieldsDisabled()"
+						(dateChange)="endDate.set($event)"
+					/>
+
+					<pr-timepicker-input
+						[time]="endTime()"
+						[disabled]="endFieldsDisabled()"
+						(timeChange)="onTimeChange($event, endTime)"
+					/>
+				</div>
+
+				<button class="pr-clear-link" (click)="clearEnd()">
+					<i class="material-icons">backspace</i>
+					<span>Clear end date and time</span>
+				</button>
+			</div>
+		}
+
+		<div class="pr-date-range-row">
+			<span>Use a date range</span>
+			<label class="pr-toggle">
+				<input
+					type="checkbox"
+					[checked]="useDateRange()"
+					(change)="toggleDateRange()"
+				/>
+				<span class="pr-toggle-slider"></span>
+			</label>
+		</div>
+	</div>
+
+	<div class="pr-dialog-footer">
+		<div class="pr-edtf-display">
+			@if (isEdtfValid()) {
+				<span
+					class="pr-edtf-value"
+					[ngbTooltip]="'Formatted EDTF date and time'"
+					placement="top"
+					>{{ edtfValue() }}</span
+				>
+			} @else {
+				<span class="pr-edtf-error">{{ edtfErrorMessage() }}</span>
+			}
+		</div>
+		<div class="pr-dialog-actions">
+			<button class="pr-btn-cancel" (click)="onCancel()">Cancel</button>
+			<button
+				class="pr-btn-save"
+				[disabled]="!isEdtfValid()"
+				(click)="onSave()"
+			>
+				Save
+			</button>
+		</div>
+	</div>
+</div>

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.scss
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.scss
@@ -1,0 +1,317 @@
+@import 'colors';
+@import 'mixins';
+
+.pr-edit-date-time-dialog {
+	background: $white;
+	border-radius: 12px;
+	min-width: 658px;
+	box-shadow: 0 8px 32px rgba($black, 0.12);
+	font-family: 'Inter', sans-serif;
+
+	// Header
+	.pr-dialog-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 8px;
+		padding: 20px 24px;
+		border-bottom: 1px solid $PR-blue-100;
+
+		h2 {
+			margin: 0;
+			font-size: 18px;
+			font-weight: 600;
+			color: $PR-blue;
+		}
+
+		.pr-close-button {
+			background: none;
+			border: none;
+			cursor: pointer;
+			padding: 4px;
+			color: $PR-blue-600;
+			display: flex;
+			align-items: center;
+			font-size: 20px;
+
+			&:hover {
+				color: $PR-blue;
+			}
+		}
+	}
+
+	// Content
+	.pr-dialog-content {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		padding: 20px 24px;
+		background: $PR-blue-25;
+	}
+
+	// Date card (one per side: start / end)
+	.pr-date-card {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		padding: 20px;
+		border: 1px solid $PR-blue-100;
+		border-radius: 12px;
+		background: $white;
+	}
+
+	.pr-card-header {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+		flex-wrap: wrap;
+	}
+
+	.pr-card-label {
+		font-size: 14px;
+		color: $PR-blue-600;
+		white-space: nowrap;
+	}
+
+	// Qualifiers row
+	.pr-qualifiers-row {
+		display: flex;
+		align-items: center;
+		gap: 0;
+		flex: 1;
+
+		.pr-qualifier-option {
+			display: flex;
+			align-items: center;
+			gap: 16px;
+			padding: 0 16px;
+			border-right: 1px solid $PR-blue-100;
+			flex: 1;
+
+			&:first-child {
+				padding-left: 0;
+			}
+
+			&:last-child {
+				border-right: none;
+				padding-right: 0;
+			}
+
+			span {
+				font-size: 14px;
+				color: $PR-blue;
+				white-space: nowrap;
+			}
+		}
+	}
+
+	// Per-card clear link
+	.pr-clear-link {
+		@include clear-btn;
+		margin-left: auto;
+
+		i {
+			font-size: 18px;
+			color: $PR-blue-900;
+		}
+
+		span {
+			font-size: 14px;
+			color: $PR-blue-900;
+		}
+	}
+
+	// Toggle switch
+	.pr-toggle {
+		position: relative;
+		display: inline-block;
+		width: 44px;
+		height: 24px;
+		flex-shrink: 0;
+
+		input {
+			opacity: 0;
+			width: 0;
+			height: 0;
+		}
+
+		.pr-toggle-slider {
+			position: absolute;
+			cursor: pointer;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background-color: $toggle;
+			border-radius: 24px;
+			transition: 0.2s;
+
+			&::before {
+				content: '';
+				position: absolute;
+				height: 18px;
+				width: 18px;
+				left: 3px;
+				bottom: 3px;
+				background-color: $white;
+				border-radius: 50%;
+				transition: 0.2s;
+			}
+		}
+
+		input:checked + .pr-toggle-slider {
+			background-color: $toggle-checked;
+		}
+
+		input:checked + .pr-toggle-slider::before {
+			transform: translateX(20px);
+		}
+	}
+
+	// Date and time row
+	.pr-datetime-row {
+		display: flex;
+		gap: 16px;
+		position: relative;
+
+		pr-datepicker-input,
+		pr-timepicker-input {
+			flex: 1;
+		}
+	}
+
+	.pr-icon-button {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 4px;
+		color: $PR-blue;
+		display: flex;
+		align-items: center;
+		margin-left: auto;
+
+		i {
+			font-size: 20px;
+		}
+	}
+
+	// Date range row
+	.pr-date-range-row {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+
+		> span {
+			font-size: 14px;
+			color: $PR-blue;
+		}
+	}
+
+	// Footer
+	.pr-dialog-footer {
+		@include panel-footer;
+		border-top: none;
+		padding: 24px;
+
+		.pr-edtf-display {
+			display: flex;
+			align-items: center;
+			gap: 10px;
+			min-width: 0;
+			max-width: 425px;
+			flex: 1;
+
+			.pr-edtf-badge {
+				font-family: 'Usual', sans-serif;
+				font-weight: 400;
+				font-style: normal;
+				font-size: 10px;
+				line-height: 8px;
+				letter-spacing: 0.16em;
+				text-align: center;
+				text-transform: uppercase;
+				color: $PR-blue;
+				background: $white;
+				border-radius: 4px;
+				padding: 0 8px;
+				height: 20px;
+				display: flex;
+				align-items: center;
+			}
+
+			.pr-edtf-value {
+				font-family: 'DM Mono', monospace;
+				font-weight: 400;
+				font-style: normal;
+				font-size: 12px;
+				line-height: 16px;
+				letter-spacing: -0.01em;
+				text-align: right;
+				color: $PR-blue-600;
+			}
+
+			.pr-edtf-error {
+				font-size: 12px;
+				line-height: 16px;
+				color: $red;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
+				white-space: normal;
+				min-width: 0;
+			}
+		}
+
+		.pr-dialog-actions {
+			display: flex;
+			gap: 12px;
+		}
+
+		.pr-btn-cancel {
+			padding: 16px 24px;
+			border: none;
+			border-radius: 6px;
+			background: $white;
+			font-size: 14px;
+			font-weight: 500;
+			color: $PR-blue;
+			cursor: pointer;
+			height: 40px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 10px;
+		}
+
+		.pr-btn-save {
+			padding: 16px 24px;
+			border: none;
+			border-radius: 6px;
+			background: $PR-blue;
+			font-size: 14px;
+			font-weight: 500;
+			color: $white;
+			cursor: pointer;
+			height: 40px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 10px;
+
+			&:hover {
+				background: $PR-blue-800;
+			}
+
+			&:disabled {
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
+		}
+	}
+
+	// Disabled state
+	.disabled,
+	.pr-datetime-row.disabled {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+}

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.spec.ts
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.spec.ts
@@ -1,0 +1,526 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import {
+	DateTimeModel,
+	DateQualifier,
+} from '@shared/services/edtf-service/edtf.service';
+import { EditDateTimeModalComponent } from './edit-date-time-modal.component';
+
+describe('EditDateTimeModalComponent', () => {
+	let component: EditDateTimeModalComponent;
+	let fixture: ComponentFixture<EditDateTimeModalComponent>;
+	let dialogRefSpy: jasmine.SpyObj<DialogRef>;
+
+	const mockDialogData: DateTimeModel = {
+		qualifiers: {
+			approximate: true,
+			uncertain: false,
+			unknown: false,
+		},
+		date: { year: '1930', month: '', day: '' },
+		time: {
+			hours: '11',
+			minutes: '',
+			seconds: '',
+			format: 'am',
+		},
+	};
+
+	beforeEach(async () => {
+		dialogRefSpy = jasmine.createSpyObj('DialogRef', ['close']);
+
+		await TestBed.configureTestingModule({
+			imports: [EditDateTimeModalComponent],
+			providers: [
+				{ provide: DialogRef, useValue: dialogRefSpy },
+				{ provide: DIALOG_DATA, useValue: mockDialogData },
+			],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(EditDateTimeModalComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+
+	it('should inject dialog data', () => {
+		expect(component.data).toEqual(mockDialogData);
+	});
+
+	// --- Initialization ---
+
+	it('should initialize fields from dialog data', () => {
+		expect(component.date().year).toBe('1930');
+		expect(component.time().hours).toBe('11');
+		expect(component.time().format).toBe('am');
+		expect(component.qualifiers().approximate).toBeTrue();
+		expect(component.qualifiers().uncertain).toBeFalse();
+		expect(component.qualifiers().unknown).toBeFalse();
+
+		expect(component.useDateRange()).toBeFalse();
+	});
+
+	it('should enable useDateRange when endDate is provided', () => {
+		component.data = {
+			...mockDialogData,
+			endDate: { year: '2026', month: '01', day: '15' },
+		};
+		component.ngOnInit();
+
+		expect(component.useDateRange()).toBeTrue();
+		expect(component.endDate().year).toBe('2026');
+	});
+
+	it('should initialize endQualifiers from dialog data', () => {
+		component.data = {
+			...mockDialogData,
+			endDate: { year: '2026', month: '01', day: '15' },
+			endTime: { format: 'am' },
+			endQualifiers: { approximate: false, uncertain: true, unknown: false },
+		};
+		component.ngOnInit();
+
+		expect(component.endQualifiers().uncertain).toBeTrue();
+		expect(component.endQualifiers().approximate).toBeFalse();
+	});
+
+	it('should save start form state with unknown false when data has unknown true', () => {
+		const unknownData: DateTimeModel = {
+			qualifiers: { approximate: false, uncertain: false, unknown: true },
+			date: { year: '', month: '', day: '' },
+			time: {
+				hours: '',
+				minutes: '',
+				seconds: '',
+				format: 'am',
+			},
+		};
+
+		component.data = unknownData;
+		component.ngOnInit();
+
+		expect(component.qualifiers().unknown).toBeTrue();
+		expect(component.savedStartState()).not.toBeNull();
+		expect(component.savedStartState().qualifiers.unknown).toBeFalse();
+	});
+
+	it('should save end form state when data has end unknown true', () => {
+		component.data = {
+			...mockDialogData,
+			endDate: { year: '', month: '', day: '' },
+			endTime: { format: 'am' },
+			endQualifiers: { approximate: false, uncertain: false, unknown: true },
+		};
+		component.ngOnInit();
+
+		expect(component.endQualifiers().unknown).toBeTrue();
+		expect(component.savedEndState()).not.toBeNull();
+	});
+
+	// --- Time updates via onTimeChange ---
+
+	it('should update time fields via onTimeChange', () => {
+		component.onTimeChange(
+			{ hours: '02', minutes: '30', seconds: '15', format: 'pm' },
+			component.time,
+		);
+
+		expect(component.time().hours).toBe('02');
+		expect(component.time().minutes).toBe('30');
+		expect(component.time().seconds).toBe('15');
+		expect(component.time().format).toBe('pm');
+	});
+
+	it('should update end time fields via onTimeChange', () => {
+		component.onTimeChange(
+			{ hours: '06', minutes: '45', seconds: '00', format: 'am' },
+			component.endTime,
+		);
+
+		expect(component.endTime().hours).toBe('06');
+		expect(component.endTime().minutes).toBe('45');
+	});
+
+	// --- Date range toggle ---
+
+	it('should toggle date range', () => {
+		expect(component.useDateRange()).toBeFalse();
+		component.toggleDateRange();
+
+		expect(component.useDateRange()).toBeTrue();
+		component.toggleDateRange();
+
+		expect(component.useDateRange()).toBeFalse();
+	});
+
+	// --- Start-side qualifiers ---
+
+	it('should toggle start approximate on and off', () => {
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+		component.onQualifierChange(DateQualifier.Approximate, false);
+
+		expect(component.qualifiers().approximate).toBeTrue();
+
+		component.onQualifierChange(DateQualifier.Approximate, false);
+
+		expect(component.qualifiers().approximate).toBeFalse();
+	});
+
+	it('should allow start approximate and uncertain to be active at the same time', () => {
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+
+		component.onQualifierChange(DateQualifier.Approximate, false);
+		component.onQualifierChange(DateQualifier.Uncertain, false);
+
+		expect(component.qualifiers().approximate).toBeTrue();
+		expect(component.qualifiers().uncertain).toBeTrue();
+	});
+
+	it('should turn off start approximate and uncertain when start unknown is toggled on', () => {
+		component.qualifiers.set({
+			approximate: true,
+			uncertain: true,
+			unknown: false,
+		});
+
+		component.onQualifierChange(DateQualifier.Unknown, false);
+
+		expect(component.qualifiers().unknown).toBeTrue();
+		expect(component.qualifiers().approximate).toBeFalse();
+		expect(component.qualifiers().uncertain).toBeFalse();
+	});
+
+	it('should turn off start unknown when start approximate is toggled on', () => {
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: true,
+		});
+
+		component.onQualifierChange(DateQualifier.Approximate, false);
+
+		expect(component.qualifiers().approximate).toBeTrue();
+		expect(component.qualifiers().unknown).toBeFalse();
+	});
+
+	it('should reset start fields and disable them when start unknown is toggled on', () => {
+		component.date.set({ year: '2026', month: '02', day: '18' });
+		component.time.update((t) => ({ ...t, hours: '10' }));
+
+		component.onQualifierChange(DateQualifier.Unknown, false);
+
+		expect(component.qualifiers().unknown).toBeTrue();
+		expect(component.startFieldsDisabled()).toBeTrue();
+		expect(component.date().year).toBe('');
+		expect(component.date().month).toBe('');
+		expect(component.time().hours).toBe('');
+	});
+
+	it('should restore start form state when start unknown is toggled off', () => {
+		component.qualifiers.set({
+			approximate: true,
+			uncertain: true,
+			unknown: false,
+		});
+		component.date.set({ year: '2026', month: '02', day: '18' });
+		component.time.update((t) => ({ ...t, hours: '10' }));
+
+		component.onQualifierChange(DateQualifier.Unknown, false);
+
+		expect(component.qualifiers().unknown).toBeTrue();
+		expect(component.date().year).toBe('');
+
+		component.onQualifierChange(DateQualifier.Unknown, false);
+
+		expect(component.qualifiers().unknown).toBeFalse();
+		expect(component.qualifiers().approximate).toBeTrue();
+		expect(component.qualifiers().uncertain).toBeTrue();
+		expect(component.startFieldsDisabled()).toBeFalse();
+		expect(component.date().year).toBe('2026');
+		expect(component.date().month).toBe('02');
+		expect(component.time().hours).toBe('10');
+		expect(component.savedStartState()).toBeNull();
+	});
+
+	it('should enable start fields when toggling start unknown off from initial unknown state', () => {
+		const unknownData: DateTimeModel = {
+			qualifiers: { approximate: false, uncertain: false, unknown: true },
+			date: { year: '', month: '', day: '' },
+			time: {
+				hours: '',
+				minutes: '',
+				seconds: '',
+				format: 'am',
+			},
+		};
+
+		component.data = unknownData;
+		component.ngOnInit();
+
+		expect(component.startFieldsDisabled()).toBeTrue();
+
+		component.onQualifierChange(DateQualifier.Unknown, false);
+
+		expect(component.qualifiers().unknown).toBeFalse();
+		expect(component.startFieldsDisabled()).toBeFalse();
+	});
+
+	it('should show XXXX-XX-XX as EDTF value when unknown is on (no range)', () => {
+		component.date.set({ year: '2026', month: '02', day: '18' });
+		component.onQualifierChange(DateQualifier.Unknown, false);
+
+		expect(component.edtfValue()).toBe('XXXX-XX-XX');
+	});
+
+	// --- End-side qualifiers ---
+
+	it('should toggle end qualifiers independently of start qualifiers', () => {
+		component.useDateRange.set(true);
+		component.qualifiers.set({
+			approximate: true,
+			uncertain: false,
+			unknown: false,
+		});
+		component.endQualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+
+		component.onQualifierChange(DateQualifier.Uncertain, true);
+
+		expect(component.qualifiers().approximate).toBeTrue();
+		expect(component.qualifiers().uncertain).toBeFalse();
+		expect(component.endQualifiers().uncertain).toBeTrue();
+		expect(component.endQualifiers().approximate).toBeFalse();
+	});
+
+	it('should reset end fields when end unknown is toggled on', () => {
+		component.useDateRange.set(true);
+		component.endDate.set({ year: '2026', month: '02', day: '18' });
+		component.endTime.update((t) => ({ ...t, hours: '10' }));
+
+		component.onQualifierChange(DateQualifier.Unknown, true);
+
+		expect(component.endQualifiers().unknown).toBeTrue();
+		expect(component.endFieldsDisabled()).toBeTrue();
+		expect(component.endDate().year).toBe('');
+		expect(component.endTime().hours).toBe('');
+	});
+
+	it('should restore end form state when end unknown is toggled off', () => {
+		component.useDateRange.set(true);
+		component.endQualifiers.set({
+			approximate: true,
+			uncertain: false,
+			unknown: false,
+		});
+		component.endDate.set({ year: '2026', month: '02', day: '18' });
+		component.endTime.update((t) => ({ ...t, hours: '10' }));
+
+		component.onQualifierChange(DateQualifier.Unknown, true);
+
+		expect(component.endQualifiers().unknown).toBeTrue();
+		expect(component.endDate().year).toBe('');
+
+		component.onQualifierChange(DateQualifier.Unknown, true);
+
+		expect(component.endQualifiers().unknown).toBeFalse();
+		expect(component.endQualifiers().approximate).toBeTrue();
+		expect(component.endDate().year).toBe('2026');
+		expect(component.endTime().hours).toBe('10');
+		expect(component.savedEndState()).toBeNull();
+	});
+
+	it('should produce empty-slot EDTF when end unknown is on in a range', () => {
+		component.useDateRange.set(true);
+		component.date.set({ year: '1985', month: '04', day: '12' });
+		component.time.set({ hours: '', minutes: '', seconds: '', format: 'am' });
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+		component.endQualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: true,
+		});
+
+		expect(component.edtfValue()).toBe('1985-04-12/');
+	});
+
+	// --- clearStart / clearEnd ---
+
+	it('should clear start fields only', () => {
+		component.date.set({ year: '2026', month: '02', day: '18' });
+		component.time.update((t) => ({ ...t, hours: '10' }));
+		component.qualifiers.set({
+			approximate: true,
+			uncertain: false,
+			unknown: false,
+		});
+		component.endDate.set({ year: '2030', month: '06', day: '01' });
+
+		component.clearStart();
+
+		expect(component.date().year).toBe('');
+		expect(component.time().hours).toBe('');
+		expect(component.qualifiers().approximate).toBeFalse();
+		expect(component.savedStartState()).toBeNull();
+		expect(component.endDate().year).toBe('2030');
+	});
+
+	it('should clear end fields only', () => {
+		component.endDate.set({ year: '2026', month: '02', day: '18' });
+		component.endTime.update((t) => ({ ...t, hours: '10' }));
+		component.endQualifiers.set({
+			approximate: false,
+			uncertain: true,
+			unknown: false,
+		});
+		component.date.set({ year: '1985' });
+
+		component.clearEnd();
+
+		expect(component.endDate().year).toBe('');
+		expect(component.endTime().hours).toBe('');
+		expect(component.endQualifiers().uncertain).toBeFalse();
+		expect(component.savedEndState()).toBeNull();
+		expect(component.date().year).toBe('1985');
+	});
+
+	// --- Dialog actions ---
+
+	it('should close dialog on cancel', () => {
+		component.onCancel();
+
+		expect(dialogRefSpy.close).toHaveBeenCalledWith();
+	});
+
+	it('should close dialog with form data on save', () => {
+		component.onSave();
+
+		expect(dialogRefSpy.close).toHaveBeenCalledWith(
+			jasmine.objectContaining({
+				qualifiers: { approximate: true, uncertain: false, unknown: false },
+				date: { year: '1930', month: '', day: '' },
+			}),
+		);
+	});
+
+	it('should include endDate, endTime and endQualifiers when useDateRange is on', () => {
+		component.useDateRange.set(true);
+		component.endDate.set({ year: '2026', month: '12', day: '31' });
+		component.endQualifiers.set({
+			approximate: false,
+			uncertain: true,
+			unknown: false,
+		});
+		component.onSave();
+
+		const result = dialogRefSpy.close.calls.mostRecent()
+			.args[0] as DateTimeModel;
+
+		expect(result.endDate).toEqual({ year: '2026', month: '12', day: '31' });
+		expect(result.endQualifiers).toEqual({
+			approximate: false,
+			uncertain: true,
+			unknown: false,
+		});
+	});
+
+	it('should not include endDate or endQualifiers when useDateRange is off', () => {
+		component.useDateRange.set(false);
+		component.onSave();
+
+		const result = dialogRefSpy.close.calls.mostRecent()
+			.args[0] as DateTimeModel;
+
+		expect(result.endDate).toBeUndefined();
+		expect(result.endQualifiers).toBeUndefined();
+	});
+
+	// --- EDTF computed ---
+
+	it('should compute EDTF value from date and time without timezone suffix', () => {
+		component.date.set({ year: '2026', month: '02', day: '18' });
+		component.time.set({
+			hours: '10',
+			minutes: '30',
+			seconds: '00',
+			format: 'am',
+		});
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+
+		expect(component.edtfValue()).toBe('2026-02-18T10:30:00');
+	});
+
+	it('should compute EDTF with date only', () => {
+		component.date.set({ year: '2026', month: '', day: '' });
+		component.time.set({
+			hours: '',
+			minutes: '',
+			seconds: '',
+			format: 'am',
+		});
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+
+		expect(component.edtfValue()).toBe('2026');
+	});
+
+	it('should show error when time has invalid hours', () => {
+		component.date.set({ year: '2026', month: '02', day: '18' });
+		component.time.set({
+			hours: '13',
+			minutes: '30',
+			seconds: '00',
+			format: 'pm',
+		});
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+
+		expect(component.isEdtfValid()).toBeFalse();
+		expect(component.edtfErrorMessage()).toBeTruthy();
+		expect(component.edtfValue()).toBe('');
+	});
+
+	it('should X-pad missing month when day is provided', () => {
+		component.date.set({ year: '2026', month: '', day: '18' });
+		component.time.set({
+			hours: '',
+			minutes: '',
+			seconds: '',
+			format: 'am',
+		});
+		component.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+
+		expect(component.edtfValue()).toBe('2026-XX-18');
+	});
+});

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.spec.ts
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.spec.ts
@@ -454,23 +454,6 @@ describe('EditDateTimeModalComponent', () => {
 
 	// --- EDTF computed ---
 
-	it('should compute EDTF value from date and time without timezone suffix', () => {
-		component.date.set({ year: '2026', month: '02', day: '18' });
-		component.time.set({
-			hours: '10',
-			minutes: '30',
-			seconds: '00',
-			format: 'am',
-		});
-		component.qualifiers.set({
-			approximate: false,
-			uncertain: false,
-			unknown: false,
-		});
-
-		expect(component.edtfValue()).toBe('2026-02-18T10:30:00');
-	});
-
 	it('should compute EDTF with date only', () => {
 		component.date.set({ year: '2026', month: '', day: '' });
 		component.time.set({

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.ts
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.ts
@@ -19,6 +19,7 @@ import {
 	TimeModel,
 	DateTimeModel,
 	DEFAULT_TIME,
+	DEFAULT_DATE_QUALIFIERS,
 	UNKNOWN_VALUE,
 } from '@shared/services/edtf-service/edtf.service';
 
@@ -43,17 +44,9 @@ interface SavedSideState {
 export class EditDateTimeModalComponent implements OnInit {
 	readonly DateQualifier = DateQualifier;
 
-	qualifiers = signal<DateQualifierFlags>({
-		approximate: false,
-		uncertain: false,
-		unknown: false,
-	});
+	qualifiers = signal<DateQualifierFlags>({ ...DEFAULT_DATE_QUALIFIERS });
 
-	endQualifiers = signal<DateQualifierFlags>({
-		approximate: false,
-		uncertain: false,
-		unknown: false,
-	});
+	endQualifiers = signal<DateQualifierFlags>({ ...DEFAULT_DATE_QUALIFIERS });
 
 	savedStartState = signal<SavedSideState | null>(null);
 	savedEndState = signal<SavedSideState | null>(null);
@@ -116,11 +109,7 @@ export class EditDateTimeModalComponent implements OnInit {
 	ngOnInit(): void {
 		if (this.data) {
 			this.qualifiers.set(
-				this.data.qualifiers ?? {
-					approximate: false,
-					uncertain: false,
-					unknown: false,
-				},
+				this.data.qualifiers ?? { ...DEFAULT_DATE_QUALIFIERS },
 			);
 			this.date.set(this.data.date ?? { year: '', month: '', day: '' });
 			this.time.set(this.data.time ?? { ...DEFAULT_TIME });
@@ -130,17 +119,13 @@ export class EditDateTimeModalComponent implements OnInit {
 				this.endDate.set(this.data.endDate);
 				this.endTime.set(this.data.endTime ?? { ...DEFAULT_TIME });
 				this.endQualifiers.set(
-					this.data.endQualifiers ?? {
-						approximate: false,
-						uncertain: false,
-						unknown: false,
-					},
+					this.data.endQualifiers ?? { ...DEFAULT_DATE_QUALIFIERS },
 				);
 			}
 
 			if (this.data.qualifiers?.unknown) {
 				this.savedStartState.set({
-					qualifiers: { approximate: false, uncertain: false, unknown: false },
+					qualifiers: { ...DEFAULT_DATE_QUALIFIERS },
 					date: { ...this.date() },
 					time: { ...this.time() },
 				});
@@ -148,7 +133,7 @@ export class EditDateTimeModalComponent implements OnInit {
 
 			if (this.data.endQualifiers?.unknown) {
 				this.savedEndState.set({
-					qualifiers: { approximate: false, uncertain: false, unknown: false },
+					qualifiers: { ...DEFAULT_DATE_QUALIFIERS },
 					date: { ...this.endDate() },
 					time: { ...this.endTime() },
 				});
@@ -255,22 +240,14 @@ export class EditDateTimeModalComponent implements OnInit {
 	}
 
 	clearStart(): void {
-		this.qualifiers.set({
-			approximate: false,
-			uncertain: false,
-			unknown: false,
-		});
+		this.qualifiers.set({ ...DEFAULT_DATE_QUALIFIERS });
 		this.date.set({ year: '', month: '', day: '' });
 		this.time.set({ ...DEFAULT_TIME });
 		this.savedStartState.set(null);
 	}
 
 	clearEnd(): void {
-		this.endQualifiers.set({
-			approximate: false,
-			uncertain: false,
-			unknown: false,
-		});
+		this.endQualifiers.set({ ...DEFAULT_DATE_QUALIFIERS });
 		this.endDate.set({ year: '', month: '', day: '' });
 		this.endTime.set({ ...DEFAULT_TIME });
 		this.savedEndState.set(null);

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.ts
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.component.ts
@@ -1,0 +1,298 @@
+import {
+	Component,
+	Inject,
+	OnInit,
+	signal,
+	computed,
+	WritableSignal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { DatepickerInputComponent } from '@shared/components/datepicker-input/datepicker-input.component';
+import { TimepickerInputComponent } from '@shared/components/timepicker-input/timepicker-input.component';
+import {
+	EdtfService,
+	DateQualifier,
+	DateQualifierFlags,
+	DateModel,
+	TimeModel,
+	DateTimeModel,
+	DEFAULT_TIME,
+	UNKNOWN_VALUE,
+} from '@shared/services/edtf-service/edtf.service';
+
+interface SavedSideState {
+	qualifiers: DateQualifierFlags;
+	date: DateModel;
+	time: TimeModel;
+}
+
+@Component({
+	selector: 'pr-edit-date-time-modal',
+	standalone: true,
+	imports: [
+		CommonModule,
+		NgbTooltipModule,
+		DatepickerInputComponent,
+		TimepickerInputComponent,
+	],
+	templateUrl: './edit-date-time-modal.component.html',
+	styleUrls: ['./edit-date-time-modal.component.scss'],
+})
+export class EditDateTimeModalComponent implements OnInit {
+	readonly DateQualifier = DateQualifier;
+
+	qualifiers = signal<DateQualifierFlags>({
+		approximate: false,
+		uncertain: false,
+		unknown: false,
+	});
+
+	endQualifiers = signal<DateQualifierFlags>({
+		approximate: false,
+		uncertain: false,
+		unknown: false,
+	});
+
+	savedStartState = signal<SavedSideState | null>(null);
+	savedEndState = signal<SavedSideState | null>(null);
+
+	startFieldsDisabled = computed(() => this.qualifiers().unknown);
+	endFieldsDisabled = computed(() => this.endQualifiers().unknown);
+
+	date = signal<DateModel>({ year: '', month: '', day: '' });
+
+	time = signal<TimeModel>({ ...DEFAULT_TIME });
+
+	useDateRange = signal(false);
+
+	endDate = signal<DateModel>({ year: '', month: '', day: '' });
+
+	endTime = signal<TimeModel>({ ...DEFAULT_TIME });
+
+	private edtfResult = computed<{
+		value: string;
+		valid: boolean;
+		errorMessage: string;
+	}>(() => {
+		if (!this.useDateRange() && this.qualifiers().unknown) {
+			return { value: UNKNOWN_VALUE, valid: true, errorMessage: '' };
+		}
+
+		const dateTimeModel: DateTimeModel = {
+			date: this.date(),
+			time: this.time(),
+			qualifiers: { ...this.qualifiers() },
+		};
+
+		if (this.useDateRange()) {
+			dateTimeModel.endDate = this.endDate();
+			dateTimeModel.endTime = this.endTime();
+			dateTimeModel.endQualifiers = { ...this.endQualifiers() };
+		}
+		try {
+			const edtfDate = this.edtfService.toEdtfDate(dateTimeModel);
+			return { value: edtfDate, valid: true, errorMessage: '' };
+		} catch (error) {
+			return {
+				value: '',
+				valid: false,
+				errorMessage: error instanceof Error ? error.message : 'Invalid date',
+			};
+		}
+	});
+
+	edtfValue = computed(() => this.edtfResult().value);
+	isEdtfValid = computed(() => this.edtfResult().valid);
+	edtfErrorMessage = computed(() => this.edtfResult().errorMessage);
+
+	constructor(
+		public dialogRef: DialogRef<DateTimeModel>,
+		@Inject(DIALOG_DATA) public data: DateTimeModel,
+		private edtfService: EdtfService,
+	) {}
+
+	ngOnInit(): void {
+		if (this.data) {
+			this.qualifiers.set(
+				this.data.qualifiers ?? {
+					approximate: false,
+					uncertain: false,
+					unknown: false,
+				},
+			);
+			this.date.set(this.data.date ?? { year: '', month: '', day: '' });
+			this.time.set(this.data.time ?? { ...DEFAULT_TIME });
+
+			if (this.data.endDate) {
+				this.useDateRange.set(true);
+				this.endDate.set(this.data.endDate);
+				this.endTime.set(this.data.endTime ?? { ...DEFAULT_TIME });
+				this.endQualifiers.set(
+					this.data.endQualifiers ?? {
+						approximate: false,
+						uncertain: false,
+						unknown: false,
+					},
+				);
+			}
+
+			if (this.data.qualifiers?.unknown) {
+				this.savedStartState.set({
+					qualifiers: { approximate: false, uncertain: false, unknown: false },
+					date: { ...this.date() },
+					time: { ...this.time() },
+				});
+			}
+
+			if (this.data.endQualifiers?.unknown) {
+				this.savedEndState.set({
+					qualifiers: { approximate: false, uncertain: false, unknown: false },
+					date: { ...this.endDate() },
+					time: { ...this.endTime() },
+				});
+			}
+		}
+	}
+
+	onTimeChange(
+		timeInputValue: TimeModel,
+		currentTime: WritableSignal<TimeModel>,
+	): void {
+		currentTime.update((t) => ({
+			...t,
+			hours: timeInputValue.hours,
+			minutes: timeInputValue.minutes,
+			seconds: timeInputValue.seconds,
+			format: timeInputValue.format,
+		}));
+	}
+
+	onQualifierChange(newDateQualifier: DateQualifier, isEnd: boolean): void {
+		const qualifierSignal = isEnd ? this.endQualifiers : this.qualifiers;
+		const dateSignal = isEnd ? this.endDate : this.date;
+		const timeSignal = isEnd ? this.endTime : this.time;
+		const savedStateSignal = isEnd ? this.savedEndState : this.savedStartState;
+
+		const currentQualifiers = qualifierSignal();
+
+		if (newDateQualifier === DateQualifier.Unknown) {
+			if (currentQualifiers.unknown) {
+				this.restoreSide(
+					qualifierSignal,
+					dateSignal,
+					timeSignal,
+					savedStateSignal,
+				);
+			} else {
+				this.saveSide(
+					qualifierSignal,
+					dateSignal,
+					timeSignal,
+					savedStateSignal,
+				);
+				qualifierSignal.set({
+					approximate: false,
+					uncertain: false,
+					unknown: true,
+				});
+				dateSignal.set({ year: '', month: '', day: '' });
+				timeSignal.set({ ...DEFAULT_TIME });
+			}
+			return;
+		}
+
+		if (newDateQualifier === DateQualifier.Approximate) {
+			qualifierSignal.update((a) => ({
+				...a,
+				approximate: !a.approximate,
+				unknown: !a.approximate || a.uncertain ? false : a.unknown,
+			}));
+		}
+
+		if (newDateQualifier === DateQualifier.Uncertain) {
+			qualifierSignal.update((a) => ({
+				...a,
+				uncertain: !a.uncertain,
+				unknown: a.approximate || !a.uncertain ? false : a.unknown,
+			}));
+		}
+	}
+
+	private saveSide(
+		qualifierSignal: WritableSignal<DateQualifierFlags>,
+		dateSignal: WritableSignal<DateModel>,
+		timeSignal: WritableSignal<TimeModel>,
+		savedStateSignal: WritableSignal<SavedSideState | null>,
+	): void {
+		savedStateSignal.set({
+			qualifiers: { ...qualifierSignal() },
+			date: { ...dateSignal() },
+			time: { ...timeSignal() },
+		});
+	}
+
+	private restoreSide(
+		qualifierSignal: WritableSignal<DateQualifierFlags>,
+		dateSignal: WritableSignal<DateModel>,
+		timeSignal: WritableSignal<TimeModel>,
+		savedStateSignal: WritableSignal<SavedSideState | null>,
+	): void {
+		const saved = savedStateSignal();
+		if (saved) {
+			qualifierSignal.set(saved.qualifiers);
+			dateSignal.set(saved.date);
+			timeSignal.set(saved.time);
+			savedStateSignal.set(null);
+		} else {
+			qualifierSignal.update((a) => ({ ...a, unknown: false }));
+		}
+	}
+
+	toggleDateRange(): void {
+		this.useDateRange.update((v) => !v);
+	}
+
+	clearStart(): void {
+		this.qualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+		this.date.set({ year: '', month: '', day: '' });
+		this.time.set({ ...DEFAULT_TIME });
+		this.savedStartState.set(null);
+	}
+
+	clearEnd(): void {
+		this.endQualifiers.set({
+			approximate: false,
+			uncertain: false,
+			unknown: false,
+		});
+		this.endDate.set({ year: '', month: '', day: '' });
+		this.endTime.set({ ...DEFAULT_TIME });
+		this.savedEndState.set(null);
+	}
+
+	onCancel(): void {
+		this.dialogRef.close();
+	}
+
+	onSave(): void {
+		const newDateModel: DateTimeModel = {
+			qualifiers: { ...this.qualifiers() },
+			date: { ...this.date() },
+			time: { ...this.time() },
+		};
+
+		if (this.useDateRange()) {
+			newDateModel.endQualifiers = { ...this.endQualifiers() };
+			newDateModel.endDate = { ...this.endDate() };
+			newDateModel.endTime = { ...this.endTime() };
+		}
+
+		this.dialogRef.close(newDateModel);
+	}
+}

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.service.spec.ts
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { DialogRef } from '@angular/cdk/dialog';
+import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
+import { DateTimeModel } from '@shared/services/edtf-service/edtf.service';
+import { EditDateTimeModalService } from './edit-date-time-modal.service';
+import { EditDateTimeModalComponent } from './edit-date-time-modal.component';
+
+describe('EditDateTimeModalService', () => {
+	let service: EditDateTimeModalService;
+	let dialogCdkServiceSpy: jasmine.SpyObj<DialogCdkService>;
+	let mockDialogRef: jasmine.SpyObj<
+		DialogRef<DateTimeModel, EditDateTimeModalComponent>
+	>;
+
+	const mockData: DateTimeModel = {
+		qualifiers: { approximate: false, uncertain: false, unknown: false },
+		date: { year: '2026', month: '02', day: '18' },
+		time: {
+			hours: '10',
+			minutes: '30',
+			seconds: '',
+			format: 'am',
+		},
+	};
+
+	beforeEach(() => {
+		mockDialogRef = jasmine.createSpyObj('DialogRef', ['close']);
+		dialogCdkServiceSpy = jasmine.createSpyObj('DialogCdkService', ['open']);
+		dialogCdkServiceSpy.open.and.returnValue(mockDialogRef);
+
+		TestBed.configureTestingModule({
+			providers: [
+				EditDateTimeModalService,
+				{ provide: DialogCdkService, useValue: dialogCdkServiceSpy },
+			],
+		});
+
+		service = TestBed.inject(EditDateTimeModalService);
+	});
+
+	it('should be created', () => {
+		expect(service).toBeTruthy();
+	});
+
+	it('should open EditDateTimeModalComponent via DialogCdkService', () => {
+		service.open(mockData);
+
+		expect(dialogCdkServiceSpy.open).toHaveBeenCalledWith(
+			EditDateTimeModalComponent,
+			jasmine.objectContaining({
+				data: mockData,
+				hasBackdrop: true,
+				panelClass: 'edit-date-time-modal-dialog-panel',
+			}),
+		);
+	});
+
+	it('should return a DialogRef', () => {
+		const result = service.open(mockData);
+
+		expect(result).toBe(mockDialogRef);
+	});
+});

--- a/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.service.ts
+++ b/src/app/file-browser/components/edit-date-time-modal/edit-date-time-modal.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { DialogRef } from '@angular/cdk/dialog';
+import { DialogCdkService } from '@root/app/dialog-cdk/dialog-cdk.service';
+import { DateTimeModel } from '@shared/services/edtf-service/edtf.service';
+import { EditDateTimeModalComponent } from './edit-date-time-modal.component';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class EditDateTimeModalService {
+	constructor(private dialogCdkService: DialogCdkService) {}
+
+	open(
+		data: DateTimeModel,
+	): DialogRef<DateTimeModel, EditDateTimeModalComponent> {
+		return this.dialogCdkService.open<
+			EditDateTimeModalComponent,
+			DateTimeModel,
+			DateTimeModel
+		>(EditDateTimeModalComponent, {
+			data,
+			hasBackdrop: true,
+			panelClass: 'edit-date-time-modal-dialog-panel',
+		});
+	}
+}

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -2,7 +2,6 @@
 	class="file-viewer"
 	[ngClass]="{
 		minimal: useMinimalView,
-		'editing-date': editingDate,
 		'can-edit': canEdit
 	}"
 >
@@ -125,26 +124,15 @@
 					></pr-inline-value-edit>
 				}
 			</div>
+			<div class="file-viewer-date">
+				<pr-sidebar-date-picker
+					[displayTime]="displayTimeObject"
+					[disabled]="!canEdit"
+					(saveClicked)="onDateSaved($event)"
+					(moreOptionsClicked)="onDateMoreOptions($event)"
+				/>
+			</div>
 			<table class="metadata-table">
-				<tr>
-					<td>Date</td>
-					<td>
-						<pr-inline-value-edit
-							[displayValue]="
-								currentRecord.displayTime || currentRecord.displayDT
-							"
-							[canEdit]="canEdit"
-							[item]="currentRecord"
-							[itemId]="currentRecord.folder_linkId"
-							emptyMessage="Click to add date"
-							readOnlyEmptyMessage="No date"
-							(doneEditing)="onFinishEditing('displayTime', $event)"
-							(toggledDatePicker)="onDateToggle($event)"
-							type="date"
-							class="no-padding"
-						></pr-inline-value-edit>
-					</td>
-				</tr>
 				<tr>
 					<td>Uploaded</td>
 					<td>{{ currentRecord.createdDT | date }}</td>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.html
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.html
@@ -2,6 +2,7 @@
 	class="file-viewer"
 	[ngClass]="{
 		minimal: useMinimalView,
+		'editing-date': editingDate,
 		'can-edit': canEdit
 	}"
 >
@@ -124,15 +125,38 @@
 					></pr-inline-value-edit>
 				}
 			</div>
-			<div class="file-viewer-date">
-				<pr-sidebar-date-picker
-					[displayTime]="displayTimeObject"
-					[disabled]="!canEdit"
-					(saveClicked)="onDateSaved($event)"
-					(moreOptionsClicked)="onDateMoreOptions($event)"
-				/>
-			</div>
+			@if (showEdtfDatePicker) {
+				<div class="file-viewer-date">
+					<pr-sidebar-date-picker
+						[displayTime]="displayTimeObject"
+						[disabled]="!canEdit"
+						(saveClicked)="onDateSaved($event)"
+						(moreOptionsClicked)="onDateMoreOptions($event)"
+					/>
+				</div>
+			}
 			<table class="metadata-table">
+				@if (!showEdtfDatePicker) {
+					<tr>
+						<td>Date</td>
+						<td>
+							<pr-inline-value-edit
+								[displayValue]="
+									currentRecord.displayTime || currentRecord.displayDT
+								"
+								[canEdit]="canEdit"
+								[item]="currentRecord"
+								[itemId]="currentRecord.folder_linkId"
+								emptyMessage="Click to add date"
+								readOnlyEmptyMessage="No date"
+								(doneEditing)="onFinishEditing('displayTime', $event)"
+								(toggledDatePicker)="onDateToggle($event)"
+								type="date"
+								class="no-padding"
+							></pr-inline-value-edit>
+						</td>
+					</tr>
+				}
 				<tr>
 					<td>Uploaded</td>
 					<td>{{ currentRecord.createdDT | date }}</td>

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.scss
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.scss
@@ -185,12 +185,6 @@ replay-web-page {
 	display: none;
 }
 
-.editing-date pr-inline-value-edit[type='date'] {
-	left: -20%;
-	top: 3em;
-	margin-bottom: 3em;
-}
-
 .can-edit {
 	pr-tags,
 	.location-container {

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.scss
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.scss
@@ -185,6 +185,12 @@ replay-web-page {
 	display: none;
 }
 
+.editing-date pr-inline-value-edit[type='date'] {
+	left: -20%;
+	top: 3em;
+	margin-bottom: 3em;
+}
+
 .can-edit {
 	pr-tags,
 	.location-container {

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
@@ -15,7 +15,9 @@ import { ApiService } from '@shared/services/api/api.service';
 import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 import { MockComponent } from 'ng-mocks';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
+import { MessageService } from '@shared/services/message/message.service';
 import { TagsComponent } from '../../../shared/components/tags/tags.component';
+import { EditDateTimeModalService } from '../edit-date-time-modal/edit-date-time-modal.service';
 import { FileViewerComponent } from './file-viewer.component';
 
 @Pipe({ name: 'dsFileSize', standalone: false })
@@ -227,6 +229,19 @@ describe('FileViewerComponent', () => {
 					provide: FeatureFlagService,
 					useValue: {
 						isEnabled: (flag: string) => featureFlagsEnabled.get(flag) ?? false,
+					},
+				},
+				{
+					provide: MessageService,
+					useValue: {
+						showError: () => {},
+						showMessage: () => {},
+					},
+				},
+				{
+					provide: EditDateTimeModalService,
+					useValue: {
+						open: () => ({ closed: { subscribe: () => {} } }),
 					},
 				},
 			],

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.spec.ts
@@ -16,6 +16,10 @@ import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag
 import { MockComponent } from 'ng-mocks';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
 import { MessageService } from '@shared/services/message/message.service';
+import {
+	DateTimeModel,
+	EdtfService,
+} from '@shared/services/edtf-service/edtf.service';
 import { TagsComponent } from '../../../shared/components/tags/tags.component';
 import { EditDateTimeModalService } from '../edit-date-time-modal/edit-date-time-modal.service';
 import { FileViewerComponent } from './file-viewer.component';
@@ -257,6 +261,68 @@ describe('FileViewerComponent', () => {
 
 	it('should create', () => {
 		expect(component).not.toBeNull();
+	});
+
+	describe('edtf-date feature flag', () => {
+		it('should show the EDTF date picker when the edtf-date flag is enabled', async () => {
+			featureFlagsEnabled.set('edtf-date', true);
+			await recreateComponent();
+
+			expect(component.showEdtfDatePicker).toBe(true);
+			expect(
+				fixture.nativeElement.querySelector('pr-sidebar-date-picker'),
+			).toBeTruthy();
+		});
+
+		it('should show the legacy date field and hide the EDTF picker when the edtf-date flag is disabled', async () => {
+			featureFlagsEnabled.set('edtf-date', false);
+			await recreateComponent();
+
+			expect(component.showEdtfDatePicker).toBe(false);
+			expect(
+				fixture.nativeElement.querySelector('pr-sidebar-date-picker'),
+			).toBeNull();
+
+			const dateRowLabel = Array.from(
+				fixture.nativeElement.querySelectorAll('.metadata-table td'),
+			).find((td: HTMLElement) => td.textContent?.trim() === 'Date');
+
+			expect(dateRowLabel).toBeTruthy();
+		});
+	});
+
+	describe('EDTF date handling', () => {
+		const recordWithDate = () =>
+			new RecordVO({
+				type: 'document',
+				displayName: 'Dated Doc',
+				TagVOs: [],
+				displayTime: '1985-05-20',
+			});
+
+		it('should compute the cached display time from the record on init', async () => {
+			activatedRouteData.currentRecord = recordWithDate();
+			await recreateComponent();
+
+			expect(component.displayTimeObject?.date.year).toBe('1985');
+		});
+
+		it('should reset the cached display time and show one error when an invalid date is saved', async () => {
+			activatedRouteData.currentRecord = recordWithDate();
+			await recreateComponent();
+
+			const edtfService = TestBed.inject(EdtfService);
+			spyOn(edtfService, 'toEdtfDate').and.throwError('invalid date');
+			const showErrorSpy = spyOn(TestBed.inject(MessageService), 'showError');
+
+			await component.onDateSaved({
+				date: { year: 'bad' } as never,
+				time: { format: 'am' },
+			} as DateTimeModel);
+
+			expect(showErrorSpy).toHaveBeenCalledTimes(1);
+			expect(component.displayTimeObject?.date.year).toBe('1985');
+		});
 	});
 
 	it('should have two tags components', () => {

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -30,7 +30,13 @@ import { GetAccessFile } from '@models/get-access-file';
 import { ShareLinksService } from '@root/app/share-links/services/share-links.service';
 import { ApiService } from '@shared/services/api/api.service';
 import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
+import {
+	DateTimeModel,
+	EdtfService,
+} from '@shared/services/edtf-service/edtf.service';
+import { MessageService } from '@shared/services/message/message.service';
 import { TagsService } from '../../../core/services/tags/tags.service';
+import { EditDateTimeModalService } from '../edit-date-time-modal/edit-date-time-modal.service';
 
 @Component({
 	selector: 'pr-file-viewer',
@@ -77,7 +83,6 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
 	// UI
 	public useMinimalView = false;
-	public editingDate: boolean = false;
 	private bodyScrollTop: number;
 	private itemTagsSubscription: Subscription;
 	private tagsSubscription: Subscription;
@@ -88,6 +93,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 		private route: ActivatedRoute,
 		private element: ElementRef,
 		private dataService: DataService,
+		private message: MessageService,
 		@Inject(DOCUMENT) private document: any,
 		public sanitizer: DomSanitizer,
 		private accountService: AccountService,
@@ -97,6 +103,8 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 		private shareLinksService: ShareLinksService,
 		private api: ApiService,
 		private feature: FeatureFlagService,
+		private edtfService: EdtfService,
+		private editDateTimeModalService: EditDateTimeModalService,
 	) {
 		// store current scroll position in file list
 		this.bodyScrollTop = window.scrollY;
@@ -432,6 +440,42 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 		}
 	}
 
+	get displayTimeObject(): DateTimeModel | null {
+		try {
+			const timeSource =
+				this.currentRecord?.displayTime || this.currentRecord?.displayDT;
+			return timeSource ? this.edtfService.toDateTimeModel(timeSource) : null;
+		} catch (err) {
+			this.message.showError({ message: err?.message });
+		}
+	}
+
+	public async onDateSaved(result: DateTimeModel): Promise<void> {
+		try {
+			const newDisplayTime = this.edtfService.toEdtfDate(result);
+			this.onFinishEditing('displayTime', newDisplayTime);
+		} catch (err) {
+			this.message.showError({ message: err?.message });
+		}
+	}
+
+	public async onDateMoreOptions(modalData: DateTimeModel): Promise<void> {
+		const dialogRef = this.editDateTimeModalService.open(modalData);
+
+		dialogRef.closed.subscribe((result) => {
+			if (result) {
+				if (result) {
+					try {
+						const newDisplayTime = this.edtfService.toEdtfDate(result);
+						this.onFinishEditing('displayTime', newDisplayTime);
+					} catch (err) {
+						this.message.showError({ message: err?.message });
+					}
+				}
+			}
+		});
+	}
+
 	public async onFinishEditing(
 		property: KeysOfType<ItemVO, string>,
 		value: string,
@@ -453,10 +497,6 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 		if (this.canEdit) {
 			this.editService.openTagsDialog(this.currentRecord as ItemVO, type);
 		}
-	}
-
-	public onDateToggle(active: boolean): void {
-		this.editingDate = active;
 	}
 
 	public onDownloadClick(): void {

--- a/src/app/file-browser/components/file-viewer/file-viewer.component.ts
+++ b/src/app/file-browser/components/file-viewer/file-viewer.component.ts
@@ -68,6 +68,12 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 
 	public canEdit: boolean;
 
+	public showEdtfDatePicker = false;
+
+	public editingDate: boolean = false;
+
+	public displayTimeObject: DateTimeModel | null = null;
+
 	// Swiping
 	private touchElement: HTMLElement;
 	private thumbElement: HTMLElement;
@@ -86,6 +92,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 	private bodyScrollTop: number;
 	private itemTagsSubscription: Subscription;
 	private tagsSubscription: Subscription;
+	private dateModalSubscription?: Subscription;
 	private isUnlistedShare = true;
 
 	constructor(
@@ -108,6 +115,8 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 	) {
 		// store current scroll position in file list
 		this.bodyScrollTop = window.scrollY;
+
+		this.showEdtfDatePicker = this.feature.isEnabled('edtf-date');
 
 		const resolvedRecord = route.snapshot.data.currentRecord;
 		this.allTags = tagsService.getTags();
@@ -194,6 +203,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 		});
 		this.itemTagsSubscription.unsubscribe();
 		this.tagsSubscription.unsubscribe();
+		this.dateModalSubscription?.unsubscribe();
 	}
 
 	private setRecordsToPreview(resolvedRecord: RecordVO) {
@@ -252,6 +262,7 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 			this.replayUrl = this.getReplayUrl();
 		}
 		this.setCurrentTags();
+		this.updateDisplayTimeObject();
 	}
 
 	toggleSwipe(value: boolean) {
@@ -440,40 +451,48 @@ export class FileViewerComponent implements OnInit, OnDestroy {
 		}
 	}
 
-	get displayTimeObject(): DateTimeModel | null {
+	private updateDisplayTimeObject(): void {
+		const timeSource =
+			this.currentRecord?.displayTime || this.currentRecord?.displayDT;
 		try {
-			const timeSource =
-				this.currentRecord?.displayTime || this.currentRecord?.displayDT;
-			return timeSource ? this.edtfService.toDateTimeModel(timeSource) : null;
+			this.displayTimeObject = timeSource
+				? this.edtfService.toDateTimeModel(timeSource)
+				: null;
 		} catch (err) {
+			this.displayTimeObject = null;
 			this.message.showError({ message: err?.message });
 		}
 	}
 
 	public async onDateSaved(result: DateTimeModel): Promise<void> {
-		try {
-			const newDisplayTime = this.edtfService.toEdtfDate(result);
-			this.onFinishEditing('displayTime', newDisplayTime);
-		} catch (err) {
-			this.message.showError({ message: err?.message });
-		}
+		await this.saveDisplayTime(result);
 	}
 
 	public async onDateMoreOptions(modalData: DateTimeModel): Promise<void> {
 		const dialogRef = this.editDateTimeModalService.open(modalData);
 
-		dialogRef.closed.subscribe((result) => {
+		this.dateModalSubscription = dialogRef.closed.subscribe(async (result) => {
 			if (result) {
-				if (result) {
-					try {
-						const newDisplayTime = this.edtfService.toEdtfDate(result);
-						this.onFinishEditing('displayTime', newDisplayTime);
-					} catch (err) {
-						this.message.showError({ message: err?.message });
-					}
-				}
+				await this.saveDisplayTime(result);
 			}
 		});
+	}
+
+	private async saveDisplayTime(result: DateTimeModel): Promise<void> {
+		try {
+			const newDisplayTime = this.edtfService.toEdtfDate(result);
+			await this.onFinishEditing('displayTime', newDisplayTime);
+		} catch (err) {
+			this.message.showError({ message: err?.message });
+		} finally {
+			// Recompute so the picker re-syncs to the stored value, whether the
+			// save came from the inline picker or the modal, and on failure too.
+			this.updateDisplayTimeObject();
+		}
+	}
+
+	public onDateToggle(active: boolean): void {
+		this.editingDate = active;
 	}
 
 	public async onFinishEditing(

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.html
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.html
@@ -14,60 +14,46 @@
 		[class.can-edit]="!disabled"
 		(click)="toggle()"
 	>
-		<div class="pr-sidebar-date-picker-row">
-			@if (hasEndDate()) {
-				<span class="pr-sidebar-date-picker-row-label">From</span>
-			}
-			@if (hasStartDate()) {
-				<span class="pr-sidebar-date-picker-row-value">
-					<span class="pr-date-part"
-						>{{ formattedStartDate() }}
-						@if (formattedStartTime()) {
-							<i class="material-icons pr-dot">fiber_manual_record</i>
-						}
+		@for (row of rows(); track $index) {
+			<div
+				class="pr-sidebar-date-picker-row"
+				[class.pr-sidebar-date-picker-to-row]="$index > 0"
+			>
+				@if (row.prefixLabel) {
+					<span class="pr-sidebar-date-picker-row-label">
+						{{ row.prefixLabel }}
 					</span>
-					@if (formattedStartTime()) {
-						<span class="pr-time-group">
-							<span class="pr-time-part">{{ formattedStartTime() }}</span>
-							<span class="pr-muted">{{ startMeridian() }}</span>
-							@if (startTimezone()) {
-								<span class="pr-muted">{{ startTimezone() }}</span>
+				}
+				@if (row.text) {
+					<span class="pr-sidebar-date-picker-row-value">{{ row.text }}</span>
+				} @else if (row.date) {
+					<span class="pr-sidebar-date-picker-row-value">
+						<span class="pr-date-part"
+							>{{ row.date }}
+							@if (row.time) {
+								<i class="material-icons pr-dot">fiber_manual_record</i>
 							}
 						</span>
-					}
-				</span>
-			} @else {
-				<span class="pr-sidebar-date-picker-row-placeholder">
-					{{ disabled ? 'No date' : 'Click to add date' }}
-				</span>
-			}
-			@if (!disabled) {
-				<span class="pr-sidebar-date-picker-edit-icon">
-					<i class="material-icons">edit</i>
-				</span>
-			}
-		</div>
-
-		@if (hasEndDate()) {
-			<div class="pr-sidebar-date-picker-row pr-sidebar-date-picker-to-row">
-				<span class="pr-sidebar-date-picker-row-label">To</span>
-				<span class="pr-sidebar-date-picker-row-value">
-					<span class="pr-date-part"
-						>{{ formattedEndDate() }}
-						@if (formattedEndTime()) {
-							<i class="material-icons pr-dot">fiber_manual_record</i>
+						@if (row.time) {
+							<span class="pr-time-group">
+								<span class="pr-time-part">{{ row.time }}</span>
+								<span class="pr-muted">{{ row.meridian }}</span>
+								@if (row.timezone) {
+									<span class="pr-muted">{{ row.timezone }}</span>
+								}
+							</span>
 						}
 					</span>
-					@if (formattedEndTime()) {
-						<span class="pr-time-group">
-							<span class="pr-time-part">{{ formattedEndTime() }}</span>
-							<span class="pr-muted">{{ endMeridian() }}</span>
-							@if (endTimezone()) {
-								<span class="pr-muted">{{ endTimezone() }}</span>
-							}
-						</span>
-					}
-				</span>
+				} @else if (row.isEmpty) {
+					<span class="pr-sidebar-date-picker-row-placeholder">
+						{{ disabled ? 'No date' : 'Click to add date' }}
+					</span>
+				}
+				@if ($index === 0 && !disabled) {
+					<span class="pr-sidebar-date-picker-edit-icon">
+						<i class="material-icons">edit</i>
+					</span>
+				}
 			</div>
 		}
 	</div>

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.html
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.html
@@ -1,0 +1,109 @@
+<div class="pr-sidebar-date-picker" #sidebarDatePickerContainer>
+	<div class="pr-sidebar-date-picker-header">
+		<span class="pr-sidebar-date-picker-label">Date</span>
+		@if (activeQualifiers().length) {
+			<i class="material-icons pr-header-dot">fiber_manual_record</i>
+			<span class="pr-sidebar-date-picker-qualifiers">
+				{{ activeQualifiers().join(', ') }}:
+			</span>
+		}
+	</div>
+
+	<div
+		class="pr-sidebar-date-picker-rows"
+		[class.can-edit]="!disabled"
+		(click)="toggle()"
+	>
+		<div class="pr-sidebar-date-picker-row">
+			@if (hasEndDate()) {
+				<span class="pr-sidebar-date-picker-row-label">From</span>
+			}
+			@if (hasStartDate()) {
+				<span class="pr-sidebar-date-picker-row-value">
+					<span class="pr-date-part"
+						>{{ formattedStartDate() }}
+						@if (formattedStartTime()) {
+							<i class="material-icons pr-dot">fiber_manual_record</i>
+						}
+					</span>
+					@if (formattedStartTime()) {
+						<span class="pr-time-group">
+							<span class="pr-time-part">{{ formattedStartTime() }}</span>
+							<span class="pr-muted">{{ startMeridian() }}</span>
+							@if (startTimezone()) {
+								<span class="pr-muted">{{ startTimezone() }}</span>
+							}
+						</span>
+					}
+				</span>
+			} @else {
+				<span class="pr-sidebar-date-picker-row-placeholder">
+					{{ disabled ? 'No date' : 'Click to add date' }}
+				</span>
+			}
+			@if (!disabled) {
+				<span class="pr-sidebar-date-picker-edit-icon">
+					<i class="material-icons">edit</i>
+				</span>
+			}
+		</div>
+
+		@if (hasEndDate()) {
+			<div class="pr-sidebar-date-picker-row pr-sidebar-date-picker-to-row">
+				<span class="pr-sidebar-date-picker-row-label">To</span>
+				<span class="pr-sidebar-date-picker-row-value">
+					<span class="pr-date-part"
+						>{{ formattedEndDate() }}
+						@if (formattedEndTime()) {
+							<i class="material-icons pr-dot">fiber_manual_record</i>
+						}
+					</span>
+					@if (formattedEndTime()) {
+						<span class="pr-time-group">
+							<span class="pr-time-part">{{ formattedEndTime() }}</span>
+							<span class="pr-muted">{{ endMeridian() }}</span>
+							@if (endTimezone()) {
+								<span class="pr-muted">{{ endTimezone() }}</span>
+							}
+						</span>
+					}
+				</span>
+			</div>
+		}
+	</div>
+
+	@if (isDropdownOpen()) {
+		<div class="pr-sidebar-date-picker-panel">
+			<div class="pr-sidebar-date-picker-fields">
+				<pr-datepicker-input
+					[date]="_date()"
+					(dateChange)="onDateChange($event)"
+				/>
+
+				<pr-timepicker-input
+					[time]="_time()"
+					(timeChange)="onTimeChange($event)"
+				/>
+
+				<button class="pr-clear-btn" (click)="clearAll()">
+					<i class="material-icons">backspace</i>
+					<span>Clear date and time</span>
+				</button>
+			</div>
+
+			<div class="pr-sidebar-date-picker-footer">
+				<button class="pr-more-options-btn" (click)="onMoreOptions()">
+					<i class="material-icons">tune</i>
+					<span>More options</span>
+				</button>
+
+				<div class="pr-sidebar-date-picker-actions">
+					<button class="pr-btn-cancel" (click)="onCancel()">Cancel</button>
+					<button class="pr-btn-save" (click)="onSave()">
+						<i class="material-icons">keyboard_return</i>
+					</button>
+				</div>
+			</div>
+		</div>
+	}
+</div>

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.scss
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.scss
@@ -1,0 +1,217 @@
+@import 'colors';
+@import 'mixins';
+@import 'variables';
+
+.pr-sidebar-date-picker {
+	position: relative;
+
+	.pr-sidebar-date-picker-header {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		font-size: 13px;
+		color: $PR-blue-600;
+		margin-bottom: 4px;
+
+		.pr-header-dot {
+			font-size: 6px;
+			color: $PR-blue-400;
+			margin: 0 2px;
+		}
+	}
+
+	.pr-sidebar-date-picker-label {
+		font-weight: 600;
+		font-size: $font-size-base;
+		color: $body-color;
+	}
+
+	.pr-sidebar-date-picker-qualifiers {
+		color: $PR-blue-400;
+	}
+
+	.pr-sidebar-date-picker-rows {
+		border-radius: 8px;
+		padding: 4px 8px;
+		transition: background-color 0.15s ease;
+
+		&.can-edit {
+			cursor: pointer;
+
+			&:hover {
+				background-color: $PR-blue-25;
+
+				.pr-sidebar-date-picker-edit-icon {
+					color: $PR-blue;
+				}
+			}
+		}
+	}
+
+	.pr-sidebar-date-picker-row {
+		display: flex;
+		align-items: baseline;
+	}
+
+	.pr-sidebar-date-picker-row-label {
+		font-size: 14px;
+		color: $PR-blue-400;
+		margin-right: 8px;
+		min-width: 36px;
+	}
+
+	.pr-sidebar-date-picker-row-value {
+		flex: 1;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 4px;
+		font-size: 14px;
+		color: $PR-blue;
+		font-weight: 500;
+
+		.pr-time-group {
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			white-space: nowrap;
+		}
+
+		.pr-dot {
+			font-size: 6px;
+			color: $PR-blue;
+			vertical-align: middle;
+			margin-left: 2px;
+		}
+
+		.pr-muted {
+			color: $PR-blue-400;
+		}
+	}
+
+	.pr-sidebar-date-picker-row-placeholder {
+		flex: 1;
+		font-size: 14px;
+		color: $PR-blue-400;
+	}
+
+	.pr-sidebar-date-picker-edit-icon {
+		padding: 4px;
+		color: $PR-blue-400;
+		display: flex;
+		align-items: center;
+
+		.material-icons {
+			font-size: 18px;
+		}
+	}
+
+	.pr-sidebar-date-picker-to-row {
+		cursor: default;
+	}
+
+	// Dropdown panel
+	.pr-sidebar-date-picker-panel {
+		position: absolute;
+		top: 0;
+		left: -16px;
+		right: -16px;
+		z-index: 20;
+		background: $white;
+		border: 1px solid $PR-blue-100;
+		border-radius: 12px;
+		box-shadow: 0 8px 24px rgba($black, 0.12);
+		overflow: visible;
+	}
+
+	.pr-sidebar-date-picker-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 16px;
+	}
+
+	.pr-clear-btn {
+		@include clear-btn;
+		margin-top: 4px;
+		width: 151px;
+
+		i {
+			color: $PR-blue;
+			font-size: 16px;
+		}
+
+		span {
+			color: $PR-blue;
+			font-size: 14px;
+		}
+	}
+
+	.pr-sidebar-date-picker-footer {
+		@include panel-footer;
+		padding: 12px 16px;
+	}
+
+	.pr-more-options-btn {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 14px;
+		font-weight: 500;
+		color: $PR-blue;
+		padding: 0;
+
+		&:hover {
+			color: $PR-blue-800;
+		}
+
+		.material-icons {
+			font-size: 18px;
+		}
+	}
+
+	.pr-sidebar-date-picker-actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.pr-btn-cancel {
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 14px;
+		font-weight: 500;
+		color: $PR-blue;
+		padding: 6px 12px;
+
+		&:hover {
+			color: $PR-blue-800;
+		}
+	}
+
+	.pr-btn-save {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: $PR-blue;
+		border: none;
+		border-radius: 6px;
+		cursor: pointer;
+		color: $white;
+		width: 36px;
+		height: 36px;
+		padding: 0;
+
+		&:hover {
+			background: $PR-blue-800;
+		}
+
+		.material-icons {
+			font-size: 18px;
+		}
+	}
+}

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -1,0 +1,599 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA, Component } from '@angular/core';
+import { DateTimeModel } from '@shared/services/edtf-service/edtf.service';
+import { SidebarDatePickerComponent } from './sidebar-date-picker.component';
+
+@Component({
+	template: `
+		<pr-sidebar-date-picker
+			[displayTime]="displayTime"
+			[disabled]="disabled"
+			(saveClicked)="onSaveClicked($event)"
+			(moreOptionsClicked)="onMoreOptionsClicked($event)"
+		/>
+	`,
+	standalone: false,
+})
+class TestHostComponent {
+	displayTime: DateTimeModel | null = null;
+	disabled = false;
+	savedValue: DateTimeModel | null = null;
+	moreOptionsData: DateTimeModel | null = null;
+
+	onSaveClicked(value: DateTimeModel) {
+		this.savedValue = value;
+	}
+	onMoreOptionsClicked(data: DateTimeModel) {
+		this.moreOptionsData = data;
+	}
+}
+
+describe('SidebarDatePickerComponent', () => {
+	let host: TestHostComponent;
+	let fixture: ComponentFixture<TestHostComponent>;
+	let component: SidebarDatePickerComponent;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [SidebarDatePickerComponent],
+			declarations: [TestHostComponent],
+			schemas: [CUSTOM_ELEMENTS_SCHEMA],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(TestHostComponent);
+		host = fixture.componentInstance;
+		fixture.detectChanges();
+		component = fixture.debugElement.children[0].componentInstance;
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+
+	describe('display', () => {
+		it('should show placeholder when no date is set', () => {
+			const placeholder = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-placeholder',
+			);
+
+			expect(placeholder).toBeTruthy();
+			expect(placeholder.textContent.trim()).toBe('Click to add date');
+		});
+
+		it('should show "No date" placeholder when disabled and no date', () => {
+			host.disabled = true;
+			fixture.detectChanges();
+
+			const placeholder = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-placeholder',
+			);
+
+			expect(placeholder.textContent.trim()).toBe('No date');
+		});
+
+		it('should display formatted date when displayTime is set', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value).toBeTruthy();
+			expect(value.textContent.trim()).toBe('May 1985');
+		});
+
+		it('should display year-only date', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent.trim()).toBe('1985');
+		});
+
+		it('should display full date with day', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent.trim()).toBe('May 20, 1985');
+		});
+
+		it('should display date with time', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '02',
+					minutes: '30',
+					seconds: '00',
+					am: false,
+					pm: true,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent).toContain('May 20, 1985');
+			expect(value.textContent).toContain('02:30:00');
+			expect(value.textContent).toContain('PM');
+		});
+
+		it('should display "Unknown date and time" when unknown qualifier is set', () => {
+			host.displayTime = {
+				qualifiers: { approximate: false, uncertain: false, unknown: true },
+				date: { year: '', month: '', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent).toContain('Unknown date and time');
+		});
+
+		it('should not show To row when no end date', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const toRow = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-to-row',
+			);
+
+			expect(toRow).toBeFalsy();
+		});
+
+		it('should show To row when end date is set', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+				endDate: { year: '1990', month: '06', day: '' },
+				endTime: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const toRow = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-to-row',
+			);
+
+			expect(toRow).toBeTruthy();
+			const toValue = toRow.querySelector('.pr-sidebar-date-picker-row-value');
+
+			expect(toValue.textContent.trim()).toBe('June 1990');
+		});
+
+		it('should show a browser-default timezone label when time is entered', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '02',
+					minutes: '30',
+					seconds: '00',
+					am: false,
+					pm: true,
+				},
+			};
+			fixture.detectChanges();
+
+			expect(component.startTimezone()).not.toBe('');
+		});
+
+		it('should not show a timezone label when no time is entered', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			expect(component.startTimezone()).toBe('');
+		});
+	});
+
+	describe('qualifiers', () => {
+		it('should not show qualifiers when none are active', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const qualifiers = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-qualifiers',
+			);
+
+			expect(qualifiers).toBeFalsy();
+		});
+
+		it('should display Approximate qualifier', () => {
+			host.displayTime = {
+				qualifiers: { approximate: true, uncertain: false, unknown: false },
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const qualifiers = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-qualifiers',
+			);
+
+			expect(qualifiers).toBeTruthy();
+			expect(qualifiers.textContent).toContain('Approximate');
+		});
+
+		it('should display Uncertain qualifier', () => {
+			host.displayTime = {
+				qualifiers: { approximate: false, uncertain: true, unknown: false },
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const qualifiers = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-qualifiers',
+			);
+
+			expect(qualifiers).toBeTruthy();
+			expect(qualifiers.textContent).toContain('Uncertain');
+		});
+	});
+
+	describe('toggle and dropdown', () => {
+		it('should not open when disabled', () => {
+			host.disabled = true;
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+
+		it('should open dropdown on toggle', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeTrue();
+		});
+
+		it('should close dropdown on second toggle', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeTrue();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+
+		it('should open modal instead of dropdown when end date is present', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+				endDate: { year: '1990', month: '06', day: '' },
+				endTime: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+			expect(host.moreOptionsData).toBeTruthy();
+		});
+
+		it('should open modal instead of dropdown when unknown qualifier is set', () => {
+			host.displayTime = {
+				qualifiers: { approximate: false, uncertain: false, unknown: true },
+				date: { year: '', month: '', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+			expect(host.moreOptionsData).toBeTruthy();
+		});
+	});
+
+	describe('clearAll', () => {
+		it('should clear all fields but keep dropdown open', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '10',
+					minutes: '30',
+					seconds: '00',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.open();
+			component.clearAll();
+
+			expect(component._date().year).toBe('');
+			expect(component._time().hours).toBe('');
+			expect(component._qualifiers().unknown).toBeFalse();
+			expect(component.isDropdownOpen()).toBeTrue();
+		});
+	});
+
+	describe('onSave', () => {
+		it('should emit saveClicked and close dropdown', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '02',
+					minutes: '30',
+					seconds: '00',
+					am: false,
+					pm: true,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+
+			component.onSave();
+			fixture.detectChanges();
+
+			expect(host.savedValue).toBeTruthy();
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+	});
+
+	describe('onCancel', () => {
+		it('should close dropdown and reset to input values', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+
+			component.onDateChange({ year: '2000', month: '01', day: '15' });
+			fixture.detectChanges();
+
+			component.onCancel();
+			fixture.detectChanges();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+			expect(component._date().year).toBe('1985');
+			expect(component._date().month).toBe('05');
+		});
+	});
+
+	describe('onMoreOptions', () => {
+		it('should emit moreOptionsClicked with current data', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+			component.onMoreOptions();
+
+			expect(host.moreOptionsData).toBeTruthy();
+			expect(host.moreOptionsData.date.year).toBe('1985');
+			expect(host.moreOptionsData.date.month).toBe('05');
+		});
+
+		it('should close dropdown when emitting', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+			component.onMoreOptions();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+	});
+
+	describe('outside click', () => {
+		it('should close dropdown on outside click', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeTrue();
+
+			const outsideEl = document.createElement('div');
+			document.body.appendChild(outsideEl);
+
+			component.onDocumentClick({ target: outsideEl } as any);
+			outsideEl.remove();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+	});
+
+	describe('field updates', () => {
+		it('should update date on onDateChange', () => {
+			component.onDateChange({ year: '2000', month: '01', day: '15' });
+
+			expect(component._date().year).toBe('2000');
+			expect(component._date().month).toBe('01');
+			expect(component._date().day).toBe('15');
+		});
+
+		it('should update time on onTimeChange', () => {
+			component.onTimeChange({
+				hours: '10',
+				minutes: '30',
+				seconds: '00',
+				am: false,
+				pm: true,
+			});
+
+			expect(component._time().hours).toBe('10');
+			expect(component._time().minutes).toBe('30');
+			expect(component._time().pm).toBe(true);
+		});
+	});
+});

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -259,6 +259,64 @@ describe('SidebarDatePickerComponent', () => {
 		});
 	});
 
+	describe('formattedStartDate with X-padding', () => {
+		const setDate = (year: string, month: string, day: string): void => {
+			host.displayTime = {
+				date: { year, month, day },
+				time: { hours: '', minutes: '', seconds: '', format: 'am' },
+			};
+			fixture.detectChanges();
+		};
+
+		it('should pad partial year with X (year only)', () => {
+			setDate('198', '', '');
+
+			expect(component.formattedStartDate()).toBe('198X');
+		});
+
+		it('should display "May XXXX" when only month is set', () => {
+			setDate('', '05', '');
+
+			expect(component.formattedStartDate()).toBe('May XXXX');
+		});
+
+		it('should display "May 20, 198X" with partial year and full month/day', () => {
+			setDate('198', '05', '20');
+
+			expect(component.formattedStartDate()).toBe('May 20, 198X');
+		});
+
+		it('should display "May 2X, 1985" with partial day', () => {
+			setDate('1985', '05', '2');
+
+			expect(component.formattedStartDate()).toBe('May 2X, 1985');
+		});
+
+		it('should fall back to ISO style "1985-XX-20" when month is missing', () => {
+			setDate('1985', '', '20');
+
+			expect(component.formattedStartDate()).toBe('1985-XX-20');
+		});
+
+		it('should fall back to ISO style "1985-1X-20" when month is partial', () => {
+			setDate('1985', '1', '20');
+
+			expect(component.formattedStartDate()).toBe('1985-1X-20');
+		});
+
+		it('should fall back to ISO style "XXXX-XX-20" when only day is set', () => {
+			setDate('', '', '20');
+
+			expect(component.formattedStartDate()).toBe('XXXX-XX-20');
+		});
+
+		it('should still display fully-specified date with month name (regression)', () => {
+			setDate('1985', '05', '20');
+
+			expect(component.formattedStartDate()).toBe('May 20, 1985');
+		});
+	});
+
 	describe('qualifiers', () => {
 		it('should not show qualifiers when none are active', () => {
 			host.displayTime = {

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -276,10 +276,10 @@ describe('SidebarDatePickerComponent', () => {
 			expect(component.formattedStartDate()).toBe('May 20, 198X');
 		});
 
-		it('should display "May 2X, 1985" with partial day', () => {
+		it('should zero-pad a single-digit day on the left ("May 02, 1985")', () => {
 			setDate('1985', '05', '2');
 
-			expect(component.formattedStartDate()).toBe('May 2X, 1985');
+			expect(component.formattedStartDate()).toBe('May 02, 1985');
 		});
 
 		it('should fall back to ISO style "1985-XX-20" when month is missing', () => {

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -78,8 +78,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -99,8 +98,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -119,8 +117,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -139,8 +136,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '02',
 					minutes: '30',
 					seconds: '00',
-					am: false,
-					pm: true,
+					format: 'pm',
 				},
 			};
 			fixture.detectChanges();
@@ -162,8 +158,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -182,8 +177,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -202,16 +196,14 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 				endDate: { year: '1990', month: '06', day: '' },
 				endTime: {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -233,8 +225,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '02',
 					minutes: '30',
 					seconds: '00',
-					am: false,
-					pm: true,
+					format: 'pm',
 				},
 			};
 			fixture.detectChanges();
@@ -249,8 +240,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -325,8 +315,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -346,8 +335,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -368,8 +356,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -400,8 +387,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -418,8 +404,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -440,16 +425,14 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 				endDate: { year: '1990', month: '06', day: '' },
 				endTime: {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -468,8 +451,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -489,8 +471,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '10',
 					minutes: '30',
 					seconds: '00',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -513,8 +494,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '02',
 					minutes: '30',
 					seconds: '00',
-					am: false,
-					pm: true,
+					format: 'pm',
 				},
 			};
 			fixture.detectChanges();
@@ -538,8 +518,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -567,8 +546,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -589,8 +567,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -611,8 +588,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -645,13 +621,12 @@ describe('SidebarDatePickerComponent', () => {
 				hours: '10',
 				minutes: '30',
 				seconds: '00',
-				am: false,
-				pm: true,
+				format: 'pm',
 			});
 
 			expect(component._time().hours).toBe('10');
 			expect(component._time().minutes).toBe('30');
-			expect(component._time().pm).toBe(true);
+			expect(component._time().format).toBe('pm');
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, Component } from '@angular/core';
-import { DateTimeModel } from '@shared/services/edtf-service/edtf.service';
+import {
+	DateTimeModel,
+	EdtfService,
+} from '@shared/services/edtf-service/edtf.service';
 import { SidebarDatePickerComponent } from './sidebar-date-picker.component';
 
 @Component({
@@ -150,7 +153,7 @@ describe('SidebarDatePickerComponent', () => {
 			expect(value.textContent).toContain('PM');
 		});
 
-		it('should display "Unknown date and time" when unknown qualifier is set', () => {
+		it('should display "Unknown" when unknown qualifier is set', () => {
 			host.displayTime = {
 				qualifiers: { approximate: false, uncertain: false, unknown: true },
 				date: { year: '', month: '', day: '' },
@@ -167,7 +170,8 @@ describe('SidebarDatePickerComponent', () => {
 				'.pr-sidebar-date-picker-row-value',
 			);
 
-			expect(value.textContent).toContain('Unknown date and time');
+			expect(value.textContent.trim()).toBe('Unknown');
+			expect(component.activeQualifiers()).not.toContain('Unknown');
 		});
 
 		it('should not show To row when no end date', () => {
@@ -368,6 +372,54 @@ describe('SidebarDatePickerComponent', () => {
 			expect(qualifiers).toBeTruthy();
 			expect(qualifiers.textContent).toContain('Uncertain');
 		});
+
+		it('should union qualifiers across start and end sides', () => {
+			host.displayTime = {
+				qualifiers: { approximate: true, uncertain: false, unknown: false },
+				date: { year: '1985', month: '05', day: '' },
+				time: { hours: '', minutes: '', seconds: '', format: 'am' },
+				endQualifiers: { approximate: false, uncertain: true, unknown: false },
+				endDate: { year: '1990', month: '06', day: '' },
+				endTime: { hours: '', minutes: '', seconds: '', format: 'am' },
+			};
+			fixture.detectChanges();
+
+			const qualifiers = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-qualifiers',
+			);
+
+			expect(qualifiers).toBeTruthy();
+			expect(qualifiers.textContent).toContain('Approximate');
+			expect(qualifiers.textContent).toContain('Uncertain');
+		});
+
+		it('should show "Unknown" for end side when endQualifiers.unknown is true', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '04', day: '12' },
+				time: { hours: '', minutes: '', seconds: '', format: 'am' },
+				endQualifiers: { approximate: false, uncertain: false, unknown: true },
+				endDate: { year: '', month: '', day: '' },
+				endTime: { hours: '', minutes: '', seconds: '', format: 'am' },
+			};
+			fixture.detectChanges();
+
+			expect(component.formattedEndDate()).toBe('Unknown');
+			expect(component.activeQualifiers()).not.toContain('Unknown');
+		});
+
+		it('should still surface Approximate / Uncertain when set alongside Unknown', () => {
+			host.displayTime = {
+				qualifiers: { approximate: true, uncertain: false, unknown: false },
+				date: { year: '1985', month: '04', day: '12' },
+				time: { hours: '', minutes: '', seconds: '', format: 'am' },
+				endQualifiers: { approximate: false, uncertain: false, unknown: true },
+				endDate: { year: '', month: '', day: '' },
+				endTime: { hours: '', minutes: '', seconds: '', format: 'am' },
+			};
+			fixture.detectChanges();
+
+			expect(component.activeQualifiers()).toEqual(['Approximate']);
+		});
 	});
 
 	describe('toggle and dropdown', () => {
@@ -453,6 +505,22 @@ describe('SidebarDatePickerComponent', () => {
 					seconds: '',
 					format: 'am',
 				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+			expect(host.moreOptionsData).toBeTruthy();
+		});
+
+		it('should open modal when end qualifier is active', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: { hours: '', minutes: '', seconds: '', format: 'am' },
+				endQualifiers: { approximate: false, uncertain: true, unknown: false },
+				endDate: { year: '1990', month: '06', day: '' },
+				endTime: { hours: '', minutes: '', seconds: '', format: 'am' },
 			};
 			fixture.detectChanges();
 
@@ -560,6 +628,25 @@ describe('SidebarDatePickerComponent', () => {
 			expect(host.moreOptionsData.date.month).toBe('05');
 		});
 
+		it('should include endQualifiers when an end side has qualifiers', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: { hours: '', minutes: '', seconds: '', format: 'am' },
+				endQualifiers: { approximate: false, uncertain: true, unknown: false },
+				endDate: { year: '1990', month: '06', day: '' },
+				endTime: { hours: '', minutes: '', seconds: '', format: 'am' },
+			};
+			fixture.detectChanges();
+
+			component.onMoreOptions();
+
+			expect(host.moreOptionsData.endQualifiers).toEqual({
+				approximate: false,
+				uncertain: true,
+				unknown: false,
+			});
+		});
+
 		it('should close dropdown when emitting', () => {
 			host.displayTime = {
 				date: { year: '1985', month: '05', day: '' },
@@ -627,6 +714,78 @@ describe('SidebarDatePickerComponent', () => {
 			expect(component._time().hours).toBe('10');
 			expect(component._time().minutes).toBe('30');
 			expect(component._time().format).toBe('pm');
+		});
+	});
+
+	describe('interval display', () => {
+		let edtfService: EdtfService;
+
+		beforeEach(() => {
+			edtfService = TestBed.inject(EdtfService);
+		});
+
+		it('should show "Sometime before" and the end date for an open-start interval', () => {
+			host.displayTime = edtfService.toDateTimeModel('../1990');
+			fixture.detectChanges();
+
+			expect(component.intervalLabel()).toBe('Sometime before');
+			expect(component.intervalValueDate()).toBe('1990');
+
+			const rows = fixture.nativeElement.querySelectorAll(
+				'.pr-sidebar-date-picker-row',
+			);
+
+			expect(rows.length).toBe(2);
+			expect(rows[0].textContent).toContain('Sometime before');
+			expect(rows[1].textContent).toContain('1990');
+		});
+
+		it('should show "Sometime after" and the start date for an open-end interval', () => {
+			host.displayTime = edtfService.toDateTimeModel('1985/..');
+			fixture.detectChanges();
+
+			expect(component.intervalLabel()).toBe('Sometime after');
+			expect(component.intervalValueDate()).toBe('1985');
+
+			const rows = fixture.nativeElement.querySelectorAll(
+				'.pr-sidebar-date-picker-row',
+			);
+
+			expect(rows.length).toBe(2);
+			expect(rows[0].textContent).toContain('Sometime after');
+			expect(rows[1].textContent).toContain('1985');
+		});
+
+		it('should keep From/To layout with Unknown on the unknown start side', () => {
+			host.displayTime = edtfService.toDateTimeModel('/1990-02-04');
+			fixture.detectChanges();
+
+			expect(component.intervalLabel()).toBeNull();
+
+			const rows = fixture.nativeElement.querySelectorAll(
+				'.pr-sidebar-date-picker-row',
+			);
+
+			expect(rows[0].textContent).toContain('From');
+			expect(rows[0].textContent).toContain('Unknown');
+			expect(rows[1].textContent).toContain('To');
+			expect(rows[1].textContent).toContain('February 04, 1990');
+		});
+
+		it('should keep From/To layout with Unknown on the unknown end side', () => {
+			host.displayTime = edtfService.toDateTimeModel('1985-04-12/');
+			fixture.detectChanges();
+
+			expect(component.intervalLabel()).toBeNull();
+
+			const rows = fixture.nativeElement.querySelectorAll(
+				'.pr-sidebar-date-picker-row',
+			);
+
+			expect(rows[0].textContent).toContain('From');
+			expect(rows[0].textContent).toContain('April 12, 1985');
+			expect(rows[1].textContent).toContain('To');
+			expect(rows[1].textContent).toContain('Unknown');
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -40,6 +40,16 @@ const EMPTY_QUALIFIERS: DateQualifierFlags = {
 	unknown: false,
 };
 
+interface SidebarDateRow {
+	prefixLabel?: string;
+	text?: string;
+	date?: string;
+	time?: string;
+	meridian?: string;
+	timezone?: string;
+	isEmpty?: boolean;
+}
+
 @Component({
 	selector: 'pr-sidebar-date-picker',
 	standalone: true,
@@ -66,15 +76,16 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 	_endDate = signal<DateModel>({ ...EMPTY_DATE });
 	_endTime = signal<TimeModel>({ ...EMPTY_TIME });
 	_qualifiers = signal<DateQualifierFlags>({ ...EMPTY_QUALIFIERS });
+	_endQualifiers = signal<DateQualifierFlags>({ ...EMPTY_QUALIFIERS });
 	_isOpenStart = signal(false);
 	_isOpenEnd = signal(false);
 
 	activeQualifiers = computed(() => {
-		const q = this._qualifiers();
+		const start = this._qualifiers();
+		const end = this._endQualifiers();
 		const active: string[] = [];
-		if (q.approximate) active.push('Approximate');
-		if (q.uncertain) active.push('Uncertain');
-		if (q.unknown) active.push('Unknown');
+		if (start.approximate || end.approximate) active.push('Approximate');
+		if (start.uncertain || end.uncertain) active.push('Uncertain');
 		return active;
 	});
 
@@ -87,7 +98,7 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 	});
 
 	formattedStartDate = computed(() => {
-		if (this._qualifiers().unknown) return 'Unknown date and time';
+		if (this._qualifiers().unknown) return 'Unknown';
 		if (this._isOpenStart()) return '..';
 		return this.formatDate(this._date());
 	});
@@ -105,12 +116,14 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 
 	// End date/time computed properties
 	hasEndDate = computed(() => {
+		if (this._endQualifiers().unknown) return true;
 		if (this._isOpenEnd()) return true;
 		const date = this._endDate();
 		return !!(date.year || date.month || date.day);
 	});
 
 	formattedEndDate = computed(() => {
+		if (this._endQualifiers().unknown) return 'Unknown';
 		if (this._isOpenEnd()) return '..';
 		return this.formatDate(this._endDate());
 	});
@@ -128,6 +141,66 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 			this._endTime(),
 		),
 	);
+
+	intervalLabel = computed(() => {
+		if (this._isOpenStart()) return 'Sometime before';
+		if (this._isOpenEnd()) return 'Sometime after';
+		return null;
+	});
+
+	intervalValueDate = computed(() =>
+		this._isOpenStart() ? this.formattedEndDate() : this.formattedStartDate(),
+	);
+	intervalValueTime = computed(() =>
+		this._isOpenStart() ? this.formattedEndTime() : this.formattedStartTime(),
+	);
+	intervalValueMeridian = computed(() =>
+		this._isOpenStart() ? this.endMeridian() : this.startMeridian(),
+	);
+	intervalValueTimezone = computed(() =>
+		this._isOpenStart() ? this.endTimezone() : this.startTimezone(),
+	);
+
+	rows = computed<SidebarDateRow[]>(() => {
+		const intervalLabel = this.intervalLabel();
+		if (intervalLabel) {
+			return [
+				{ text: intervalLabel },
+				{
+					date: this.intervalValueDate(),
+					time: this.intervalValueTime(),
+					meridian: this.intervalValueMeridian(),
+					timezone: this.intervalValueTimezone(),
+				},
+			];
+		}
+
+		const isInterval = this.hasEndDate();
+		const startRow: SidebarDateRow = {
+			prefixLabel: isInterval ? 'From' : undefined,
+		};
+		if (this.hasStartDate()) {
+			startRow.date = this.formattedStartDate();
+			startRow.time = this.formattedStartTime();
+			startRow.meridian = this.startMeridian();
+			startRow.timezone = this.startTimezone();
+		} else {
+			startRow.isEmpty = true;
+		}
+
+		if (!isInterval) return [startRow];
+
+		return [
+			startRow,
+			{
+				prefixLabel: 'To',
+				date: this.formattedEndDate(),
+				time: this.formattedEndTime(),
+				meridian: this.endMeridian(),
+				timezone: this.endTimezone(),
+			},
+		];
+	});
 
 	ngOnInit(): void {
 		this.updateFromDisplayTime();
@@ -154,8 +227,11 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 
 	toggle(): void {
 		if (this.disabled) return;
-		const q = this._qualifiers();
-		if (this.hasEndDate() || q.unknown || q.approximate || q.uncertain) {
+		if (
+			this.hasEndDate() ||
+			this.hasAnyQualifier(this._qualifiers()) ||
+			this.hasAnyQualifier(this._endQualifiers())
+		) {
 			this.onMoreOptions();
 			return;
 		}
@@ -189,6 +265,7 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 		this._endDate.set({ ...EMPTY_DATE });
 		this._endTime.set({ ...EMPTY_TIME });
 		this._qualifiers.set({ ...EMPTY_QUALIFIERS });
+		this._endQualifiers.set({ ...EMPTY_QUALIFIERS });
 		this._isOpenStart.set(false);
 		this._isOpenEnd.set(false);
 	}
@@ -200,13 +277,8 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 			qualifiers: { ...this._qualifiers() },
 			date: { ...this._date() },
 			time: { ...this._time() },
+			...(this.buildEndSide() ?? {}),
 		};
-
-		const endDate = this._endDate();
-		if (endDate.year || endDate.month || endDate.day || this._isOpenEnd()) {
-			modalData.endDate = { ...endDate };
-			modalData.endTime = { ...this._endTime() };
-		}
 
 		this.moreOptionsClicked.emit(modalData);
 	}
@@ -221,16 +293,33 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 			qualifiers: { ...this._qualifiers() },
 			date: { ...this._date() },
 			time: { ...this._time() },
+			...(this.buildEndSide() ?? {}),
 		};
-
-		const endDate = this._endDate();
-		if (endDate.year || endDate.month || endDate.day || this._isOpenEnd()) {
-			dateTimeModel.endDate = { ...endDate };
-			dateTimeModel.endTime = { ...this._endTime() };
-		}
 
 		this.saveClicked.emit(dateTimeModel);
 		this.isDropdownOpen.set(false);
+	}
+
+	private hasAnyQualifier(flags: DateQualifierFlags): boolean {
+		return flags.approximate || flags.uncertain || flags.unknown;
+	}
+
+	private buildEndSide(): Pick<
+		DateTimeModel,
+		'endQualifiers' | 'endDate' | 'endTime'
+	> | null {
+		const endDate = this._endDate();
+		const endQualifiers = this._endQualifiers();
+		const hasEnd =
+			!!(endDate.year || endDate.month || endDate.day) ||
+			this._isOpenEnd() ||
+			this.hasAnyQualifier(endQualifiers);
+		if (!hasEnd) return null;
+		return {
+			endQualifiers: { ...endQualifiers },
+			endDate: { ...endDate },
+			endTime: { ...this._endTime() },
+		};
 	}
 
 	private updateFromDisplayTime(): void {
@@ -240,6 +329,7 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 			this._endDate.set({ ...EMPTY_DATE });
 			this._endTime.set({ ...EMPTY_TIME });
 			this._qualifiers.set({ ...EMPTY_QUALIFIERS });
+			this._endQualifiers.set({ ...EMPTY_QUALIFIERS });
 			this._isOpenStart.set(false);
 			this._isOpenEnd.set(false);
 			return;
@@ -247,23 +337,24 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 
 		const startDate = this.displayTime.date ?? { ...EMPTY_DATE };
 		const endDate = this.displayTime.endDate;
+		const startQualifiers = this.displayTime.qualifiers ?? EMPTY_QUALIFIERS;
+		const endQualifiers = this.displayTime.endQualifiers ?? EMPTY_QUALIFIERS;
 		const isInterval = !!endDate;
 		const isStartEmpty = !startDate.year && !startDate.month && !startDate.day;
 		const isEndEmpty =
 			isInterval && !endDate.year && !endDate.month && !endDate.day;
 
-		this._isOpenStart.set(isInterval && isStartEmpty);
-		this._isOpenEnd.set(isEndEmpty);
+		this._isOpenStart.set(
+			isInterval && isStartEmpty && !startQualifiers.unknown,
+		);
+		this._isOpenEnd.set(isEndEmpty && !endQualifiers.unknown);
 
 		this._date.set({ ...startDate });
 		this._time.set(
 			this.displayTime.time ? { ...this.displayTime.time } : { ...EMPTY_TIME },
 		);
-		this._qualifiers.set(
-			this.displayTime.qualifiers
-				? { ...this.displayTime.qualifiers }
-				: { ...EMPTY_QUALIFIERS },
-		);
+		this._qualifiers.set({ ...startQualifiers });
+		this._endQualifiers.set({ ...endQualifiers });
 		this._endDate.set(endDate ? { ...endDate } : { ...EMPTY_DATE });
 		this._endTime.set(
 			this.displayTime.endTime

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -16,7 +16,7 @@ import { CommonModule } from '@angular/common';
 import { format } from 'date-fns';
 import {
 	EdtfService,
-	Meridian,
+	TIME_FORMAT_LABEL,
 	DateTimeModel,
 	DateModel,
 	TimeModel,
@@ -31,8 +31,7 @@ const EMPTY_TIME: TimeModel = {
 	hours: '',
 	minutes: '',
 	seconds: '',
-	am: true,
-	pm: false,
+	format: 'am',
 };
 
 const EMPTY_QUALIFIERS: DateQualifierFlags = {
@@ -94,9 +93,11 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 	});
 
 	formattedStartTime = computed(() => this.formatTime(this._time()));
-	startMeridian = computed(() =>
-		this._time().hours ? (this._time().pm ? Meridian.PM : Meridian.AM) : '',
-	);
+	startMeridian = computed(() => {
+		const time = this._time();
+		if (!time.hours || time.format === 'h24') return '';
+		return TIME_FORMAT_LABEL[time.format];
+	});
 
 	startTimezone = computed(() =>
 		this.edtfService.browserTimezoneAbbreviation(this._date(), this._time()),
@@ -115,13 +116,11 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 	});
 
 	formattedEndTime = computed(() => this.formatTime(this._endTime()));
-	endMeridian = computed(() =>
-		this._endTime().hours
-			? this._endTime().pm
-				? Meridian.PM
-				: Meridian.AM
-			: '',
-	);
+	endMeridian = computed(() => {
+		const time = this._endTime();
+		if (!time.hours || time.format === 'h24') return '';
+		return TIME_FORMAT_LABEL[time.format];
+	});
 
 	endTimezone = computed(() =>
 		this.edtfService.browserTimezoneAbbreviation(

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -1,0 +1,315 @@
+import {
+	Component,
+	Input,
+	Output,
+	EventEmitter,
+	signal,
+	computed,
+	OnInit,
+	OnChanges,
+	SimpleChanges,
+	HostListener,
+	ViewChild,
+	ElementRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { format, setYear } from 'date-fns';
+import {
+	EdtfService,
+	Meridian,
+	DateTimeModel,
+	DateModel,
+	TimeModel,
+	DateQualifierFlags,
+} from '@shared/services/edtf-service/edtf.service';
+import { DatepickerInputComponent } from '@shared/components/datepicker-input/datepicker-input.component';
+import { TimepickerInputComponent } from '@shared/components/timepicker-input/timepicker-input.component';
+
+const EMPTY_DATE: DateModel = { year: '', month: '', day: '' };
+
+const EMPTY_TIME: TimeModel = {
+	hours: '',
+	minutes: '',
+	seconds: '',
+	am: true,
+	pm: false,
+};
+
+const EMPTY_QUALIFIERS: DateQualifierFlags = {
+	approximate: false,
+	uncertain: false,
+	unknown: false,
+};
+
+@Component({
+	selector: 'pr-sidebar-date-picker',
+	standalone: true,
+	imports: [CommonModule, DatepickerInputComponent, TimepickerInputComponent],
+	templateUrl: './sidebar-date-picker.component.html',
+	styleUrls: ['./sidebar-date-picker.component.scss'],
+})
+export class SidebarDatePickerComponent implements OnInit, OnChanges {
+	@Input() displayTime: DateTimeModel | null;
+	@Input() disabled = false;
+
+	@Output() saveClicked = new EventEmitter<DateTimeModel>();
+	@Output() moreOptionsClicked = new EventEmitter<DateTimeModel>();
+
+	@ViewChild('sidebarDatePickerContainer')
+	container?: ElementRef<HTMLElement>;
+
+	constructor(private readonly edtfService: EdtfService) {}
+
+	isDropdownOpen = signal(false);
+
+	_date = signal<DateModel>({ ...EMPTY_DATE });
+	_time = signal<TimeModel>({ ...EMPTY_TIME });
+	_endDate = signal<DateModel>({ ...EMPTY_DATE });
+	_endTime = signal<TimeModel>({ ...EMPTY_TIME });
+	_qualifiers = signal<DateQualifierFlags>({ ...EMPTY_QUALIFIERS });
+	_isOpenStart = signal(false);
+	_isOpenEnd = signal(false);
+
+	activeQualifiers = computed(() => {
+		const q = this._qualifiers();
+		const active: string[] = [];
+		if (q.approximate) active.push('Approximate');
+		if (q.uncertain) active.push('Uncertain');
+		if (q.unknown) active.push('Unknown');
+		return active;
+	});
+
+	// Start date/time computed properties
+	hasStartDate = computed(() => {
+		if (this._qualifiers().unknown) return true;
+		if (this._isOpenStart()) return true;
+		const date = this._date();
+		return !!(date.year || date.month || date.day);
+	});
+
+	formattedStartDate = computed(() => {
+		if (this._qualifiers().unknown) return 'Unknown date and time';
+		if (this._isOpenStart()) return '..';
+		return this.formatDate(this._date());
+	});
+
+	formattedStartTime = computed(() => this.formatTime(this._time()));
+	startMeridian = computed(() =>
+		this._time().hours ? (this._time().pm ? Meridian.PM : Meridian.AM) : '',
+	);
+
+	startTimezone = computed(() =>
+		this.edtfService.browserTimezoneAbbreviation(this._date(), this._time()),
+	);
+
+	// End date/time computed properties
+	hasEndDate = computed(() => {
+		if (this._isOpenEnd()) return true;
+		const date = this._endDate();
+		return !!(date.year || date.month || date.day);
+	});
+
+	formattedEndDate = computed(() => {
+		if (this._isOpenEnd()) return '..';
+		return this.formatDate(this._endDate());
+	});
+
+	formattedEndTime = computed(() => this.formatTime(this._endTime()));
+	endMeridian = computed(() =>
+		this._endTime().hours
+			? this._endTime().pm
+				? Meridian.PM
+				: Meridian.AM
+			: '',
+	);
+
+	endTimezone = computed(() =>
+		this.edtfService.browserTimezoneAbbreviation(
+			this._endDate(),
+			this._endTime(),
+		),
+	);
+
+	ngOnInit(): void {
+		this.updateFromDisplayTime();
+	}
+
+	ngOnChanges(changes: SimpleChanges): void {
+		if (changes.displayTime && !this.isDropdownOpen()) {
+			this.updateFromDisplayTime();
+		}
+	}
+
+	@HostListener('document:click', ['$event'])
+	onDocumentClick(event: MouseEvent): void {
+		const target = event.target as Node;
+		if (
+			this.isDropdownOpen() &&
+			this.container &&
+			target.isConnected &&
+			!this.container.nativeElement.contains(target)
+		) {
+			this.onCancel();
+		}
+	}
+
+	toggle(): void {
+		if (this.disabled) return;
+		const q = this._qualifiers();
+		if (this.hasEndDate() || q.unknown || q.approximate || q.uncertain) {
+			this.onMoreOptions();
+			return;
+		}
+		if (this.isDropdownOpen()) {
+			this.onCancel();
+		} else {
+			this.open();
+		}
+	}
+
+	open(): void {
+		if (this.disabled) return;
+		this.updateFromDisplayTime();
+		this.isDropdownOpen.set(true);
+	}
+
+	onDateChange(newDate: DateModel): void {
+		this._date.set(newDate);
+	}
+
+	onTimeChange(newTime: TimeModel): void {
+		this._time.update((t) => ({
+			...t,
+			...newTime,
+		}));
+	}
+
+	clearAll(): void {
+		this._date.set({ ...EMPTY_DATE });
+		this._time.set({ ...EMPTY_TIME });
+		this._endDate.set({ ...EMPTY_DATE });
+		this._endTime.set({ ...EMPTY_TIME });
+		this._qualifiers.set({ ...EMPTY_QUALIFIERS });
+		this._isOpenStart.set(false);
+		this._isOpenEnd.set(false);
+	}
+
+	onMoreOptions(): void {
+		this.isDropdownOpen.set(false);
+
+		const modalData: DateTimeModel = {
+			qualifiers: { ...this._qualifiers() },
+			date: { ...this._date() },
+			time: { ...this._time() },
+		};
+
+		const endDate = this._endDate();
+		if (endDate.year || endDate.month || endDate.day || this._isOpenEnd()) {
+			modalData.endDate = { ...endDate };
+			modalData.endTime = { ...this._endTime() };
+		}
+
+		this.moreOptionsClicked.emit(modalData);
+	}
+
+	onCancel(): void {
+		this.updateFromDisplayTime();
+		this.isDropdownOpen.set(false);
+	}
+
+	onSave(): void {
+		const dateTimeModel: DateTimeModel = {
+			qualifiers: { ...this._qualifiers() },
+			date: { ...this._date() },
+			time: { ...this._time() },
+		};
+
+		const endDate = this._endDate();
+		if (endDate.year || endDate.month || endDate.day || this._isOpenEnd()) {
+			dateTimeModel.endDate = { ...endDate };
+			dateTimeModel.endTime = { ...this._endTime() };
+		}
+
+		this.saveClicked.emit(dateTimeModel);
+		this.isDropdownOpen.set(false);
+	}
+
+	private updateFromDisplayTime(): void {
+		if (!this.displayTime) {
+			this._date.set({ ...EMPTY_DATE });
+			this._time.set({ ...EMPTY_TIME });
+			this._endDate.set({ ...EMPTY_DATE });
+			this._endTime.set({ ...EMPTY_TIME });
+			this._qualifiers.set({ ...EMPTY_QUALIFIERS });
+			this._isOpenStart.set(false);
+			this._isOpenEnd.set(false);
+			return;
+		}
+
+		const startDate = this.displayTime.date ?? { ...EMPTY_DATE };
+		const endDate = this.displayTime.endDate;
+		const isInterval = !!endDate;
+		const isStartEmpty = !startDate.year && !startDate.month && !startDate.day;
+		const isEndEmpty =
+			isInterval && !endDate.year && !endDate.month && !endDate.day;
+
+		this._isOpenStart.set(isInterval && isStartEmpty);
+		this._isOpenEnd.set(isEndEmpty);
+
+		this._date.set({ ...startDate });
+		this._time.set(
+			this.displayTime.time ? { ...this.displayTime.time } : { ...EMPTY_TIME },
+		);
+		this._qualifiers.set(
+			this.displayTime.qualifiers
+				? { ...this.displayTime.qualifiers }
+				: { ...EMPTY_QUALIFIERS },
+		);
+		this._endDate.set(endDate ? { ...endDate } : { ...EMPTY_DATE });
+		this._endTime.set(
+			this.displayTime.endTime
+				? { ...this.displayTime.endTime }
+				: { ...EMPTY_TIME },
+		);
+	}
+
+	private formatDate(date: DateModel): string {
+		const hasYear = !!date.year;
+		const hasMonth = !!date.month;
+		const hasDay = !!date.day && parseInt(date.day, 10) > 0;
+
+		if (!hasYear && !hasMonth && !hasDay) return '';
+
+		if (hasYear) {
+			const yearNum = parseInt(date.year, 10);
+			const monthNum = hasMonth ? parseInt(date.month, 10) - 1 : 0;
+			const dayNum = hasDay ? parseInt(date.day, 10) : 1;
+
+			// setYear avoids the JS Date quirk where years 0-99 are interpreted as 1900-1999
+			const dateObj = setYear(new Date(2000, monthNum, dayNum), yearNum);
+
+			if (hasMonth && hasDay) return format(dateObj, 'MMMM d, yyyy');
+			if (hasMonth) return format(dateObj, 'MMMM yyyy');
+			return format(dateObj, 'yyyy');
+		}
+
+		const dateParts: string[] = [];
+		if (hasMonth) {
+			const monthIdx = parseInt(date.month, 10) - 1;
+			if (monthIdx >= 0 && monthIdx < 12) {
+				dateParts.push(format(new Date(2000, monthIdx), 'MMMM'));
+			}
+		}
+		if (hasDay) dateParts.push(date.day);
+		return dateParts.join(' ');
+	}
+
+	private formatTime(time: TimeModel): string {
+		if (!time?.hours) return '';
+
+		const h = time.hours.padStart(2, '0');
+		const m = (time.minutes || '00').padStart(2, '0');
+		const s = (time.seconds || '00').padStart(2, '0');
+		return `${h}:${m}:${s}`;
+	}
+}

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -21,6 +21,7 @@ import {
 	DateModel,
 	TimeModel,
 	DateQualifierFlags,
+	DEFAULT_DATE_QUALIFIERS,
 } from '@shared/services/edtf-service/edtf.service';
 import { DatepickerInputComponent } from '@shared/components/datepicker-input/datepicker-input.component';
 import { TimepickerInputComponent } from '@shared/components/timepicker-input/timepicker-input.component';
@@ -32,12 +33,6 @@ const EMPTY_TIME: TimeModel = {
 	minutes: '',
 	seconds: '',
 	format: 'am',
-};
-
-const EMPTY_QUALIFIERS: DateQualifierFlags = {
-	approximate: false,
-	uncertain: false,
-	unknown: false,
 };
 
 interface SidebarDateRow {
@@ -75,8 +70,8 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 	_time = signal<TimeModel>({ ...EMPTY_TIME });
 	_endDate = signal<DateModel>({ ...EMPTY_DATE });
 	_endTime = signal<TimeModel>({ ...EMPTY_TIME });
-	_qualifiers = signal<DateQualifierFlags>({ ...EMPTY_QUALIFIERS });
-	_endQualifiers = signal<DateQualifierFlags>({ ...EMPTY_QUALIFIERS });
+	_qualifiers = signal<DateQualifierFlags>({ ...DEFAULT_DATE_QUALIFIERS });
+	_endQualifiers = signal<DateQualifierFlags>({ ...DEFAULT_DATE_QUALIFIERS });
 	_isOpenStart = signal(false);
 	_isOpenEnd = signal(false);
 
@@ -264,8 +259,8 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 		this._time.set({ ...EMPTY_TIME });
 		this._endDate.set({ ...EMPTY_DATE });
 		this._endTime.set({ ...EMPTY_TIME });
-		this._qualifiers.set({ ...EMPTY_QUALIFIERS });
-		this._endQualifiers.set({ ...EMPTY_QUALIFIERS });
+		this._qualifiers.set({ ...DEFAULT_DATE_QUALIFIERS });
+		this._endQualifiers.set({ ...DEFAULT_DATE_QUALIFIERS });
 		this._isOpenStart.set(false);
 		this._isOpenEnd.set(false);
 	}
@@ -328,8 +323,8 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 			this._time.set({ ...EMPTY_TIME });
 			this._endDate.set({ ...EMPTY_DATE });
 			this._endTime.set({ ...EMPTY_TIME });
-			this._qualifiers.set({ ...EMPTY_QUALIFIERS });
-			this._endQualifiers.set({ ...EMPTY_QUALIFIERS });
+			this._qualifiers.set({ ...DEFAULT_DATE_QUALIFIERS });
+			this._endQualifiers.set({ ...DEFAULT_DATE_QUALIFIERS });
 			this._isOpenStart.set(false);
 			this._isOpenEnd.set(false);
 			return;
@@ -337,8 +332,10 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 
 		const startDate = this.displayTime.date ?? { ...EMPTY_DATE };
 		const endDate = this.displayTime.endDate;
-		const startQualifiers = this.displayTime.qualifiers ?? EMPTY_QUALIFIERS;
-		const endQualifiers = this.displayTime.endQualifiers ?? EMPTY_QUALIFIERS;
+		const startQualifiers =
+			this.displayTime.qualifiers ?? DEFAULT_DATE_QUALIFIERS;
+		const endQualifiers =
+			this.displayTime.endQualifiers ?? DEFAULT_DATE_QUALIFIERS;
 		const isInterval = !!endDate;
 		const isStartEmpty = !startDate.year && !startDate.month && !startDate.day;
 		const isEndEmpty =

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -293,7 +293,9 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 		const monthName = monthComplete
 			? format(new Date(2000, parseInt(monthRaw, 10) - 1), 'MMMM')
 			: null;
-		const dayDisplay = hasDay ? this.padDigitsWithX(dayRaw, 2) : '';
+		// A day is a discrete value, not a range, so a single digit is
+		// zero-padded on the left ("2" -> "02") rather than X-padded.
+		const dayDisplay = hasDay ? dayRaw.padStart(2, '0') : '';
 
 		if (monthName && hasDay)
 			return `${monthName} ${dayDisplay}, ${yearDisplay}`;

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -13,7 +13,7 @@ import {
 	ElementRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { format, setYear } from 'date-fns';
+import { format } from 'date-fns';
 import {
 	EdtfService,
 	Meridian,
@@ -273,35 +273,38 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 		);
 	}
 
+	private padDigitsWithX(value: string, width: number): string {
+		const v = value ?? '';
+		return v.length >= width ? v : v + 'X'.repeat(width - v.length);
+	}
+
 	private formatDate(date: DateModel): string {
-		const hasYear = !!date.year;
-		const hasMonth = !!date.month;
-		const hasDay = !!date.day && parseInt(date.day, 10) > 0;
+		const yearRaw = date.year ?? '';
+		const monthRaw = date.month ?? '';
+		const dayRaw = date.day ?? '';
+
+		const hasYear = !!yearRaw;
+		const hasMonth = !!monthRaw;
+		const hasDay = !!dayRaw && parseInt(dayRaw, 10) !== 0;
 
 		if (!hasYear && !hasMonth && !hasDay) return '';
 
-		if (hasYear) {
-			const yearNum = parseInt(date.year, 10);
-			const monthNum = hasMonth ? parseInt(date.month, 10) - 1 : 0;
-			const dayNum = hasDay ? parseInt(date.day, 10) : 1;
+		const yearDisplay = this.padDigitsWithX(yearRaw, 4);
+		const monthComplete = /^\d{2}$/.test(monthRaw);
+		const monthName = monthComplete
+			? format(new Date(2000, parseInt(monthRaw, 10) - 1), 'MMMM')
+			: null;
+		const dayDisplay = hasDay ? this.padDigitsWithX(dayRaw, 2) : '';
 
-			// setYear avoids the JS Date quirk where years 0-99 are interpreted as 1900-1999
-			const dateObj = setYear(new Date(2000, monthNum, dayNum), yearNum);
+		if (monthName && hasDay)
+			return `${monthName} ${dayDisplay}, ${yearDisplay}`;
+		if (monthName) return `${monthName} ${yearDisplay}`;
+		if (!hasMonth && !hasDay) return yearDisplay;
 
-			if (hasMonth && hasDay) return format(dateObj, 'MMMM d, yyyy');
-			if (hasMonth) return format(dateObj, 'MMMM yyyy');
-			return format(dateObj, 'yyyy');
-		}
-
-		const dateParts: string[] = [];
-		if (hasMonth) {
-			const monthIdx = parseInt(date.month, 10) - 1;
-			if (monthIdx >= 0 && monthIdx < 12) {
-				dateParts.push(format(new Date(2000, monthIdx), 'MMMM'));
-			}
-		}
-		if (hasDay) dateParts.push(date.day);
-		return dateParts.join(' ');
+		const monthDisplay = hasMonth ? this.padDigitsWithX(monthRaw, 2) : 'XX';
+		const parts: string[] = [yearDisplay, monthDisplay];
+		if (hasDay) parts.push(dayDisplay);
+		return parts.join('-');
 	}
 
 	private formatTime(time: TimeModel): string {

--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -106,35 +106,13 @@
 			</div>
 		</div>
 		<div class="sidebar-item">
-			<label>{{ selectedItem.isFolder ? 'Start date' : 'Date' }}</label>
-			<pr-inline-value-edit
-				[displayValue]="displayTime"
-				[canEdit]="canEdit"
-				[item]="selectedItem"
-				[itemId]="selectedItem.folder_linkId"
-				emptyMessage="Click to add date"
-				[readOnlyEmptyMessage]="
-					selectedItem.isFolder ? 'No start date' : 'No date'
-				"
-				(doneEditing)="onDateEditing('start', $event)"
-				type="date"
-			></pr-inline-value-edit>
+			<pr-sidebar-date-picker
+				[displayTime]="displayTimeObject"
+				[disabled]="!canEdit"
+				(saveClicked)="onDateSaved($event)"
+				(moreOptionsClicked)="onDateMoreOptions($event)"
+			/>
 		</div>
-		@if (selectedItem.isFolder) {
-			<div class="sidebar-item">
-				<label>End date</label>
-				<pr-inline-value-edit
-					[displayValue]="displayEndTime"
-					[canEdit]="canEdit"
-					[item]="selectedItem"
-					[itemId]="selectedItem.folder_linkId"
-					emptyMessage="Click to add date"
-					readOnlyEmptyMessage="No end date"
-					(doneEditing)="onDateEditing('end', $event)"
-					type="date"
-				></pr-inline-value-edit>
-			</div>
-		}
 		<div class="sidebar-item">
 			<label>Location</label>
 			<div

--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -105,14 +105,47 @@
 				></pr-edit-tags>
 			</div>
 		</div>
-		<div class="sidebar-item">
-			<pr-sidebar-date-picker
-				[displayTime]="displayTimeObject"
-				[disabled]="!canEdit"
-				(saveClicked)="onDateSaved($event)"
-				(moreOptionsClicked)="onDateMoreOptions($event)"
-			/>
-		</div>
+		@if (showEdtfDatePicker) {
+			<div class="sidebar-item">
+				<pr-sidebar-date-picker
+					[displayTime]="displayTimeObject"
+					[disabled]="!canEdit"
+					(saveClicked)="onDateSaved($event)"
+					(moreOptionsClicked)="onDateMoreOptions($event)"
+				/>
+			</div>
+		} @else {
+			<div class="sidebar-item">
+				<label>{{ selectedItem.isFolder ? 'Start date' : 'Date' }}</label>
+				<pr-inline-value-edit
+					[displayValue]="displayTime"
+					[canEdit]="canEdit"
+					[item]="selectedItem"
+					[itemId]="selectedItem.folder_linkId"
+					emptyMessage="Click to add date"
+					[readOnlyEmptyMessage]="
+						selectedItem.isFolder ? 'No start date' : 'No date'
+					"
+					(doneEditing)="onDateEditing('start', $event)"
+					type="date"
+				></pr-inline-value-edit>
+			</div>
+			@if (selectedItem.isFolder) {
+				<div class="sidebar-item">
+					<label>End date</label>
+					<pr-inline-value-edit
+						[displayValue]="displayEndTime"
+						[canEdit]="canEdit"
+						[item]="selectedItem"
+						[itemId]="selectedItem.folder_linkId"
+						emptyMessage="Click to add date"
+						readOnlyEmptyMessage="No end date"
+						(doneEditing)="onDateEditing('end', $event)"
+						type="date"
+					></pr-inline-value-edit>
+				</div>
+			}
+		}
 		<div class="sidebar-item">
 			<label>Location</label>
 			<div

--- a/src/app/file-browser/components/sidebar/sidebar.component.scss
+++ b/src/app/file-browser/components/sidebar/sidebar.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 $sidebar-border: $file-list-border;
 $sidebar-thumb-height: 200px;

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -7,6 +7,7 @@ import { ArchiveVO, RecordVO } from '@models/index';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
 import { BehaviorSubject } from 'rxjs';
 import { MessageService } from '@shared/services/message/message.service';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 import { SidebarComponent } from './sidebar.component';
 
 @Pipe({ name: 'prTooltip', standalone: false })
@@ -120,6 +121,10 @@ class MockAccountService {
 	}
 }
 
+const mockFeatureFlagService = {
+	isEnabled: (_flag: string) => false,
+};
+
 describe('SidebarComponent', () => {
 	let component: SidebarComponent;
 	let fixture: ComponentFixture<SidebarComponent>;
@@ -169,6 +174,10 @@ describe('SidebarComponent', () => {
 						showError: () => {},
 						showMessage: () => {},
 					},
+				},
+				{
+					provide: FeatureFlagService,
+					useValue: mockFeatureFlagService,
 				},
 			],
 			schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -273,6 +282,23 @@ describe('SidebarComponent', () => {
 			component.selectedItem.displayTime || component.selectedItem.displayDT;
 
 		expect(displayValue).toBe('2024-01-01T00:00:00.000Z');
+	});
+
+	describe('edtf-date feature flag', () => {
+		it('should set showEdtfDatePicker to false when edtf-date flag is disabled', () => {
+			expect(component.showEdtfDatePicker).toBe(false);
+		});
+
+		it('should set showEdtfDatePicker to true when edtf-date flag is enabled', () => {
+			spyOn(mockFeatureFlagService, 'isEnabled').and.callFake(
+				(flag: string) => flag === 'edtf-date',
+			);
+
+			const enabledFixture = TestBed.createComponent(SidebarComponent);
+			enabledFixture.detectChanges();
+
+			expect(enabledFixture.componentInstance.showEdtfDatePicker).toBe(true);
+		});
 	});
 
 	it('should hide the original format for folders', () => {

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -581,6 +581,58 @@ describe('SidebarComponent', () => {
 			);
 		});
 
+		it('should refresh the cached display time after saving from the modal', async () => {
+			spyOn(mockEditService, 'saveItemVoProperty').and.callFake(
+				async (item: any, prop: any, value: any) => {
+					item[prop] = value;
+				},
+			);
+
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			component.onDateMoreOptions({
+				date: { year: '1985', month: '05', day: '20' },
+				time: { format: 'am' },
+			} as DateTimeModel);
+
+			closedSubject.next({
+				date: { year: '2000', month: '03', day: '15' },
+				time: { format: 'am' },
+			} as DateTimeModel);
+			await fixture.whenStable();
+
+			expect(component.displayTimeObject?.date.year).toBe('2000');
+		});
+
+		it('should not save when the modal closes after the sidebar is destroyed', () => {
+			const saveSpy = spyOn(mockEditService, 'saveItemVoProperty');
+
+			const modalData: DateTimeModel = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					format: 'am',
+				},
+			};
+
+			component.onDateMoreOptions(modalData);
+			component.ngOnDestroy();
+
+			closedSubject.next({
+				date: { year: '2000', month: '03', day: '15' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					format: 'am',
+				},
+			});
+
+			expect(saveSpy).not.toHaveBeenCalled();
+		});
+
 		it('should not save when modal is dismissed', () => {
 			const saveSpy = spyOn(
 				mockEditService,

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -4,8 +4,9 @@ import { DataService } from '@shared/services/data/data.service';
 import { EditService } from '@core/services/edit/edit.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { ArchiveVO, RecordVO } from '@models/index';
-import { of } from 'rxjs';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
+import { BehaviorSubject } from 'rxjs';
+import { MessageService } from '@shared/services/message/message.service';
 import { SidebarComponent } from './sidebar.component';
 
 @Pipe({ name: 'prTooltip', standalone: false })
@@ -92,15 +93,10 @@ class MockSelectedItemPipe implements PipeTransform {
 	}
 }
 
+let selectedItemsSubject: BehaviorSubject<Set<any>>;
+
 const mockDataService = {
-	selectedItems$: () =>
-		of(
-			new Set([
-				new RecordVO({
-					accessRole: 'access.role.owner',
-				}),
-			]),
-		),
+	selectedItems$: () => selectedItemsSubject.asObservable(),
 	fetchFullItems: (_: any) => {},
 	currentFolder: {
 		type: 'folder',
@@ -109,9 +105,7 @@ const mockDataService = {
 
 const mockEditService = {
 	openLocationDialog: (_: any) => {},
-	saveItemVoProperty: jasmine
-		.createSpy('saveItemVoProperty')
-		.and.returnValue(Promise.resolve()),
+	saveItemVoProperty: (_item: any, _prop: any, _value: any) => {},
 };
 
 class MockAccountService {
@@ -131,6 +125,14 @@ describe('SidebarComponent', () => {
 	let fixture: ComponentFixture<SidebarComponent>;
 
 	beforeEach(async () => {
+		selectedItemsSubject = new BehaviorSubject<Set<any>>(
+			new Set([
+				new RecordVO({
+					accessRole: 'access.role.owner',
+				}),
+			]),
+		);
+
 		await TestBed.configureTestingModule({
 			declarations: [
 				SidebarComponent,
@@ -160,6 +162,13 @@ describe('SidebarComponent', () => {
 				{
 					provide: AccountService,
 					useClass: MockAccountService,
+				},
+				{
+					provide: MessageService,
+					useValue: {
+						showError: () => {},
+						showMessage: () => {},
+					},
 				},
 			],
 			schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -335,72 +344,6 @@ describe('SidebarComponent', () => {
 			component.selectedItem = item;
 
 			expect(component.displayEndTime).toBe('');
-		});
-	});
-
-	describe('onDateEditing', () => {
-		beforeEach(() => {
-			mockEditService.saveItemVoProperty.calls.reset();
-		});
-
-		it('should build EDTF interval when setting start date and end date exists', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('start', '2000-01-01');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				'2000-01-01/1990-06-15',
-			);
-		});
-
-		it('should build EDTF interval when setting end date and start date exists', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('end', '2025-12-31');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				'1985-05-20/2025-12-31',
-			);
-		});
-
-		it('should set only start date when no end date is provided', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('start', '2000-01-01');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				'2000-01-01',
-			);
-		});
-
-		it('should set displayTime to null when start date is cleared', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('start', '');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				null,
-			);
-		});
-
-		it('should not call saveItemVoProperty when selectedItem is null', async () => {
-			component.selectedItem = null;
-
-			await component.onDateEditing('start', '2000-01-01');
-
-			expect(mockEditService.saveItemVoProperty).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -492,5 +492,22 @@ describe('SidebarComponent', () => {
 			expect(component.displayTimeObject).toBeNull();
 			expect(showErrorSpy).toHaveBeenCalledTimes(1);
 		});
+
+		it('should recompute the display time object when saving an invalid date fails, so the picker re-syncs to the stored value', async () => {
+			const messageService = TestBed.inject(MessageService);
+			const showErrorSpy = spyOn(messageService, 'showError');
+			const edtfService = TestBed.inject(EdtfService);
+			spyOn(edtfService, 'toEdtfDate').and.throwError('invalid date');
+
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: 'not-a-year' } as never,
+				time: { format: 'am' },
+			});
+
+			expect(showErrorSpy).toHaveBeenCalledTimes(1);
+			expect(component.displayTimeObject?.date.year).toBe('1985');
+		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -8,6 +8,7 @@ import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
 import { BehaviorSubject } from 'rxjs';
 import { MessageService } from '@shared/services/message/message.service';
 import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
+import { EdtfService } from '@shared/services/edtf-service/edtf.service';
 import { SidebarComponent } from './sidebar.component';
 
 @Pipe({ name: 'prTooltip', standalone: false })
@@ -370,6 +371,126 @@ describe('SidebarComponent', () => {
 			component.selectedItem = item;
 
 			expect(component.displayEndTime).toBe('');
+		});
+	});
+
+	describe('onDateEditing', () => {
+		let saveItemVoPropertySpy: jasmine.Spy;
+
+		beforeEach(() => {
+			saveItemVoPropertySpy = spyOn(mockEditService, 'saveItemVoProperty');
+		});
+
+		it('should build EDTF interval when setting start date and end date exists', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('start', '2000-01-01');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				'2000-01-01/1990-06-15',
+			);
+		});
+
+		it('should build EDTF interval when setting end date and start date exists', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('end', '2025-12-31');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				'1985-05-20/2025-12-31',
+			);
+		});
+
+		it('should set only start date when no end date is provided', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('start', '2000-01-01');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				'2000-01-01',
+			);
+		});
+
+		it('should set displayTime to null when start date is cleared', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('start', '');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				null,
+			);
+		});
+
+		it('should not call saveItemVoProperty when selectedItem is null', async () => {
+			component.selectedItem = null;
+
+			await component.onDateEditing('start', '2000-01-01');
+
+			expect(saveItemVoPropertySpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('displayTimeObject', () => {
+		it('should keep a stable reference across reads instead of creating a new object each time', async () => {
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: '1985', month: '05', day: '20' },
+				time: { format: 'am' },
+			});
+
+			const firstRead = component.displayTimeObject;
+			const secondRead = component.displayTimeObject;
+
+			expect(firstRead).not.toBeNull();
+			expect(secondRead).toBe(firstRead);
+		});
+
+		it('should recompute the display time object when a new date is saved', async () => {
+			const editService = TestBed.inject(EditService);
+			spyOn(editService, 'saveItemVoProperty').and.callFake(
+				async (item: any, prop: any, value: any) => {
+					item[prop] = value;
+				},
+			);
+
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: '1990', month: '06', day: '15' },
+				time: { format: 'am' },
+			});
+
+			expect(component.displayTimeObject?.date.year).toBe('1990');
+		});
+
+		it('should null the display time object and show one error when parsing fails', async () => {
+			const messageService = TestBed.inject(MessageService);
+			const showErrorSpy = spyOn(messageService, 'showError');
+			const edtfService = TestBed.inject(EdtfService);
+			spyOn(edtfService, 'toDateTimeModel').and.throwError('bad date');
+
+			component.selectedItem = new RecordVO({ displayTime: 'not-a-date' });
+
+			await component.onDateSaved({
+				date: { year: '1990', month: '06', day: '15' },
+				time: { format: 'am' },
+			});
+
+			expect(component.displayTimeObject).toBeNull();
+			expect(showErrorSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -5,10 +5,12 @@ import { EditService } from '@core/services/edit/edit.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { ArchiveVO, RecordVO } from '@models/index';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { DateTimeModel } from '@shared/services/edtf-service/edtf.service';
 import { MessageService } from '@shared/services/message/message.service';
 import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 import { EdtfService } from '@shared/services/edtf-service/edtf.service';
+import { EditDateTimeModalService } from '../edit-date-time-modal/edit-date-time-modal.service';
 import { SidebarComponent } from './sidebar.component';
 
 @Pipe({ name: 'prTooltip', standalone: false })
@@ -110,6 +112,14 @@ const mockEditService = {
 	saveItemVoProperty: (_item: any, _prop: any, _value: any) => {},
 };
 
+let closedSubject: Subject<DateTimeModel | undefined>;
+
+const mockModalService = {
+	open: (_data: DateTimeModel) => ({
+		closed: closedSubject.asObservable(),
+	}),
+};
+
 class MockAccountService {
 	getArchive() {
 		return new ArchiveVO({});
@@ -131,6 +141,8 @@ describe('SidebarComponent', () => {
 	let fixture: ComponentFixture<SidebarComponent>;
 
 	beforeEach(async () => {
+		closedSubject = new Subject<DateTimeModel | undefined>();
+
 		selectedItemsSubject = new BehaviorSubject<Set<any>>(
 			new Set([
 				new RecordVO({
@@ -168,6 +180,10 @@ describe('SidebarComponent', () => {
 				{
 					provide: AccountService,
 					useClass: MockAccountService,
+				},
+				{
+					provide: EditDateTimeModalService,
+					useValue: mockModalService,
 				},
 				{
 					provide: MessageService,
@@ -508,6 +524,83 @@ describe('SidebarComponent', () => {
 
 			expect(showErrorSpy).toHaveBeenCalledTimes(1);
 			expect(component.displayTimeObject?.date.year).toBe('1985');
+		});
+	});
+
+	describe('onDateMoreOptions', () => {
+		it('should open the edit date time modal with provided data', () => {
+			const openSpy = spyOn(mockModalService, 'open').and.callThrough();
+
+			const modalData: DateTimeModel = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					format: 'am',
+				},
+			};
+
+			component.onDateMoreOptions(modalData);
+
+			expect(openSpy).toHaveBeenCalledWith(modalData);
+		});
+
+		it('should save displayTime when modal returns a result', () => {
+			const saveSpy = spyOn(
+				mockEditService,
+				'saveItemVoProperty',
+			).and.callThrough();
+
+			const modalData: DateTimeModel = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					format: 'am',
+				},
+			};
+
+			component.onDateMoreOptions(modalData);
+
+			closedSubject.next({
+				date: { year: '2000', month: '03', day: '15' },
+				time: {
+					hours: '10',
+					minutes: '30',
+					seconds: '00',
+					format: 'am',
+				},
+			});
+
+			expect(saveSpy).toHaveBeenCalledWith(
+				component.selectedItem,
+				'displayTime',
+				jasmine.any(String),
+			);
+		});
+
+		it('should not save when modal is dismissed', () => {
+			const saveSpy = spyOn(
+				mockEditService,
+				'saveItemVoProperty',
+			).and.callThrough();
+
+			const modalData: DateTimeModel = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					format: 'am',
+				},
+			};
+
+			component.onDateMoreOptions(modalData);
+			closedSubject.next(undefined);
+
+			expect(saveSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -19,6 +19,7 @@ import {
 } from '@shared/services/edtf-service/edtf.service';
 import { MessageService } from '@shared/services/message/message.service';
 import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
+import { EditDateTimeModalService } from '../edit-date-time-modal/edit-date-time-modal.service';
 
 type SidebarTab = 'info' | 'details' | 'sharing' | 'views';
 @Component({
@@ -97,6 +98,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		private edtfService: EdtfService,
 		private message: MessageService,
 		private accountService: AccountService,
+		private editDateTimeModalService: EditDateTimeModalService,
 		private cdr: ChangeDetectorRef,
 		private feature: FeatureFlagService,
 	) {
@@ -258,8 +260,19 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		}
 	}
 
-	async onDateMoreOptions(): Promise<void> {
-		//TODO: add edit date time modal PER-10642
+	async onDateMoreOptions(modalData: DateTimeModel): Promise<void> {
+		const dialogRef = this.editDateTimeModalService.open(modalData);
+
+		dialogRef.closed.subscribe(async (result) => {
+			if (result) {
+				try {
+					const newDisplayTime = this.edtfService.toEdtfDate(result);
+					await this.onFinishEditing('displayTime', newDisplayTime);
+				} catch (err) {
+					this.message.showError({ message: err?.message });
+				}
+			}
+		});
 	}
 
 	onLocationClick() {

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -250,29 +250,32 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	}
 
 	async onDateSaved(result: DateTimeModel) {
+		await this.saveDisplayTime(result);
+	}
+
+	async onDateMoreOptions(modalData: DateTimeModel): Promise<void> {
+		const dialogRef = this.editDateTimeModalService.open(modalData);
+
+		this.subscriptions.push(
+			dialogRef.closed.subscribe(async (result) => {
+				if (result) {
+					await this.saveDisplayTime(result);
+				}
+			}),
+		);
+	}
+
+	private async saveDisplayTime(result: DateTimeModel): Promise<void> {
 		try {
 			const newDisplayTime = this.edtfService.toEdtfDate(result);
 			await this.onFinishEditing('displayTime', newDisplayTime);
 		} catch (err) {
 			this.message.showError({ message: err?.message });
 		} finally {
+			// Recompute so the picker re-syncs to the stored value, whether the
+			// save came from the inline picker or the modal, and on failure too.
 			this.updateDisplayTimeObject();
 		}
-	}
-
-	async onDateMoreOptions(modalData: DateTimeModel): Promise<void> {
-		const dialogRef = this.editDateTimeModalService.open(modalData);
-
-		dialogRef.closed.subscribe(async (result) => {
-			if (result) {
-				try {
-					const newDisplayTime = this.edtfService.toEdtfDate(result);
-					await this.onFinishEditing('displayTime', newDisplayTime);
-				} catch (err) {
-					this.message.showError({ message: err?.message });
-				}
-			}
-		});
 	}
 
 	onLocationClick() {

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -18,6 +18,7 @@ import {
 	EdtfService,
 } from '@shared/services/edtf-service/edtf.service';
 import { MessageService } from '@shared/services/message/message.service';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 
 type SidebarTab = 'info' | 'details' | 'sharing' | 'views';
 @Component({
@@ -45,6 +46,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	canUseViews: boolean;
 
 	originalFileExtension: string = '';
+
+	showEdtfDatePicker: boolean;
 
 	get displayTimeObject(): DateTimeModel | null {
 		try {
@@ -91,8 +94,10 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		private message: MessageService,
 		private accountService: AccountService,
 		private cdr: ChangeDetectorRef,
+		private feature: FeatureFlagService,
 	) {
 		this.currentArchive = this.accountService.getArchive();
+		this.showEdtfDatePicker = this.feature.isEnabled('edtf-date');
 
 		this.subscriptions.push(
 			this.dataService.selectedItems$().subscribe(async (selectedItems) => {

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -49,14 +49,18 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 
 	showEdtfDatePicker: boolean;
 
-	get displayTimeObject(): DateTimeModel | null {
+	displayTimeObject: DateTimeModel | null = null;
+
+	private updateDisplayTimeObject(): void {
+		const timeSource =
+			this.selectedItem?.displayTime || this.selectedItem?.displayDT;
 		try {
-			const timeSource =
-				this.selectedItem?.displayTime || this.selectedItem?.displayDT;
-			return timeSource ? this.edtfService.toDateTimeModel(timeSource) : null;
+			this.displayTimeObject = timeSource
+				? this.edtfService.toDateTimeModel(timeSource)
+				: null;
 		} catch (err) {
+			this.displayTimeObject = null;
 			this.message.showError({ message: err?.message });
-			return null;
 		}
 	}
 
@@ -162,6 +166,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 					this.isRecord = !this.selectedItem.isFolder;
 				}
 
+				this.updateDisplayTimeObject();
+
 				this.cdr.markForCheck();
 			}),
 		);
@@ -245,6 +251,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		try {
 			const newDisplayTime = this.edtfService.toEdtfDate(result);
 			await this.onFinishEditing('displayTime', newDisplayTime);
+			this.updateDisplayTimeObject();
 		} catch (err) {
 			this.message.showError({ message: err?.message });
 		}

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -251,9 +251,10 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		try {
 			const newDisplayTime = this.edtfService.toEdtfDate(result);
 			await this.onFinishEditing('displayTime', newDisplayTime);
-			this.updateDisplayTimeObject();
 		} catch (err) {
 			this.message.showError({ message: err?.message });
+		} finally {
+			this.updateDisplayTimeObject();
 		}
 	}
 

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -13,6 +13,11 @@ import { EditService } from '@core/services/edit/edit.service';
 import { AccountService } from '@shared/services/account/account.service';
 
 import type { KeysOfType } from '@shared/utilities/keysoftype';
+import {
+	DateTimeModel,
+	EdtfService,
+} from '@shared/services/edtf-service/edtf.service';
+import { MessageService } from '@shared/services/message/message.service';
 
 type SidebarTab = 'info' | 'details' | 'sharing' | 'views';
 @Component({
@@ -40,6 +45,17 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	canUseViews: boolean;
 
 	originalFileExtension: string = '';
+
+	get displayTimeObject(): DateTimeModel | null {
+		try {
+			const timeSource =
+				this.selectedItem?.displayTime || this.selectedItem?.displayDT;
+			return timeSource ? this.edtfService.toDateTimeModel(timeSource) : null;
+		} catch (err) {
+			this.message.showError({ message: err?.message });
+			return null;
+		}
+	}
 
 	get displayTime(): string {
 		return this.parseEdtfInterval('start');
@@ -71,6 +87,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	constructor(
 		private dataService: DataService,
 		private editService: EditService,
+		private edtfService: EdtfService,
+		private message: MessageService,
 		private accountService: AccountService,
 		private cdr: ChangeDetectorRef,
 	) {
@@ -117,7 +135,13 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 						await this.dataService.fetchFullItems(items);
 						this.isLoading = false;
 					}
+				} else if (
+					this.selectedItem?.isFolder &&
+					!this.selectedItem?.displayTime
+				) {
+					await this.dataService.fetchFullItems([this.selectedItem]);
 				}
+
 				if (
 					this.selectedItem instanceof RecordVO &&
 					this.selectedItem.FileVOs &&
@@ -132,6 +156,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 					this.originalFileExtension = '';
 					this.isRecord = !this.selectedItem.isFolder;
 				}
+
+				this.cdr.markForCheck();
 			}),
 		);
 	}
@@ -202,8 +228,25 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	}
 
 	async onFinishEditing(property: KeysOfType<ItemVO, String>, value: string) {
-		this.editService.saveItemVoProperty(this.selectedItem, property, value);
-		this.cdr.detectChanges();
+		await this.editService.saveItemVoProperty(
+			this.selectedItem,
+			property,
+			value,
+		);
+		this.cdr.markForCheck();
+	}
+
+	async onDateSaved(result: DateTimeModel) {
+		try {
+			const newDisplayTime = this.edtfService.toEdtfDate(result);
+			await this.onFinishEditing('displayTime', newDisplayTime);
+		} catch (err) {
+			this.message.showError({ message: err?.message });
+		}
+	}
+
+	async onDateMoreOptions(): Promise<void> {
+		//TODO: add edit date time modal PER-10642
 	}
 
 	onLocationClick() {

--- a/src/app/file-browser/file-browser-components.module.ts
+++ b/src/app/file-browser/file-browser-components.module.ts
@@ -27,6 +27,7 @@ import { SidebarViewOptionComponent } from './components/sidebar-view-option/sid
 import { SharingDialogComponent } from './components/sharing-dialog/sharing-dialog.component';
 
 import { DownloadButtonComponent } from './components/download-button/download-button.component';
+import { SidebarDatePickerComponent } from './components/sidebar-date-picker/sidebar-date-picker.component';
 
 @NgModule({
 	imports: [
@@ -36,6 +37,7 @@ import { DownloadButtonComponent } from './components/download-button/download-b
 		GoogleMapsModule,
 		InViewportModule,
 		FontAwesomeModule,
+		SidebarDatePickerComponent,
 	],
 	exports: [
 		FileListComponent,

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.html
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.html
@@ -1,51 +1,57 @@
-<div class="pr-date-input-group" [class.active]="showDatepicker()">
-	<input
-		#yearInput
-		type="text"
-		class="pr-date-segment year"
-		[value]="date.year"
-		[disabled]="disabled"
-		(input)="updateYear($event)"
-		placeholder="YYYY"
-		maxlength="4"
-	/>
-	<span class="pr-separator">/</span>
-	<input
-		#monthInput
-		type="text"
-		class="pr-date-segment"
-		[value]="date.month ?? ''"
-		[disabled]="disabled"
-		(input)="updateMonth($event)"
-		(keydown)="onMonthKeydown($event)"
-		placeholder="MM"
-		maxlength="2"
-	/>
-	<span class="pr-separator">/</span>
-	<input
-		#dayInput
-		type="text"
-		class="pr-date-segment"
-		[value]="date.day ?? ''"
-		[disabled]="disabled"
-		(input)="updateDay($event)"
-		(keydown)="onDayKeydown($event)"
-		placeholder="DD"
-		maxlength="2"
-	/>
-	<div class="pr-calendar-icon-wrapper">
-		<span
-			class="pr-icon-button"
-			role="button"
-			tabindex="0"
-			[class.disabled]="disabled"
-			(click)="toggleDatepicker()"
-			(keydown.enter)="toggleDatepicker()"
-			(keydown.space)="toggleDatepicker()"
-		>
-			<i class="material-icons">calendar_today</i>
-		</span>
+<div class="pr-date-input-wrap">
+	<div
+		class="pr-date-input-group"
+		[class.active]="showDatepicker()"
+		[class.has-error]="!!currentError()"
+	>
+		<input
+			#yearInput
+			type="text"
+			class="pr-date-segment year"
+			[value]="date.year"
+			[disabled]="disabled"
+			(input)="updateYear($event)"
+			placeholder="YYYY"
+			maxlength="4"
+		/>
+		<span class="pr-separator">/</span>
+		<input
+			#monthInput
+			type="text"
+			class="pr-date-segment"
+			[value]="date.month ?? ''"
+			[disabled]="disabled"
+			(input)="updateMonth($event)"
+			(keydown)="onMonthKeydown($event)"
+			placeholder="MM"
+			maxlength="2"
+		/>
+		<span class="pr-separator">/</span>
+		<input
+			#dayInput
+			type="text"
+			class="pr-date-segment"
+			[value]="date.day ?? ''"
+			[disabled]="disabled"
+			(input)="updateDay($event)"
+			(keydown)="onDayKeydown($event)"
+			placeholder="DD"
+			maxlength="2"
+		/>
+		<div class="pr-calendar-icon-wrapper">
+			<span
+				class="pr-icon-button"
+				[class.disabled]="disabled"
+				(click)="toggleDatepicker()"
+			>
+				<i class="material-icons">calendar_today</i>
+			</span>
+		</div>
 	</div>
+
+	@if (currentError()) {
+		<span class="pr-input-error">{{ currentError() }}</span>
+	}
 </div>
 
 @if (showDatepicker()) {

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.scss
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.scss
@@ -4,7 +4,13 @@
 :host {
 	position: relative;
 	display: block;
-	height: 40px;
+	min-height: 40px;
+}
+
+.pr-date-input-wrap {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 }
 
 .pr-date-input-group {
@@ -15,6 +21,14 @@
 	&.active {
 		@include input-focus-state;
 	}
+
+	&.has-error {
+		@include input-error-state;
+	}
+}
+
+.pr-input-error {
+	@include input-error-message;
 }
 
 .pr-date-segment {

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
@@ -110,6 +110,17 @@ describe('DatepickerInputComponent', () => {
 		expect(hostComponent.lastEmittedDate?.day).toBe('3');
 	});
 
+	it('should allow backspacing a left-padded day down to a single "0" without reverting', () => {
+		hostComponent.date = { year: '2026', month: '01', day: '05' };
+		fixture.detectChanges();
+		const input = { value: '0' } as HTMLInputElement;
+
+		component.updateDay({ target: input } as unknown as Event);
+
+		expect(input.value).toBe('0');
+		expect(hostComponent.lastEmittedDate?.day).toBe('0');
+	});
+
 	it('should not emit day greater than max for month', () => {
 		hostComponent.date = { year: '2026', month: '02', day: '' };
 		fixture.detectChanges();

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
@@ -1,7 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { DateModel } from '@shared/services/edtf-service/edtf.service';
-import { DatepickerInputComponent } from './datepicker-input.component';
+import {
+	DatepickerInputComponent,
+	DAY_RANGE_ERROR,
+	INVALID_CHARS_ERROR,
+	MONTH_RANGE_ERROR,
+} from './datepicker-input.component';
 
 @Component({
 	standalone: true,
@@ -46,22 +51,20 @@ describe('DatepickerInputComponent', () => {
 	const mockEvent = (value: string): Event =>
 		({ target: { value } }) as unknown as Event;
 
+	// --- Valid input ---
+
 	it('should accept valid 4-digit year and emit', () => {
 		component.updateYear(mockEvent('2026'));
 
 		expect(hostComponent.lastEmittedDate?.year).toBe('2026');
+		expect(component.fieldErrors.year()).toBeNull();
 	});
 
 	it('should emit incomplete year as raw digits (no X in input)', () => {
 		component.updateYear(mockEvent('202'));
 
 		expect(hostComponent.lastEmittedDate?.year).toBe('202');
-	});
-
-	it('should reject non-numeric year', () => {
-		component.updateYear(mockEvent('20ab'));
-
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(component.fieldErrors.year()).toBeNull();
 	});
 
 	it('should accept year padded with leading zeros (ISO 8601)', () => {
@@ -74,40 +77,72 @@ describe('DatepickerInputComponent', () => {
 		component.updateMonth(mockEvent('06'));
 
 		expect(hostComponent.lastEmittedDate?.month).toBe('06');
+		expect(component.fieldErrors.month()).toBeNull();
 	});
 
-	it('should emit single digit month', () => {
+	it('should accept single digit month', () => {
 		component.updateMonth(mockEvent('1'));
 
 		expect(hostComponent.lastEmittedDate?.month).toBe('1');
+		expect(component.fieldErrors.month()).toBeNull();
 	});
 
-	it('should not emit or auto-focus for invalid month', () => {
+	it('should accept day 29 for February in leap year', () => {
+		hostComponent.date = { year: '2024', month: '02', day: '' };
+		fixture.detectChanges();
+		component.updateDay(mockEvent('29'));
+
+		expect(hostComponent.lastEmittedDate?.day).toBe('29');
+		expect(component.fieldErrors.day()).toBeNull();
+	});
+
+	// --- Invalid input now emits AND surfaces an error ---
+
+	it('should emit invalid characters in the year and surface the invalid-characters error', () => {
+		component.updateYear(mockEvent('20ab'));
+
+		expect(hostComponent.lastEmittedDate?.year).toBe('20ab');
+		expect(component.fieldErrors.year()).toBe(INVALID_CHARS_ERROR);
+		expect(component.currentError()).toBe(INVALID_CHARS_ERROR);
+	});
+
+	it('should emit out-of-range month and surface the month error', () => {
 		component.updateMonth(mockEvent('13'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.month).toBe('13');
+		expect(component.fieldErrors.month()).toBe(MONTH_RANGE_ERROR);
 	});
 
-	it('should reject non-numeric month', () => {
+	it('should NOT surface the month range error while only one digit has been typed', () => {
+		component.updateMonth(mockEvent('5'));
+
+		expect(hostComponent.lastEmittedDate?.month).toBe('5');
+		expect(component.fieldErrors.month()).toBeNull();
+	});
+
+	it('should NOT surface the day range error while only one digit has been typed', () => {
+		hostComponent.date = { year: '2026', month: '02', day: '' };
+		fixture.detectChanges();
+		component.updateDay(mockEvent('9'));
+
+		expect(hostComponent.lastEmittedDate?.day).toBe('9');
+		expect(component.fieldErrors.day()).toBeNull();
+	});
+
+	it('should emit invalid characters in the month and surface the invalid-characters error', () => {
 		component.updateMonth(mockEvent('ab'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.month).toBe('ab');
+		expect(component.fieldErrors.month()).toBe(INVALID_CHARS_ERROR);
 	});
 
-	it('should accept valid 2-digit day for month and emit', () => {
-		hostComponent.date = { year: '2026', month: '01', day: '' };
+	it('should emit day 31 in April and surface the day error', () => {
+		hostComponent.date = { year: '2026', month: '04', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('31'));
 
 		expect(hostComponent.lastEmittedDate?.day).toBe('31');
-	});
-
-	it('should emit single digit day', () => {
-		hostComponent.date = { year: '2026', month: '01', day: '' };
-		fixture.detectChanges();
-		component.updateDay(mockEvent('3'));
-
-		expect(hostComponent.lastEmittedDate?.day).toBe('3');
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
 	it('should allow backspacing a left-padded day down to a single "0" without reverting', () => {
@@ -121,55 +156,84 @@ describe('DatepickerInputComponent', () => {
 		expect(hostComponent.lastEmittedDate?.day).toBe('0');
 	});
 
-	it('should not emit day greater than max for month', () => {
+	it('should emit day 30 in February and surface the day error', () => {
 		hostComponent.date = { year: '2026', month: '02', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('30'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.day).toBe('30');
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
-	it('should accept day 29 for February in leap year', () => {
-		hostComponent.date = { year: '2024', month: '02', day: '' };
-		fixture.detectChanges();
-		component.updateDay(mockEvent('29'));
-
-		expect(hostComponent.lastEmittedDate?.day).toBe('29');
-	});
-
-	it('should not emit day 29 for February in non-leap year', () => {
+	it('should emit day 29 in February of a non-leap year and surface the day error', () => {
 		hostComponent.date = { year: '2025', month: '02', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('29'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.day).toBe('29');
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
-	it('should not emit day 31 for 30-day months', () => {
-		hostComponent.date = { year: '2026', month: '04', day: '' };
+	it('should re-validate the day when the month changes', () => {
+		hostComponent.date = { year: '2026', month: '01', day: '31' };
 		fixture.detectChanges();
-		component.updateDay(mockEvent('31'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(component.fieldErrors.day()).toBeNull();
+
+		component.updateMonth(mockEvent('04'));
+
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
-	it('should allow typing first digit 0 or 1 for month', () => {
-		const input = { value: '0' } as HTMLInputElement;
-		component.updateMonth({ target: input } as unknown as Event);
+	it('should clear the year error when the field is cleared', () => {
+		component.updateYear(mockEvent('20ab'));
 
-		expect(input.value).toBe('0');
+		expect(component.fieldErrors.year()).not.toBeNull();
+
+		component.updateYear(mockEvent(''));
+
+		expect(component.fieldErrors.year()).toBeNull();
 	});
 
-	it('should reject first digit > 1 for month', () => {
-		hostComponent.date = { year: '', month: '', day: '' };
-		fixture.detectChanges();
-		const input = { value: '5' } as HTMLInputElement;
-		component.updateMonth({ target: input } as unknown as Event);
+	// --- Auto-focus behavior ---
 
-		expect(input.value).toBe('');
+	it('should auto-focus the month input after a valid 4-digit year', () => {
+		const focusSpy = spyOn(
+			component.monthInput.nativeElement,
+			'focus',
+		).and.callThrough();
+		component.updateYear(mockEvent('2026'));
+
+		expect(focusSpy).toHaveBeenCalled();
 	});
 
-	it('should emit when clearing year field', () => {
+	it('should NOT auto-focus the month input when the year has invalid characters', () => {
+		const focusSpy = spyOn(component.monthInput.nativeElement, 'focus');
+		component.updateYear(mockEvent('20ab'));
+
+		expect(focusSpy).not.toHaveBeenCalled();
+	});
+
+	it('should auto-focus the day input after a valid 2-digit month', () => {
+		const focusSpy = spyOn(
+			component.dayInput.nativeElement,
+			'focus',
+		).and.callThrough();
+		component.updateMonth(mockEvent('06'));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('should NOT auto-focus the day input when the month is out of range', () => {
+		const focusSpy = spyOn(component.dayInput.nativeElement, 'focus');
+		component.updateMonth(mockEvent('13'));
+
+		expect(focusSpy).not.toHaveBeenCalled();
+	});
+
+	// --- Misc ---
+
+	it('should emit when clearing the year field', () => {
 		hostComponent.date = { year: '2026', month: '02', day: '18' };
 		fixture.detectChanges();
 		component.updateYear(mockEvent(''));
@@ -201,8 +265,9 @@ describe('DatepickerInputComponent', () => {
 		expect(component.showDatepicker()).toBeFalse();
 	});
 
-	it('should emit date and close datepicker on date select', () => {
+	it('should emit date and clear errors on date select', () => {
 		component.showDatepicker.set(true);
+		component.fieldErrors.month.set(MONTH_RANGE_ERROR);
 		component.onDateSelect({ year: 2026, month: 3, day: 15 });
 
 		expect(hostComponent.lastEmittedDate).toEqual({
@@ -212,6 +277,7 @@ describe('DatepickerInputComponent', () => {
 		});
 
 		expect(component.showDatepicker()).toBeFalse();
+		expect(component.currentError()).toBeNull();
 	});
 
 	it('should return null datepickerModel for incomplete date', () => {
@@ -228,5 +294,12 @@ describe('DatepickerInputComponent', () => {
 		} as unknown as MouseEvent);
 
 		expect(component.showDatepicker()).toBeFalse();
+	});
+
+	it('should refresh errors from incoming @Input date on changes', () => {
+		hostComponent.date = { year: '2026', month: '13', day: '' };
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.month()).toBe(MONTH_RANGE_ERROR);
 	});
 });

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.ts
@@ -4,12 +4,14 @@ import {
 	Output,
 	EventEmitter,
 	signal,
+	computed,
 	HostListener,
 	ElementRef,
 	ViewChild,
 	OnChanges,
 	SimpleChanges,
 	OnInit,
+	WritableSignal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgbDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
@@ -17,6 +19,12 @@ import {
 	DateModel,
 	EdtfService,
 } from '@shared/services/edtf-service/edtf.service';
+
+export const INVALID_CHARS_ERROR = 'The date contains invalid characters.';
+export const MONTH_RANGE_ERROR = 'Month must be between 1 and 12.';
+export const DAY_RANGE_ERROR = 'Day must be between 1 and 31.';
+
+type DateFieldKey = keyof DateModel;
 
 @Component({
 	selector: 'pr-datepicker-input',
@@ -38,6 +46,18 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 	showDatepicker = signal(false);
 	datepickerModel = signal<NgbDateStruct | null>(null);
 
+	readonly fieldErrors: Record<DateFieldKey, WritableSignal<string | null>> = {
+		year: signal<string | null>(null),
+		month: signal<string | null>(null),
+		day: signal<string | null>(null),
+	};
+	currentError = computed(
+		() =>
+			this.fieldErrors.year() ??
+			this.fieldErrors.month() ??
+			this.fieldErrors.day(),
+	);
+
 	constructor(
 		private elementRef: ElementRef,
 		private edtfService: EdtfService,
@@ -45,11 +65,13 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 
 	ngOnInit(): void {
 		this.updateDatepickerModel(this.date);
+		this.refreshErrorsFromInput();
 	}
 
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.date) {
 			this.updateDatepickerModel(this.date);
+			this.refreshErrorsFromInput();
 		}
 	}
 
@@ -62,6 +84,46 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 		} else {
 			this.datepickerModel.set(null);
 		}
+	}
+
+	private refreshErrorsFromInput(): void {
+		(Object.keys(this.fieldErrors) as DateFieldKey[]).forEach((datePropKey) =>
+			this.fieldErrors[datePropKey].set(
+				this.getFieldError(datePropKey, this.date[datePropKey] ?? ''),
+			),
+		);
+	}
+
+	private getFieldError(
+		datePropKey: DateFieldKey,
+		value: string,
+	): string | null {
+		if (datePropKey === 'year') return this.getYearError(value);
+		if (datePropKey === 'month') return this.getMonthError(value);
+		return this.getDayError(value, this.date.month ?? '');
+	}
+
+	private getYearError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+		});
+	}
+
+	private getMonthError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (month) => this.edtfService.isValidMonth(month),
+			rangeMessage: MONTH_RANGE_ERROR,
+		});
+	}
+
+	private getDayError(value: string, month: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (day) =>
+				this.edtfService.isValidDay(day, this.date.year, month),
+			rangeMessage: DAY_RANGE_ERROR,
+		});
 	}
 
 	@HostListener('document:click', ['$event'])
@@ -77,45 +139,34 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 	}
 
 	updateYear(event: Event): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (!this.edtfService.isValidYear(value)) {
-			input.value = this.date.year;
-			return;
-		}
+		const value = (event.target as HTMLInputElement).value;
+		const error = this.getFieldError('year', value);
+		this.fieldErrors.year.set(error);
 
 		this.dateChange.emit({ ...this.date, year: value });
-		if (value.length === 4) {
+		if (!error && value.length === 4) {
 			this.monthInput.nativeElement.focus();
 		}
 	}
 
 	updateMonth(event: Event): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (!this.edtfService.isValidMonth(value)) {
-			input.value = this.date.month ?? '';
-			return;
-		}
+		const value = (event.target as HTMLInputElement).value;
+		const error = this.getFieldError('month', value);
+		this.fieldErrors.month.set(error);
 
 		this.dateChange.emit({ ...this.date, month: value });
-		if (value.length === 2) {
+
+		// Re-validate day because its bounds depend on the month.
+		this.fieldErrors.day.set(this.getDayError(this.date.day ?? '', value));
+
+		if (!error && value.length === 2) {
 			this.dayInput.nativeElement.focus();
 		}
 	}
 
 	updateDay(event: Event): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (
-			!this.edtfService.isValidDay(value, this.date.year, this.date.month ?? '')
-		) {
-			input.value = this.date.day ?? '';
-			return;
-		}
+		const value = (event.target as HTMLInputElement).value;
+		this.fieldErrors.day.set(this.getFieldError('day', value));
 
 		this.dateChange.emit({ ...this.date, day: value });
 	}
@@ -126,6 +177,7 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newYear = (this.date.year ?? '').slice(0, -1);
+		this.fieldErrors.year.set(this.getFieldError('year', newYear));
 		this.dateChange.emit({ ...this.date, year: newYear });
 		this.yearInput.nativeElement.focus();
 	}
@@ -136,6 +188,8 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newMonth = (this.date.month ?? '').slice(0, -1);
+		this.fieldErrors.month.set(this.getFieldError('month', newMonth));
+		this.fieldErrors.day.set(this.getDayError(this.date.day ?? '', newMonth));
 		this.dateChange.emit({ ...this.date, month: newMonth });
 		this.monthInput.nativeElement.focus();
 	}
@@ -148,6 +202,9 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 			day: String(newDate.day).padStart(2, '0'),
 		};
 		this.date = updatedDate;
+		Object.values(this.fieldErrors).forEach((fieldError) =>
+			fieldError.set(null),
+		);
 		this.dateChange.emit(updatedDate);
 		this.showDatepicker.set(false);
 	}

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.html
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.html
@@ -1,54 +1,64 @@
-<div class="pr-time-input-group" [class.active]="showTimepicker()">
-	<input
-		#hoursInput
-		type="text"
-		class="pr-time-segment"
-		[value]="time.hours ?? ''"
-		[disabled]="disabled"
-		(input)="updateTime($event, 'hours', minutesInput)"
-		placeholder="hh"
-		maxlength="2"
-	/>
-	<span class="pr-colon">:</span>
-	<input
-		#minutesInput
-		type="text"
-		class="pr-time-segment"
-		[value]="time.minutes ?? ''"
-		[disabled]="disabled"
-		(input)="updateTime($event, 'minutes', secondsInput?.nativeElement)"
-		(keydown)="onMinutesKeydown($event)"
-		placeholder="mm"
-		maxlength="2"
-	/>
-	<span class="pr-colon">:</span>
-	<input
-		#secondsInput
-		type="text"
-		class="pr-time-segment"
-		[value]="time.seconds ?? ''"
-		[disabled]="disabled"
-		(input)="updateTime($event, 'seconds')"
-		(keydown)="onSecondsKeydown($event)"
-		placeholder="ss"
-		maxlength="2"
-	/>
-	<button class="pr-am-pm-toggle" [disabled]="disabled" (click)="cycleFormat()">
-		{{ formatLabel() }}
-	</button>
-	<div class="pr-time-icon-wrapper">
-		<span
-			class="pr-icon-button"
-			role="button"
-			tabindex="0"
-			[class.disabled]="disabled"
-			(click)="toggleTimepicker()"
-			(keydown.enter)="toggleTimepicker()"
-			(keydown.space)="toggleTimepicker()"
+<div class="pr-time-input-wrap">
+	<div
+		class="pr-time-input-group"
+		[class.active]="showTimepicker()"
+		[class.has-error]="!!currentError()"
+	>
+		<input
+			#hoursInput
+			type="text"
+			class="pr-time-segment"
+			[value]="time.hours ?? ''"
+			[disabled]="disabled"
+			(input)="updateTime($event, 'hours', minutesInput)"
+			placeholder="hh"
+			maxlength="2"
+		/>
+		<span class="pr-colon">:</span>
+		<input
+			#minutesInput
+			type="text"
+			class="pr-time-segment"
+			[value]="time.minutes ?? ''"
+			[disabled]="disabled"
+			(input)="updateTime($event, 'minutes', secondsInput)"
+			(keydown)="onMinutesKeydown($event)"
+			placeholder="mm"
+			maxlength="2"
+		/>
+		<span class="pr-colon">:</span>
+		<input
+			#secondsInput
+			type="text"
+			class="pr-time-segment"
+			[value]="time.seconds ?? ''"
+			[disabled]="disabled"
+			(input)="updateTime($event, 'seconds')"
+			(keydown)="onSecondsKeydown($event)"
+			placeholder="ss"
+			maxlength="2"
+		/>
+		<button
+			class="pr-am-pm-toggle"
+			[disabled]="disabled"
+			(click)="cycleFormat()"
 		>
-			<i class="material-icons">access_time</i>
-		</span>
+			{{ formatLabel() }}
+		</button>
+		<div class="pr-time-icon-wrapper">
+			<span
+				class="pr-icon-button"
+				[class.disabled]="disabled"
+				(click)="toggleTimepicker()"
+			>
+				<i class="material-icons">access_time</i>
+			</span>
+		</div>
 	</div>
+
+	@if (currentError()) {
+		<span class="pr-input-error">{{ currentError() }}</span>
+	}
 </div>
 
 @if (showTimepicker()) {

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.scss
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.scss
@@ -4,7 +4,13 @@
 :host {
 	position: relative;
 	display: block;
-	height: 40px;
+	min-height: 40px;
+}
+
+.pr-time-input-wrap {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 }
 
 .pr-time-input-group {
@@ -15,6 +21,14 @@
 	&.active {
 		@include input-focus-state;
 	}
+
+	&.has-error {
+		@include input-error-state;
+	}
+}
+
+.pr-input-error {
+	@include input-error-message;
 }
 
 .pr-time-segment {

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.spec.ts
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.spec.ts
@@ -1,7 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { TimeModel } from '@shared/services/edtf-service/edtf.service';
-import { TimepickerInputComponent } from './timepicker-input.component';
+import {
+	HOUR_12_RANGE_ERROR,
+	HOUR_24_RANGE_ERROR,
+	INVALID_CHARS_ERROR,
+	MINUTES_RANGE_ERROR,
+	SECONDS_RANGE_ERROR,
+	TimepickerInputComponent,
+} from './timepicker-input.component';
 
 @Component({
 	template: `<pr-timepicker-input
@@ -47,6 +54,16 @@ describe('TimepickerInputComponent', () => {
 	const mockEvent = (value: string): Event =>
 		({ target: { value } }) as unknown as Event;
 
+	const switchToH24 = (): void => {
+		hostComponent.time = {
+			hours: '',
+			minutes: '',
+			seconds: '',
+			format: 'h24',
+		};
+		fixture.detectChanges();
+	};
+
 	// --- Basic rendering ---
 
 	it('should create', () => {
@@ -80,107 +97,120 @@ describe('TimepickerInputComponent', () => {
 		expect(component.showTimepicker()).toBeFalse();
 	});
 
-	// --- Hour validation (12-hour) ---
+	// --- Hour validation (12-hour mode) ---
 
-	it('should accept valid hour', () => {
+	it('should accept valid hour and clear hours error', () => {
 		component.updateTime(mockEvent('10'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('10');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	it('should reject hour greater than 12', () => {
+	it('should emit hour > 12 in 12-hour mode AND surface 1-12 error', () => {
 		component.updateTime(mockEvent('13'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('13');
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
 	});
 
-	it('should reject non-numeric hour', () => {
+	it('should emit non-numeric hour AND surface the invalid-characters error', () => {
 		component.updateTime(mockEvent('ab'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('ab');
+		expect(component.fieldErrors.hours()).toBe(INVALID_CHARS_ERROR);
 	});
 
-	it('should accept single digit 0 or 1 for hours', () => {
+	it('should accept single digit 0 or 1 for hours in 12-hour mode', () => {
 		component.updateTime(mockEvent('1'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('1');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	it('should reject single digit greater than 1 for hours', () => {
+	it('should NOT surface the hours range error while only one digit has been typed', () => {
 		component.updateTime(mockEvent('2'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('2');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	// --- Hour validation (24-hour) ---
+	it('should NOT surface the minutes range error while only one digit has been typed', () => {
+		component.updateTime(mockEvent('9'), 'minutes');
+
+		expect(hostComponent.lastEmittedTime?.minutes).toBe('9');
+		expect(component.fieldErrors.minutes()).toBeNull();
+	});
+
+	it('should NOT surface the seconds range error while only one digit has been typed', () => {
+		component.updateTime(mockEvent('9'), 'seconds');
+
+		expect(hostComponent.lastEmittedTime?.seconds).toBe('9');
+		expect(component.fieldErrors.seconds()).toBeNull();
+	});
+
+	// --- Hour validation (24-hour mode) ---
 
 	it('should accept hours 00-23 in h24 mode', () => {
-		hostComponent.time = {
-			hours: '',
-			minutes: '',
-			seconds: '',
-			format: 'h24',
-		};
-		fixture.detectChanges();
+		switchToH24();
 
 		component.updateTime(mockEvent('00'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('00');
-
-		component.updateTime(mockEvent('13'), 'hours');
-
-		expect(hostComponent.lastEmittedTime?.hours).toBe('13');
+		expect(component.fieldErrors.hours()).toBeNull();
 
 		component.updateTime(mockEvent('23'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('23');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	it('should reject hours 24 and above in h24 mode', () => {
-		hostComponent.time = {
-			hours: '12',
-			minutes: '',
-			seconds: '',
-			format: 'h24',
-		};
-		fixture.detectChanges();
-		hostComponent.lastEmittedTime = null;
+	it('should emit hour 24 in h24 mode AND surface 0-23 error', () => {
+		switchToH24();
 
 		component.updateTime(mockEvent('24'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
-
-		component.updateTime(mockEvent('30'), 'hours');
-
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('24');
+		expect(component.fieldErrors.hours()).toBe(HOUR_24_RANGE_ERROR);
 	});
 
-	it('should accept single digit 0-2 for hours in h24 mode', () => {
+	it('should re-validate the hour when the format toggles (15 valid in h24, invalid in 12-hour)', () => {
 		hostComponent.time = {
-			hours: '',
+			hours: '15',
 			minutes: '',
 			seconds: '',
 			format: 'h24',
 		};
 		fixture.detectChanges();
 
-		component.updateTime(mockEvent('2'), 'hours');
+		expect(component.fieldErrors.hours()).toBeNull();
 
-		expect(hostComponent.lastEmittedTime?.hours).toBe('2');
+		component.cycleFormat();
+
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
 	});
 
-	it('should reject single digit greater than 2 for hours in h24 mode', () => {
+	it('should clear the hour error when the format toggles to one where the value is valid', () => {
 		hostComponent.time = {
-			hours: '',
+			hours: '15',
 			minutes: '',
 			seconds: '',
-			format: 'h24',
+			format: 'am',
 		};
 		fixture.detectChanges();
 
-		component.updateTime(mockEvent('3'), 'hours');
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		// am -> pm: still 12-hour, still invalid
+		component.cycleFormat();
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
+
+		// pm -> h24: now valid
+		component.cycleFormat();
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
 	// --- Minute validation ---
@@ -189,24 +219,21 @@ describe('TimepickerInputComponent', () => {
 		component.updateTime(mockEvent('30'), 'minutes');
 
 		expect(hostComponent.lastEmittedTime?.minutes).toBe('30');
+		expect(component.fieldErrors.minutes()).toBeNull();
 	});
 
-	it('should reject minutes greater than 59', () => {
+	it('should emit minutes 60 AND surface the minutes error', () => {
 		component.updateTime(mockEvent('60'), 'minutes');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.minutes).toBe('60');
+		expect(component.fieldErrors.minutes()).toBe(MINUTES_RANGE_ERROR);
 	});
 
-	it('should accept single digit 0-5 for minutes', () => {
-		component.updateTime(mockEvent('5'), 'minutes');
+	it('should emit non-numeric minutes AND surface the invalid-characters error', () => {
+		component.updateTime(mockEvent('a5'), 'minutes');
 
-		expect(hostComponent.lastEmittedTime?.minutes).toBe('5');
-	});
-
-	it('should reject single digit greater than 5 for minutes', () => {
-		component.updateTime(mockEvent('6'), 'minutes');
-
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.minutes).toBe('a5');
+		expect(component.fieldErrors.minutes()).toBe(INVALID_CHARS_ERROR);
 	});
 
 	// --- Second validation ---
@@ -215,17 +242,19 @@ describe('TimepickerInputComponent', () => {
 		component.updateTime(mockEvent('45'), 'seconds');
 
 		expect(hostComponent.lastEmittedTime?.seconds).toBe('45');
+		expect(component.fieldErrors.seconds()).toBeNull();
 	});
 
-	it('should reject seconds greater than 59', () => {
+	it('should emit seconds 60 AND surface the seconds error', () => {
 		component.updateTime(mockEvent('60'), 'seconds');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.seconds).toBe('60');
+		expect(component.fieldErrors.seconds()).toBe(SECONDS_RANGE_ERROR);
 	});
 
-	// --- Empty values ---
+	// --- Empty values clear errors ---
 
-	it('should allow clearing fields', () => {
+	it('should allow clearing fields and clear errors', () => {
 		hostComponent.time = {
 			hours: '10',
 			minutes: '30',
@@ -236,6 +265,69 @@ describe('TimepickerInputComponent', () => {
 		component.updateTime(mockEvent(''), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('');
+		expect(component.fieldErrors.hours()).toBeNull();
+	});
+
+	// --- currentError priority ---
+
+	it('should surface hours error first when both hours and minutes are invalid', () => {
+		component.updateTime(mockEvent('13'), 'hours');
+		component.updateTime(mockEvent('60'), 'minutes');
+
+		expect(component.currentError()).toBe(HOUR_12_RANGE_ERROR);
+	});
+
+	// --- Auto-focus ---
+
+	it('should auto-focus the next field after a valid 2-digit hour', () => {
+		const focusSpy = spyOn(
+			component.minutesInput.nativeElement,
+			'focus',
+		).and.callThrough();
+		component.updateTime(
+			mockEvent('10'),
+			'hours',
+			component.minutesInput.nativeElement,
+		);
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('should NOT auto-focus the next field when the value is out of range', () => {
+		const focusSpy = spyOn(component.minutesInput.nativeElement, 'focus');
+		component.updateTime(
+			mockEvent('13'),
+			'hours',
+			component.minutesInput.nativeElement,
+		);
+
+		expect(focusSpy).not.toHaveBeenCalled();
+	});
+
+	// Dispatches real DOM input events so the template bindings themselves are
+	// exercised — a regression test for the minutes -> seconds focus jump.
+	it('should auto-focus the seconds input after a valid 2-digit minutes value via the template', () => {
+		const [, minutesElement, secondsElement] = Array.from<HTMLInputElement>(
+			fixture.nativeElement.querySelectorAll('.pr-time-segment'),
+		);
+		const focusSpy = spyOn(secondsElement, 'focus');
+
+		minutesElement.value = '30';
+		minutesElement.dispatchEvent(new Event('input'));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('should auto-focus the minutes input after a valid 2-digit hour via the template', () => {
+		const [hoursElement, minutesElement] = Array.from<HTMLInputElement>(
+			fixture.nativeElement.querySelectorAll('.pr-time-segment'),
+		);
+		const focusSpy = spyOn(minutesElement, 'focus');
+
+		hoursElement.value = '10';
+		hoursElement.dispatchEvent(new Event('input'));
+
+		expect(focusSpy).toHaveBeenCalled();
 	});
 
 	// --- Format cycle ---
@@ -503,5 +595,18 @@ describe('TimepickerInputComponent', () => {
 		component.onTimeSelect({ hour: 14, minute: 45, second: 0 });
 
 		expect(hostComponent.lastEmittedTime?.timezoneOffset).toBe('+05:30');
+	});
+	// --- Initial / @Input-driven error sync ---
+
+	it('should surface errors derived from incoming @Input time', () => {
+		hostComponent.time = {
+			hours: '25',
+			minutes: '',
+			seconds: '',
+			format: 'h24',
+		};
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.hours()).toBe(HOUR_24_RANGE_ERROR);
 	});
 });

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.ts
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.ts
@@ -12,6 +12,7 @@ import {
 	OnDestroy,
 	ViewChild,
 	ElementRef,
+	WritableSignal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
@@ -24,6 +25,14 @@ import {
 	DEFAULT_TIME,
 	EdtfService,
 } from '@shared/services/edtf-service/edtf.service';
+
+export const INVALID_CHARS_ERROR = 'The time contains invalid characters.';
+export const HOUR_24_RANGE_ERROR = 'Hour must be between 0 and 23.';
+export const HOUR_12_RANGE_ERROR = 'Hour must be between 1 and 12.';
+export const MINUTES_RANGE_ERROR = 'Minutes must be between 0 and 59.';
+export const SECONDS_RANGE_ERROR = 'Seconds must be between 0 and 59.';
+
+type TimeFieldKey = keyof Pick<TimeModel, 'hours' | 'minutes' | 'seconds'>;
 
 @Component({
 	selector: 'pr-timepicker-input',
@@ -51,6 +60,18 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 	formatLabel = computed(() => TIME_FORMAT_LABEL[this.timeSignal().format]);
 	is24Hour = computed(() => this.timeSignal().format === 'h24');
 
+	readonly fieldErrors: Record<TimeFieldKey, WritableSignal<string | null>> = {
+		hours: signal<string | null>(null),
+		minutes: signal<string | null>(null),
+		seconds: signal<string | null>(null),
+	};
+	currentError = computed(
+		() =>
+			this.fieldErrors.hours() ??
+			this.fieldErrors.minutes() ??
+			this.fieldErrors.seconds(),
+	);
+
 	private destroy$ = new Subject<void>();
 
 	constructor(
@@ -62,6 +83,7 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		this.timepickerControl.valueChanges
 			.pipe(takeUntil(this.destroy$))
 			.subscribe((ngbTime) => this.onTimeSelect(ngbTime));
+		this.refreshErrorsFromInput();
 	}
 
 	ngOnChanges(changes: SimpleChanges): void {
@@ -72,12 +94,58 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 			if (!this.ngbTimeEquals(model, current)) {
 				this.timepickerControl.setValue(model, { emitEvent: false });
 			}
+			this.refreshErrorsFromInput();
 		}
 	}
 
 	ngOnDestroy(): void {
 		this.destroy$.next();
 		this.destroy$.complete();
+	}
+
+	private refreshErrorsFromInput(): void {
+		(Object.keys(this.fieldErrors) as TimeFieldKey[]).forEach((timePropKey) =>
+			this.fieldErrors[timePropKey].set(
+				this.getFieldError(timePropKey, this.time[timePropKey] ?? ''),
+			),
+		);
+	}
+
+	private getFieldError(
+		timePropKey: TimeFieldKey,
+		value: string,
+	): string | null {
+		if (timePropKey === 'hours') {
+			return this.getHoursError(value, this.is24Hour());
+		}
+		if (timePropKey === 'minutes') return this.getMinutesError(value);
+		return this.getSecondsError(value);
+	}
+
+	private getHoursError(value: string, is24Hour: boolean): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (hours) => this.edtfService.isValidHour(hours, is24Hour),
+			rangeMessage: is24Hour ? HOUR_24_RANGE_ERROR : HOUR_12_RANGE_ERROR,
+		});
+	}
+
+	private getMinutesError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (minutes) =>
+				this.edtfService.isValidMinutesSeconds(minutes),
+			rangeMessage: MINUTES_RANGE_ERROR,
+		});
+	}
+
+	private getSecondsError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (seconds) =>
+				this.edtfService.isValidMinutesSeconds(seconds),
+			rangeMessage: SECONDS_RANGE_ERROR,
+		});
 	}
 
 	@HostListener('document:click', ['$event'])
@@ -126,6 +194,10 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		const nextFormat =
 			this.FORMAT_CYCLE[(currentIndex + 1) % this.FORMAT_CYCLE.length];
 		this.timeChange.emit({ ...this.time, format: nextFormat });
+		// Hour validity depends on the format — re-check against the new format.
+		this.fieldErrors.hours.set(
+			this.getHoursError(this.time.hours ?? '', nextFormat === 'h24'),
+		);
 	}
 
 	onMinutesKeydown(event: KeyboardEvent): void {
@@ -134,6 +206,7 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newHours = (this.time.hours ?? '').slice(0, -1);
+		this.fieldErrors.hours.set(this.getFieldError('hours', newHours));
 		this.timeChange.emit({ ...this.time, hours: newHours });
 		this.hoursInput.nativeElement.focus();
 	}
@@ -144,37 +217,24 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newMinutes = (this.time.minutes ?? '').slice(0, -1);
+		this.fieldErrors.minutes.set(this.getFieldError('minutes', newMinutes));
 		this.timeChange.emit({ ...this.time, minutes: newMinutes });
 		this.minutesInput.nativeElement.focus();
 	}
 
 	updateTime(
 		event: Event,
-		timePropKey: keyof Pick<TimeModel, 'hours' | 'minutes' | 'seconds'>,
+		timePropKey: TimeFieldKey,
 		nextField?: HTMLInputElement,
 	): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (value !== '') {
-			const isValid =
-				timePropKey === 'hours'
-					? this.edtfService.isValidHour(value, this.is24Hour())
-					: this.edtfService.isValidMinutesSeconds(value);
-			if (!isValid) {
-				input.value = this.time[timePropKey] ?? '';
-				return;
-			}
-		}
+		const value = (event.target as HTMLInputElement).value;
+		const error = this.getFieldError(timePropKey, value);
+		this.fieldErrors[timePropKey].set(error);
 
 		this.timeChange.emit({ ...this.time, [timePropKey]: value });
 
-		if (nextField && value.length === 2) {
-			const isComplete =
-				timePropKey === 'hours'
-					? this.edtfService.isValidHour(value, this.is24Hour())
-					: this.edtfService.isValidMinutesSeconds(value);
-			if (isComplete) nextField.focus();
+		if (!error && nextField && value.length === 2) {
+			nextField.focus();
 		}
 	}
 

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -201,7 +201,7 @@ export class FolderRepo extends BaseRepo {
 		const queryData = {
 			folderIds: folderVOs.map((currentFolder) => currentFolder.folderId),
 		};
-		let folderResponse: PagedStelaResponse<StelaFolder> | any;
+		let folderResponse: PagedStelaResponse<StelaFolder>;
 		if (shareToken) {
 			folderResponse = (
 				await firstValueFrom(

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -201,7 +201,7 @@ export class FolderRepo extends BaseRepo {
 		const queryData = {
 			folderIds: folderVOs.map((currentFolder) => currentFolder.folderId),
 		};
-		let folderResponse: PagedStelaResponse<StelaFolder>;
+		let folderResponse: PagedStelaResponse<StelaFolder> | any;
 		if (shareToken) {
 			folderResponse = (
 				await firstValueFrom(

--- a/src/app/shared/services/api/record.repo.spec.ts
+++ b/src/app/shared/services/api/record.repo.spec.ts
@@ -6,7 +6,11 @@ import {
 import { of } from 'rxjs';
 import { environment } from '@root/environments/environment';
 import { HttpService } from '@shared/services/http/http.service';
-import { RecordRepo, RecordResponse } from '@shared/services/api/record.repo';
+import {
+	convertStelaRecordToRecordVO,
+	RecordRepo,
+	RecordResponse,
+} from '@shared/services/api/record.repo';
 import { RecordVO } from '@root/app/models';
 import {
 	provideHttpClient,
@@ -231,6 +235,7 @@ describe('RecordRepo', () => {
 			displayName: 'Test Record',
 			archiveNumber: 'arch-1',
 			displayDate: '2025-01-01',
+			displayTime: '1985-05-20T10:00:00+05:30',
 			folderLinkId: '1',
 			folderLinkType: 'type.folder_link.private',
 			parentFolderLinkId: '2',
@@ -305,6 +310,46 @@ describe('RecordRepo', () => {
 			const resultRecord = result.getRecordVO();
 
 			expect(resultRecord).toBeInstanceOf(RecordVO);
+		});
+	});
+
+	describe('convertStelaRecordToRecordVO', () => {
+		const baseStelaRecord = {
+			recordId: 42,
+			displayName: 'Test Record',
+			archiveNumber: 'arch-1',
+			displayDate: '2025-01-01',
+			folderLinkId: '1',
+			folderLinkType: 'type.folder_link.private' as any,
+			parentFolderLinkId: '2',
+			thumbUrl200: '',
+			thumbUrl500: '',
+			thumbUrl1000: '',
+			thumbUrl2000: '',
+			location: null,
+			files: [],
+			createdAt: '2025-01-01',
+			updatedAt: '2025-01-01',
+			archive: { id: '1', name: 'Archive', thumbURL200: '' },
+			shares: null,
+			tags: null,
+		};
+
+		it('should map displayTime from the stela record', () => {
+			const record = convertStelaRecordToRecordVO({
+				...baseStelaRecord,
+				displayTime: '1985-05-20T10:00:00+05:30',
+			} as any);
+
+			expect(record.displayTime).toBe('1985-05-20T10:00:00+05:30');
+		});
+
+		it('should leave displayTime undefined when not present in stela record', () => {
+			const record = convertStelaRecordToRecordVO({
+				...baseStelaRecord,
+			} as any);
+
+			expect(record.displayTime).toBeUndefined();
 		});
 	});
 });

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -101,6 +101,7 @@ export type StelaRecord = Omit<RecordVO, 'files'> & {
 	tags: Array<StelaTag> | null;
 	archiveNumber: string;
 	displayDate: string;
+	displayTime?: string;
 	folderLinkId: string;
 	folderLinkType: FolderLinkType;
 	parentFolderLinkId: string;
@@ -180,6 +181,7 @@ export const convertStelaRecordToRecordVO = (
 		),
 		archiveNbr: stelaRecord.archiveNumber,
 		displayDT: stelaRecord.displayDate,
+		displayTime: stelaRecord.displayTime,
 		folder_linkId: Number.parseInt(stelaRecord.folderLinkId, 10),
 		folder_linkType: stelaRecord.folderLinkType,
 		LocnVO: convertStelaLocationToLocnVOData(stelaRecord.location),

--- a/src/app/shared/services/data/data.service.spec.ts
+++ b/src/app/shared/services/data/data.service.spec.ts
@@ -272,6 +272,11 @@ describe('DataService', () => {
 			service.registerItem(item);
 		});
 
+		const leanItemsResponse = new FolderResponse(getLeanItemsData);
+		spyOn(api.folder, 'getWithChildren').and.returnValue(
+			Promise.resolve(leanItemsResponse),
+		);
+
 		service
 			.fetchLeanItems(currentFolder.ChildItemVOs)
 			.then(() => {

--- a/src/app/shared/services/data/data.service.spec.ts
+++ b/src/app/shared/services/data/data.service.spec.ts
@@ -272,11 +272,6 @@ describe('DataService', () => {
 			service.registerItem(item);
 		});
 
-		const leanItemsResponse = new FolderResponse(getLeanItemsData);
-		spyOn(api.folder, 'getWithChildren').and.returnValue(
-			Promise.resolve(leanItemsResponse),
-		);
-
 		service
 			.fetchLeanItems(currentFolder.ChildItemVOs)
 			.then(() => {

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -736,6 +736,71 @@ describe('EdtfService', () => {
 		});
 	});
 
+	describe('browserTimezoneAbbreviation', () => {
+		const stubTimezoneName = (timezoneName: string): void => {
+			spyOn(Intl, 'DateTimeFormat').and.returnValue({
+				formatToParts: () => [{ type: 'timeZoneName', value: timezoneName }],
+			} as unknown as Intl.DateTimeFormat);
+		};
+
+		const sampleDate = { year: '1985', month: '05', day: '20' };
+		const sampleTime = {
+			hours: '02',
+			minutes: '30',
+			seconds: '00',
+			format: 'pm' as const,
+		};
+
+		it('should return empty string when time has no hours', () => {
+			const result = service.browserTimezoneAbbreviation(sampleDate, {
+				hours: '',
+				format: 'am',
+			});
+
+			expect(result).toBe('');
+		});
+
+		it('should keep named abbreviations unchanged', () => {
+			stubTimezoneName('EDT');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'EDT',
+			);
+		});
+
+		it('should pad a whole-hour offset to +/-HH:MM', () => {
+			stubTimezoneName('GMT+3');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT+03:00',
+			);
+		});
+
+		it('should pad a half-hour positive offset to +/-HH:MM', () => {
+			stubTimezoneName('GMT+5:30');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT+05:30',
+			);
+		});
+
+		it('should pad a negative offset to +/-HH:MM', () => {
+			stubTimezoneName('GMT-9:30');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT-09:30',
+			);
+		});
+
+		it('should leave an already-normalized offset unchanged', () => {
+			stubTimezoneName('GMT+03:00');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT+03:00',
+			);
+		});
+	});
+
 	describe('parseTimeAs24Hour', () => {
 		it('should convert PM time to 24-hour format', () => {
 			const result = service.parseTimeAs24Hour({
@@ -1125,46 +1190,6 @@ describe('EdtfService', () => {
 			const result = service.toEdtfDate(model);
 
 			expect(result).toBe(`1985-05-20T23:23:23${localTimezoneOffset()}`);
-		});
-
-		it('should roundtrip partial year (198X)', () => {
-			const edtfString = '198X';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip month-only with unknown year (XXXX-05)', () => {
-			const edtfString = 'XXXX-05';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip known year and day with unknown month (1985-XX-20)', () => {
-			const edtfString = '1985-XX-20';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip partial day (1985-05-2X)', () => {
-			const edtfString = '1985-05-2X';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
-			const edtfString = '198X-05-20';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
 		});
 
 		it('should roundtrip partial year (198X)', () => {

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -718,6 +718,24 @@ describe('EdtfService', () => {
 		});
 	});
 
+	describe('isNumeric', () => {
+		it('should return true for digit-only string', () => {
+			expect(service.isNumeric('12345')).toBe(true);
+		});
+
+		it('should return false for string with letters', () => {
+			expect(service.isNumeric('12a5')).toBe(false);
+		});
+
+		it('should return false for empty string', () => {
+			expect(service.isNumeric('')).toBe(false);
+		});
+
+		it('should return false for negative number string', () => {
+			expect(service.isNumeric('-1')).toBe(false);
+		});
+	});
+
 	describe('parseTimeAs24Hour', () => {
 		it('should convert PM time to 24-hour format', () => {
 			const result = service.parseTimeAs24Hour({

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -632,7 +632,7 @@ describe('EdtfService', () => {
 				expect(service.toEdtfDate(model)).toBe('1985/1990');
 			});
 
-			it('should apply approximate qualifier to both dates in a range', () => {
+			it('should apply approximate qualifier only to the start when end has no qualifiers', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '05' },
 					time: { format: 'am' },
@@ -641,28 +641,51 @@ describe('EdtfService', () => {
 					qualifiers: { approximate: true, uncertain: false, unknown: false },
 				};
 
-				expect(service.toEdtfDate(model)).toBe('1985-05~/1990-06~');
+				expect(service.toEdtfDate(model)).toBe('1985-05~/1990-06');
 			});
 
-			it('should apply uncertain qualifier to both dates in a range', () => {
+			it('should apply uncertain qualifier only to the end', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '05' },
 					time: { format: 'am' },
 					endDate: { year: '1990', month: '06' },
 					endTime: { format: 'am' },
-					qualifiers: { approximate: false, uncertain: true, unknown: false },
+					qualifiers: { approximate: false, uncertain: false, unknown: false },
+					endQualifiers: {
+						approximate: false,
+						uncertain: true,
+						unknown: false,
+					},
 				};
 
-				expect(service.toEdtfDate(model)).toBe('1985-05?/1990-06?');
+				expect(service.toEdtfDate(model)).toBe('1985-05/1990-06?');
 			});
 
-			it('should apply combined qualifier to both dates in a range', () => {
+			it('should apply different qualifiers to each side independently', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05' },
+					time: { format: 'am' },
+					endDate: { year: '1990', month: '06' },
+					endTime: { format: 'am' },
+					qualifiers: { approximate: true, uncertain: false, unknown: false },
+					endQualifiers: {
+						approximate: false,
+						uncertain: true,
+						unknown: false,
+					},
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05~/1990-06?');
+			});
+
+			it('should apply combined qualifier per side', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '05' },
 					time: { format: 'am' },
 					endDate: { year: '1990', month: '06' },
 					endTime: { format: 'am' },
 					qualifiers: { approximate: true, uncertain: true, unknown: false },
+					endQualifiers: { approximate: true, uncertain: true, unknown: false },
 				};
 
 				expect(service.toEdtfDate(model)).toBe('1985-05%/1990-06%');
@@ -680,16 +703,48 @@ describe('EdtfService', () => {
 				expect(service.toEdtfDate(model)).toBe('1985-05~/..');
 			});
 
-			it('should apply qualifier to both dates with mixed precision', () => {
+			it('should emit empty-slot form when end qualifier is unknown', () => {
 				const model: DateTimeModel = {
-					date: { year: '1985' },
+					date: { year: '1985', month: '04', day: '12' },
 					time: { format: 'am' },
-					endDate: { year: '1990', month: '06' },
+					endDate: { year: '', month: '', day: '' },
 					endTime: { format: 'am' },
-					qualifiers: { approximate: true, uncertain: false, unknown: false },
+					qualifiers: { approximate: false, uncertain: false, unknown: false },
+					endQualifiers: {
+						approximate: false,
+						uncertain: false,
+						unknown: true,
+					},
 				};
 
-				expect(service.toEdtfDate(model)).toBe('1985~/1990-06~');
+				expect(service.toEdtfDate(model)).toBe('1985-04-12/');
+			});
+
+			it('should emit empty-slot form when start qualifier is unknown', () => {
+				const model: DateTimeModel = {
+					date: { year: '', month: '', day: '' },
+					time: { format: 'am' },
+					endDate: { year: '1990', month: '02', day: '04' },
+					endTime: { format: 'am' },
+					qualifiers: { approximate: false, uncertain: false, unknown: true },
+					endQualifiers: {
+						approximate: false,
+						uncertain: false,
+						unknown: false,
+					},
+				};
+
+				expect(service.toEdtfDate(model)).toBe('/1990-02-04');
+			});
+
+			it('should still return XXXX-XX-XX for standalone unknown without a range', () => {
+				const model: DateTimeModel = {
+					date: { year: '', month: '', day: '' },
+					time: { format: 'am' },
+					qualifiers: { approximate: false, uncertain: false, unknown: true },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('XXXX-XX-XX');
 			});
 		});
 	});

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -383,13 +383,22 @@ describe('EdtfService', () => {
 				expect(service.toEdtfDate(model)).toBe('1985-XX-20');
 			});
 
-			it('should pad single-digit day with one X', () => {
+			it('should zero-pad a single-digit day on the left', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '05', day: '2' },
 					time: { format: 'am' },
 				};
 
-				expect(service.toEdtfDate(model)).toBe('1985-05-2X');
+				expect(service.toEdtfDate(model)).toBe('1985-05-02');
+			});
+
+			it('should zero-pad a single-digit day that would be an invalid X-range', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '9' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-09');
 			});
 
 			it('should pad single-digit month with one X', () => {
@@ -1083,6 +1092,10 @@ describe('EdtfService', () => {
 			expect(service.isValidDay('3', '1985', '05')).toBe(true);
 		});
 
+		it('should accept a single "0" as in-progress input so backspace works on a padded day', () => {
+			expect(service.isValidDay('0', '1985', '05')).toBe(true);
+		});
+
 		it('should fall back to leap year 2000 when year is missing', () => {
 			// 2000 is a leap year so Feb 29 is allowed
 			expect(service.isValidDay('29', '', '02')).toBe(true);
@@ -1198,12 +1211,13 @@ describe('EdtfService', () => {
 			expect(result).toBe(edtfString);
 		});
 
-		it('should roundtrip partial day (1985-05-2X)', () => {
-			const edtfString = '1985-05-2X';
-			const model = service.toDateTimeModel(edtfString);
+		it('should normalize a partial day (1985-05-2X) to a discrete zero-padded day', () => {
+			// A day is treated as a discrete value, not an unspecified-digit
+			// range, so 2X collapses to the 2nd rather than round-tripping.
+			const model = service.toDateTimeModel('1985-05-2X');
 			const result = service.toEdtfDate(model);
 
-			expect(result).toBe(edtfString);
+			expect(result).toBe('1985-05-02');
 		});
 
 		it('should roundtrip partial year with full month and day (198X-05-20)', () => {

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -1227,5 +1227,45 @@ describe('EdtfService', () => {
 
 			expect(result).toBe(edtfString);
 		});
+
+		it('should roundtrip partial year (198X)', () => {
+			const edtfString = '198X';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip month-only with unknown year (XXXX-05)', () => {
+			const edtfString = 'XXXX-05';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip known year and day with unknown month (1985-XX-20)', () => {
+			const edtfString = '1985-XX-20';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip partial day (1985-05-2X)', () => {
+			const edtfString = '1985-05-2X';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
+			const edtfString = '198X-05-20';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
 	});
 });

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -335,6 +335,51 @@ describe('EdtfService', () => {
 
 				expect(service.toEdtfDate(model)).toBe('1985-05-20');
 			});
+
+			it('should left-pad a single-digit month with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '5' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05');
+			});
+
+			it('should left-pad a single-digit month with zero when a day is present', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '5', day: '20' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-20');
+			});
+
+			it('should left-pad single-digit month 1 with zero (January)', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '1' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-01');
+			});
+
+			it('should left-pad a single-digit day with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '2' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-02');
+			});
+
+			it('should left-pad single-digit day 1 with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '1' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-01');
+			});
 		});
 
 		describe('unspecified-digit (X-padding)', () => {
@@ -383,33 +428,6 @@ describe('EdtfService', () => {
 				expect(service.toEdtfDate(model)).toBe('1985-XX-20');
 			});
 
-			it('should zero-pad a single-digit day on the left', () => {
-				const model: DateTimeModel = {
-					date: { year: '1985', month: '05', day: '2' },
-					time: { format: 'am' },
-				};
-
-				expect(service.toEdtfDate(model)).toBe('1985-05-02');
-			});
-
-			it('should zero-pad a single-digit day that would be an invalid X-range', () => {
-				const model: DateTimeModel = {
-					date: { year: '1985', month: '05', day: '9' },
-					time: { format: 'am' },
-				};
-
-				expect(service.toEdtfDate(model)).toBe('1985-05-09');
-			});
-
-			it('should pad single-digit month with one X', () => {
-				const model: DateTimeModel = {
-					date: { year: '1985', month: '1' },
-					time: { format: 'am' },
-				};
-
-				expect(service.toEdtfDate(model)).toBe('1985-1X');
-			});
-
 			it('should combine partial year, full month, and full day', () => {
 				const model: DateTimeModel = {
 					date: { year: '198', month: '05', day: '20' },
@@ -421,6 +439,34 @@ describe('EdtfService', () => {
 		});
 
 		describe('time building', () => {
+			it('should left-pad single-digit hour, minute and second with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '20' },
+					time: {
+						hours: '5',
+						minutes: '7',
+						seconds: '9',
+						format: 'am',
+					},
+				};
+
+				expect(service.toEdtfDate(model)).toContain('T05:07:09');
+			});
+
+			it('should left-pad a single-digit hour in 24-hour mode', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '20' },
+					time: {
+						hours: '5',
+						minutes: '30',
+						seconds: '00',
+						format: 'h24',
+					},
+				};
+
+				expect(service.toEdtfDate(model)).toContain('T05:30:00');
+			});
+
 			it('should build date with PM time', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '05', day: '20' },
@@ -778,6 +824,48 @@ describe('EdtfService', () => {
 				expect(() => service.toEdtfDate(model)).toThrowError(
 					/Please check the values/,
 				);
+			});
+
+			it('should throw when time is filled but the date is missing the day', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '' },
+					time: { hours: '10', minutes: '30', seconds: '00', format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/complete date is required/i,
+				);
+			});
+
+			it('should throw when time is filled but the date is missing the month', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '', day: '20' },
+					time: { hours: '10', minutes: '30', seconds: '00', format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/complete date is required/i,
+				);
+			});
+
+			it('should throw when time is filled but the date has only a year', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '', day: '' },
+					time: { hours: '10', minutes: '30', seconds: '00', format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/complete date is required/i,
+				);
+			});
+
+			it('should still emit a partial date when no time is provided', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05');
 			});
 		});
 	});
@@ -1161,6 +1249,44 @@ describe('EdtfService', () => {
 		});
 	});
 
+	describe('getSegmentError', () => {
+		const INVALID_MESSAGE = 'invalid characters';
+		const RANGE_MESSAGE = 'out of range';
+		const rangeOptions = {
+			invalidCharsMessage: INVALID_MESSAGE,
+			isWithinRange: (value: string): boolean => parseInt(value, 10) <= 12,
+			rangeMessage: RANGE_MESSAGE,
+		};
+
+		it('should return null for an empty value', () => {
+			expect(service.getSegmentError('', rangeOptions)).toBeNull();
+		});
+
+		it('should flag non-numeric characters with the provided message', () => {
+			expect(service.getSegmentError('a5', rangeOptions)).toBe(INVALID_MESSAGE);
+		});
+
+		it('should NOT range-check a partially-typed single digit', () => {
+			expect(service.getSegmentError('9', rangeOptions)).toBeNull();
+		});
+
+		it('should flag a complete out-of-range value with the provided message', () => {
+			expect(service.getSegmentError('13', rangeOptions)).toBe(RANGE_MESSAGE);
+		});
+
+		it('should return null for a complete in-range value', () => {
+			expect(service.getSegmentError('12', rangeOptions)).toBeNull();
+		});
+
+		it('should skip the range check when no range options are provided', () => {
+			expect(
+				service.getSegmentError('9999', {
+					invalidCharsMessage: INVALID_MESSAGE,
+				}),
+			).toBeNull();
+		});
+	});
+
 	describe('roundtrip', () => {
 		it('should roundtrip a full date', () => {
 			const edtfString = '1985-05-20';
@@ -1266,21 +1392,21 @@ describe('EdtfService', () => {
 			expect(result).toBe(edtfString);
 		});
 
-		it('should normalize a partial day (1985-05-2X) to a discrete zero-padded day', () => {
-			// A day is treated as a discrete value, not an unspecified-digit
-			// range, so 2X collapses to the 2nd rather than round-tripping.
-			const model = service.toDateTimeModel('1985-05-2X');
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe('1985-05-02');
-		});
-
 		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
 			const edtfString = '198X-05-20';
 			const model = service.toDateTimeModel(edtfString);
 			const result = service.toEdtfDate(model);
 
 			expect(result).toBe(edtfString);
+		});
+
+		it('should canonicalize a partial day from "1985-05-2X" to "1985-05-02"', () => {
+			// The parser strips the trailing X, leaving day "2"; the serializer now
+			// treats a single 1–9 digit as a complete day and left-pads with zero.
+			const model = service.toDateTimeModel('1985-05-2X');
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe('1985-05-02');
 		});
 	});
 });

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -718,24 +718,6 @@ describe('EdtfService', () => {
 		});
 	});
 
-	describe('isNumeric', () => {
-		it('should return true for digit-only string', () => {
-			expect(service.isNumeric('12345')).toBe(true);
-		});
-
-		it('should return false for string with letters', () => {
-			expect(service.isNumeric('12a5')).toBe(false);
-		});
-
-		it('should return false for empty string', () => {
-			expect(service.isNumeric('')).toBe(false);
-		});
-
-		it('should return false for negative number string', () => {
-			expect(service.isNumeric('-1')).toBe(false);
-		});
-	});
-
 	describe('browserTimezoneAbbreviation', () => {
 		const stubTimezoneName = (timezoneName: string): void => {
 			spyOn(Intl, 'DateTimeFormat').and.returnValue({

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -1282,45 +1282,5 @@ describe('EdtfService', () => {
 
 			expect(result).toBe(edtfString);
 		});
-
-		it('should roundtrip partial year (198X)', () => {
-			const edtfString = '198X';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip month-only with unknown year (XXXX-05)', () => {
-			const edtfString = 'XXXX-05';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip known year and day with unknown month (1985-XX-20)', () => {
-			const edtfString = '1985-XX-20';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip partial day (1985-05-2X)', () => {
-			const edtfString = '1985-05-2X';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
-			const edtfString = '198X-05-20';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
 	});
 });

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -1166,5 +1166,45 @@ describe('EdtfService', () => {
 
 			expect(result).toBe(edtfString);
 		});
+
+		it('should roundtrip partial year (198X)', () => {
+			const edtfString = '198X';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip month-only with unknown year (XXXX-05)', () => {
+			const edtfString = 'XXXX-05';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip known year and day with unknown month (1985-XX-20)', () => {
+			const edtfString = '1985-XX-20';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip partial day (1985-05-2X)', () => {
+			const edtfString = '1985-05-2X';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
+			const edtfString = '198X-05-20';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
 	});
 });

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -359,10 +359,6 @@ export class EdtfService {
 		return model;
 	}
 
-	isNumeric(value: string): boolean {
-		return /^\d+$/.test(value);
-	}
-
 	buildReferenceDate(date: DateModel, time: TimeModel): Date {
 		const year = parseInt(date?.year ?? '', 10);
 		if (Number.isNaN(year)) return new Date();

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -203,7 +203,9 @@ export class EdtfService {
 		const month = hasMonth ? this.padWithX(date.month, 2) : 'XX';
 		if (!hasDay) return `${year}-${month}`;
 
-		const day = this.padWithX(date.day, 2);
+		// A day is a discrete value, so a single digit is zero-padded on the
+		// left ("9" -> "09"); X-padding would produce an invalid day (90-99).
+		const day = date.day.padStart(2, '0');
 		return `${year}-${month}-${day}`;
 	}
 
@@ -470,6 +472,9 @@ export class EdtfService {
 
 	isValidDay(value: string, year: string, month: string): boolean {
 		if (value === '') return true;
+		// A single digit is an in-progress value (e.g. "0" while deleting "05"),
+		// so accept it; full validation runs once two digits are entered.
+		if (/^\d$/.test(value)) return true;
 		// Defaults let day be typed before year/month are filled in.
 		// 2000 is a leap year (allows Feb 29); 01 has 31 days (most permissive).
 		const yearStr = year.length === 4 ? year : '2000';

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -359,6 +359,39 @@ export class EdtfService {
 		return model;
 	}
 
+	isNumeric(value: string): boolean {
+		return /^\d+$/.test(value);
+	}
+
+	buildReferenceDate(date: DateModel, time: TimeModel): Date {
+		const year = parseInt(date?.year ?? '', 10);
+		if (Number.isNaN(year)) return new Date();
+		const month = date.month ? parseInt(date.month, 10) - 1 : 0;
+		const day = date.day ? parseInt(date.day, 10) : 1;
+		const time24 = time?.hours ? this.parseTimeAs24Hour(time) : null;
+		return new Date(
+			year,
+			month,
+			day,
+			time24?.hour ?? 0,
+			time24?.minute ?? 0,
+			time24?.second ?? 0,
+		);
+	}
+
+	browserTimezoneAbbreviation(date: DateModel, time: TimeModel): string {
+		if (!time?.hours) return '';
+		try {
+			const referenceDate = this.buildReferenceDate(date, time);
+			const parts = new Intl.DateTimeFormat('en-US', {
+				timeZoneName: 'short',
+			}).formatToParts(referenceDate);
+			return parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+		} catch {
+			return '';
+		}
+	}
+
 	parseTimeAs24Hour(
 		time: TimeModel,
 	): { hour: number; minute: number; second: number } | null {

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -386,10 +386,22 @@ export class EdtfService {
 			const parts = new Intl.DateTimeFormat('en-US', {
 				timeZoneName: 'short',
 			}).formatToParts(referenceDate);
-			return parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+			const timezoneName =
+				parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+			return this.normalizeTimezoneOffsetDisplay(timezoneName);
 		} catch {
 			return '';
 		}
+	}
+
+	// Intl 'short' renders offset-only zones as e.g. GMT+3 or GMT+5:30;
+	// rewrite the offset part to the canonical +/-HH:MM form (GMT+03:00).
+	private normalizeTimezoneOffsetDisplay(timezoneName: string): string {
+		const offsetMatch = /([+-])(\d{1,2})(?::(\d{2}))?/.exec(timezoneName);
+		if (!offsetMatch) return timezoneName;
+		const [rawOffset, sign, offsetHours, offsetMinutes] = offsetMatch;
+		const normalizedOffset = `${sign}${offsetHours.padStart(2, '0')}:${offsetMinutes ?? '00'}`;
+		return timezoneName.replace(rawOffset, normalizedOffset);
 	}
 
 	parseTimeAs24Hour(

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -38,6 +38,12 @@ export interface DateQualifierFlags {
 	unknown: boolean;
 }
 
+export const DEFAULT_DATE_QUALIFIERS: DateQualifierFlags = {
+	approximate: false,
+	uncertain: false,
+	unknown: false,
+};
+
 export interface DateModel {
 	year: string;
 	month?: string;

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -25,6 +25,8 @@ export enum EdtfPrecision {
 
 export const UNKNOWN_VALUE = 'XXXX-XX-XX';
 
+const DIGITS_ONLY = /^\d*$/;
+
 export const DEFAULT_TIME: TimeModel = {
 	hours: '',
 	minutes: '',
@@ -184,13 +186,19 @@ export class EdtfService {
 		time: TimeModel,
 		qualifiers?: DateQualifierFlags,
 	): string {
+		const hasCompleteDate = !!(date.year && date.month && date.day);
+		const hasTime = !!time?.hours;
+
+		if (hasTime && !hasCompleteDate) {
+			throw new Error('A complete date is required when time is provided.');
+		}
+
 		const dateStr = this.buildDateString(date);
 		const edtfObject = edtf(dateStr);
 		// Strip any time/timezone the library may append (e.g. T00:00:00.000Z)
 		let result = edtfObject.toEDTF().replace(/T.*$/, '');
 
-		const hasCompleteDate = !!(date.year && date.month && date.day);
-		const timeStr = hasCompleteDate ? this.buildTimeString(time) : '';
+		const timeStr = hasTime ? this.buildTimeString(time) : '';
 
 		if (timeStr) {
 			result = `${result}${timeStr}`;
@@ -218,13 +226,18 @@ export class EdtfService {
 		const year = this.padWithX(date.year, 4);
 		if (!hasMonth && !hasDay) return year;
 
-		const month = hasMonth ? this.padWithX(date.month, 2) : 'XX';
+		const month = hasMonth ? this.padMonthOrDay(date.month) : 'XX';
 		if (!hasDay) return `${year}-${month}`;
 
-		// A day is a discrete value, so a single digit is zero-padded on the
-		// left ("9" -> "09"); X-padding would produce an invalid day (90-99).
-		const day = date.day.padStart(2, '0');
+		const day = this.padMonthOrDay(date.day);
 		return `${year}-${month}-${day}`;
+	}
+
+	private padMonthOrDay(value: string): string {
+		// A single 1–9 digit is treated as a complete value (e.g. '5' → '05'),
+		// since the user can't be mid-typing a two-digit value starting with 2–9.
+		if (/^[1-9]$/.test(value)) return `0${value}`;
+		return this.padWithX(value, 2);
 	}
 
 	private padWithX(value: string, width: number): string {
@@ -347,6 +360,10 @@ export class EdtfService {
 			message.includes('invalid upper bound')
 		) {
 			return 'The date range is not valid. Please make sure the start date is before the end date.';
+		}
+
+		if (message.includes('complete date is required')) {
+			return 'A complete date is required when time is provided.';
 		}
 
 		return 'The date entered is not valid. Please check the values and try again.';
@@ -525,5 +542,22 @@ export class EdtfService {
 		return isValid(
 			parse(`${yearStr}-${monthStr}-${dayStr}`, 'yyyy-MM-dd', new Date()),
 		);
+	}
+
+	getSegmentError(
+		value: string,
+		options: {
+			invalidCharsMessage: string;
+			isWithinRange?: (completeValue: string) => boolean;
+			rangeMessage?: string;
+		},
+	): string | null {
+		if (value === '') return null;
+		if (!DIGITS_ONLY.test(value)) return options.invalidCharsMessage;
+		if (value.length < 2) return null;
+		if (options.isWithinRange && !options.isWithinRange(value)) {
+			return options.rangeMessage ?? null;
+		}
+		return null;
 	}
 }

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -56,6 +56,7 @@ export interface DateTimeModel {
 	qualifiers?: DateQualifierFlags;
 	date: DateModel;
 	time: TimeModel;
+	endQualifiers?: DateQualifierFlags;
 	endDate?: DateModel;
 	endTime?: TimeModel;
 }
@@ -99,9 +100,13 @@ export class EdtfService {
 		const [startPart, endPart] = edtfString.split('/');
 
 		const normalizedStart =
-			startPart === '..' ? '..' : this.normalizeForParsing(startPart);
+			startPart === '..' || startPart === ''
+				? startPart
+				: this.normalizeForParsing(startPart);
 		const normalizedEnd =
-			endPart === '..' ? '..' : this.normalizeForParsing(endPart);
+			endPart === '..' || endPart === ''
+				? endPart
+				: this.normalizeForParsing(endPart);
 
 		try {
 			const edtfObject = edtf(`${normalizedStart}/${normalizedEnd}`);
@@ -130,30 +135,37 @@ export class EdtfService {
 
 	toEdtfDate(model: DateTimeModel): string {
 		try {
-			const { date, time, qualifiers, endDate, endTime } = model;
+			const { date, time, qualifiers, endQualifiers, endDate, endTime } = model;
+			const hasRange = !!endDate;
 
-			if (qualifiers?.unknown) {
+			if (!hasRange && qualifiers?.unknown) {
 				return UNKNOWN_VALUE;
 			}
 
 			const isStartEmpty = this.isEmptyDateTime(date, time);
-			const isOpenEnd = endDate && this.isEmptyDateTime(endDate, endTime);
-			const hasEndDate = endDate && !this.isEmptyDateTime(endDate, endTime);
+			const isEndEmpty = hasRange && this.isEmptyDateTime(endDate, endTime);
 
-			if (isStartEmpty && !hasEndDate) {
+			if (isStartEmpty && !hasRange) {
 				return '';
 			}
 
-			const startPart = isStartEmpty
-				? '..'
-				: this.normalizeEdtfString(date, time, qualifiers);
+			const startPart = qualifiers?.unknown
+				? ''
+				: isStartEmpty
+					? '..'
+					: this.normalizeEdtfString(date, time, qualifiers);
 
-			const endPart = isOpenEnd
-				? '..'
-				: hasEndDate
-					? this.normalizeEdtfString(endDate, endTime, qualifiers)
-					: null;
-			const stringDate = endPart ? `${startPart}/${endPart}` : startPart;
+			let endPart: string | null = null;
+			if (hasRange) {
+				endPart = endQualifiers?.unknown
+					? ''
+					: isEndEmpty
+						? '..'
+						: this.normalizeEdtfString(endDate, endTime, endQualifiers);
+			}
+
+			const stringDate =
+				endPart === null ? startPart : `${startPart}/${endPart}`;
 			edtf(stringDate);
 			return stringDate;
 		} catch (error) {
@@ -342,18 +354,42 @@ export class EdtfService {
 		const lower = interval.lower;
 		const upper = interval.upper;
 
-		const openStart = typeof lower === 'number' || lower === null;
-		const openEnd = typeof upper === 'number' || upper === null;
+		const isStartUnknownSlot = startRaw === '';
+		const isEndUnknownSlot = endRaw === '';
+		const isStartOpenBound = startRaw === '..';
+		const isEndOpenBound = endRaw === '..';
 
-		const model: DateTimeModel = openStart
-			? { date: { year: '' } as DateModel, time: { format: 'am' } }
-			: this.extDateToDateTimeModel(lower, startRaw);
+		let model: DateTimeModel;
+		if (isStartUnknownSlot) {
+			model = {
+				qualifiers: { approximate: false, uncertain: false, unknown: true },
+				date: { year: '', month: '', day: '' },
+				time: { ...DEFAULT_TIME },
+			};
+		} else if (
+			isStartOpenBound ||
+			lower === null ||
+			typeof lower === 'number'
+		) {
+			model = { date: { year: '' } as DateModel, time: { format: 'am' } };
+		} else {
+			model = this.extDateToDateTimeModel(lower, startRaw);
+		}
 
-		if (openEnd) {
+		if (isEndUnknownSlot) {
+			model.endQualifiers = {
+				approximate: false,
+				uncertain: false,
+				unknown: true,
+			};
+			model.endDate = { year: '', month: '', day: '' };
+			model.endTime = { ...DEFAULT_TIME };
+		} else if (isEndOpenBound || upper === null || typeof upper === 'number') {
 			model.endDate = { year: '' } as DateModel;
 			model.endTime = { format: 'am' };
 		} else if (upper) {
 			const upperModel = this.extDateToDateTimeModel(upper, endRaw);
+			model.endQualifiers = upperModel.qualifiers;
 			model.endDate = upperModel.date;
 			model.endTime = upperModel.time;
 		}

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -13,6 +13,7 @@ $PR-blue-100: #d0d1db;
 $PR-blue-300: #a1a4b7;
 $PR-blue-400: #898da4;
 $PR-blue-600: #5a5f80;
+$PR-blue-800: #2b325c;
 $PR-blue-900: #131b4a;
 
 $PR-orange-light: #ffc779;

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -44,6 +44,17 @@
 	box-shadow: 0px 0px 0px 4px #131b4a08;
 }
 
+@mixin input-error-state {
+	border-color: $red;
+	background: rgba($red, 0.06);
+}
+
+@mixin input-error-message {
+	display: block;
+	font-size: 12px;
+	color: $red;
+}
+
 @mixin icon-wrapper {
 	background: $PR-blue-25;
 	border-radius: 0 8px 8px 0;


### PR DESCRIPTION
> [!WARNING]
> This functionality is hidden under the `edtf-date` flag. Enable it only for testing — it must stay **OFF** in production.

# Manual test cases — EDTF date in the full-screen record view (file-viewer)

## Setup (run once)

1. Log in or create a new account.
2. Upload two files.
3. Click a file to open it in full-screen view.
   **Expected:** The full-screen viewer opens with a metadata panel (name, description, Date, Uploaded, Size, Type).

---

## Flag ON — EDTF date appears

1. Turn the `edtf-date` flag ON.
2. Open a file in full-screen view.
   **Expected:** The Date area shows the EDTF date control (clickable, opens a dropdown).
   **Expected:** No legacy plain "Date" text field is shown.

## Flag OFF — legacy date appears

1. Turn the `edtf-date` flag OFF.
2. Open a file in full-screen view.
   **Expected:** The metadata table shows a legacy "Date" row with the inline date editor.
   **Expected:** The EDTF dropdown/modal control does not appear.

## Modify the date from the dropdown (flag ON)

1. Open a file in full-screen view.
2. Click the Date control.
   **Expected:** The date dropdown opens.
3. Enter April 12, 1985.
4. Click Save.
   **Expected:** The Date area shows "April 12, 1985" with no error banner.

## Modify the date from the modal (flag ON)

1. Click the Date control.
2. Click "More options".
   **Expected:** The edit date/time modal opens with a Start date card.
3. Enter June 15, 1990.
4. Click Save.
   **Expected:** The Date area updates to "June 15, 1990".

## Cancel in the modal (flag ON)

1. Click the Date control.
2. Click "More options".
3. Change the date to a new value.
4. Click Cancel.
   **Expected:** The modal closes and the Date area still shows the previously saved value.

## Persistence after refresh (flag ON)

1. Set the date to April 12, 1985 and save.
   **Expected:** The Date area shows "April 12, 1985".
2. Refresh the browser page.
   **Expected:** The full-screen view shows "April 12, 1985".

## Persistence across left/right navigation (flag ON)

1. Open the first file in full-screen view.
2. Set its date to April 12, 1985 and save.
3. Click the right chevron (›).
   **Expected:** The next file shows its own date or the empty state, not "April 12, 1985".
4. Set this file's date to June 15, 1990 and save.
5. Click the left chevron (‹).
   **Expected:** The first file shows "April 12, 1985".
6. Click the right chevron (›).
   **Expected:** The second file shows "June 15, 1990".

## Date shows in the sidebar after closing full-screen (flag ON)

1. Set the date to April 12, 1985 and save.
2. Click "Back".
   **Expected:** The full-screen view closes and the file list appears.
3. Select the same file.
   **Expected:** The sidebar's Date section shows "April 12, 1985".

## Shared item — date is disabled (flag ON)

1. Share a file with another account using view-only (Viewer) access.
2. Log in as the recipient account.
3. Open the shared file in full-screen view.
   **Expected:** The Date area shows the saved date (or empty state).
4. Click the Date control.
   **Expected:** Nothing happens — the date is disabled and the dropdown/modal does not open.