### PR TITLE
Ignore location `displayName`

### DIFF
--- a/src/app/file-browser/components/location-picker/location-picker.component.html
+++ b/src/app/file-browser/components/location-picker/location-picker.component.html
@@ -15,10 +15,6 @@
 			@if (currentLocation) {
 				<div class="location-panel" @ngIfFadeInAnimation>
 					<div class="location-info">
-						@if (currentLocationDisplay.displayName) {
-							<span>{{ currentLocationDisplay.displayName }}</span>
-							<br />
-						}
 						<span>{{ currentLocationDisplay.line1 }}</span>
 						<br />
 						<span>{{ currentLocationDisplay.line2 }}</span>

--- a/src/app/file-browser/components/location-picker/location-picker.component.ts
+++ b/src/app/file-browser/components/location-picker/location-picker.component.ts
@@ -244,10 +244,6 @@ export class LocationPickerComponent implements OnInit, AfterViewInit {
 			countryCode: getComponentName(addr, 'country', true),
 		};
 
-		if (!place.name.includes(locn.streetNumber)) {
-			locn.displayName = place.name;
-		}
-
 		return locn;
 
 		function getComponentName(

--- a/src/app/models/locn-vo.ts
+++ b/src/app/models/locn-vo.ts
@@ -4,7 +4,6 @@ export interface LocnVOData extends BaseVOData {
 	locnId?: number;
 	timeZoneId?: number;
 
-	displayName?: string;
 	geoCodeLookup?: string;
 	streetNumber?: string;
 	streetName?: string;

--- a/src/app/shared/pipes/pr-location.pipe.ts
+++ b/src/app/shared/pipes/pr-location.pipe.ts
@@ -5,7 +5,6 @@ export interface LocnPipeOutput {
 	line1?: string;
 	line2?: string;
 	full?: string;
-	displayName?: string;
 }
 
 @Pipe({
@@ -53,12 +52,6 @@ export class PrLocationPipe implements PipeTransform {
 
 		output.line2 = line2.length ? line2.join(', ') : 'Unknown Location';
 		output.full = output.line1 + ', ' + output.line2;
-		if (locnVO.displayName) {
-			if (locnVO.displayName.toLowerCase() !== output.line1.toLowerCase()) {
-				output.displayName = locnVO.displayName;
-				output.full = locnVO.displayName + ', ' + output.full;
-			}
-		}
 		return output;
 	}
 }


### PR DESCRIPTION
This PR removes recognition of the `displayName` attribute of a location.  This is a legacy field we are about to remove, but also it wasn't actually being stored which resulted in unexpected behavior (specifically, the value disappeared on refresh for users)

Resolves #1024