### PR TITLE
[PER-10593] Reset page scroll on public gallery navigation

### DIFF
--- a/src/app/public/components/public/public.component.ts
+++ b/src/app/public/components/public/public.component.ts
@@ -54,6 +54,7 @@ export class PublicComponent implements OnInit, OnDestroy {
 					this.isNavigating = true;
 				} else if (event instanceof NavigationEnd) {
 					this.isNavigating = false;
+					window.scrollTo(0, 0);
 				}
 			});
 	}


### PR DESCRIPTION
When navigating into a sub-folder in a public archive, the page kept the parent view's scroll position so users landed at the bottom of the new sub-folder rather than the top. Reset window scroll to (0, 0) on every NavigationEnd inside PublicComponent so each folder load starts at the top.

Issue: PER-10593