### PR TITLE
[PER-10590] Remove the drag while scrolling

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -4,6 +4,7 @@ body {
 	height: 100%;
 	position: relative;
 	background: none;
+	overscroll-behavior: none;
 }
 
 pr-app-root {


### PR DESCRIPTION
While scrolling, there was a drag for the whole app. Removing the "mobile like" behavior that can be added automatically by css libraries, like bootstrap, the scroll won't be affected anymore and will work as expected on web.