### PR TITLE
[PER-10641] Create edtf date dropdown component

### DIFF
--- a/src/app/core/services/edit/edit.service.spec.ts
+++ b/src/app/core/services/edit/edit.service.spec.ts
@@ -445,6 +445,77 @@ describe('EditService', () => {
 		expect(apiService.folder.getStelaFolderVOs).not.toHaveBeenCalled();
 	});
 
+	it('should revert property and show error when updateStelaRecord fails', async () => {
+		const messageService = TestBed.inject(MessageService);
+		spyOn(messageService, 'showError');
+
+		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
+		const httpError = {
+			error: { message: 'Invalid date format' },
+			message: 'Http failure',
+		};
+
+		(apiService.record.updateStelaRecord as jasmine.Spy).and.returnValue(
+			Promise.reject(httpError),
+		);
+		(apiService.record.update as jasmine.Spy).and.returnValue(
+			Promise.resolve([]),
+		);
+
+		await service.saveItemVoProperty(record, 'displayTime', 'new-value');
+
+		expect(record.displayTime).toBe('original-value');
+		expect(messageService.showError).toHaveBeenCalledWith({
+			message: 'Invalid date format',
+		});
+	});
+
+	it('should show fallback error when updateStelaRecord fails without error body', async () => {
+		const messageService = TestBed.inject(MessageService);
+		spyOn(messageService, 'showError');
+
+		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
+
+		(apiService.record.updateStelaRecord as jasmine.Spy).and.returnValue(
+			Promise.reject({}),
+		);
+		(apiService.record.update as jasmine.Spy).and.returnValue(
+			Promise.resolve([]),
+		);
+
+		await service.saveItemVoProperty(record, 'displayTime', 'new-value');
+
+		expect(record.displayTime).toBe('original-value');
+		expect(messageService.showError).toHaveBeenCalledWith({
+			message: 'Failed to save changes',
+		});
+	});
+
+	it('should revert property and show error when updateStelaFolder fails', async () => {
+		const messageService = TestBed.inject(MessageService);
+		spyOn(messageService, 'showError');
+
+		const folder = new FolderVO({ folderId: 1, displayTime: 'original-value' });
+		const httpError = { error: { error: 'Invalid EDTF string' } };
+
+		(apiService.folder.updateStelaFolder as jasmine.Spy).and.returnValue(
+			Promise.reject(httpError),
+		);
+		(apiService.folder.update as jasmine.Spy).and.returnValue(
+			Promise.resolve({}),
+		);
+		(apiService.folder.getStelaFolderVOs as jasmine.Spy).and.returnValue(
+			Promise.resolve({ getFolderVOs: () => [] }),
+		);
+
+		await service.saveItemVoProperty(folder, 'displayTime', 'new-value');
+
+		expect(folder.displayTime).toBe('original-value');
+		expect(messageService.showError).toHaveBeenCalledWith({
+			message: 'Invalid EDTF string',
+		});
+	});
+
 	describe('openShareDialog', () => {
 		const mockShareLink: ShareLink = {
 			id: 'link1',

--- a/src/app/core/services/edit/edit.service.spec.ts
+++ b/src/app/core/services/edit/edit.service.spec.ts
@@ -445,9 +445,10 @@ describe('EditService', () => {
 		expect(apiService.folder.getStelaFolderVOs).not.toHaveBeenCalled();
 	});
 
-	it('should revert property and show error when updateStelaRecord fails', async () => {
+	it('should revert property and show a translatable generic error when updateStelaRecord fails', async () => {
 		const messageService = TestBed.inject(MessageService);
 		spyOn(messageService, 'showError');
+		const consoleErrorSpy = spyOn(console, 'error');
 
 		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
 		const httpError = {
@@ -466,13 +467,20 @@ describe('EditService', () => {
 
 		expect(record.displayTime).toBe('original-value');
 		expect(messageService.showError).toHaveBeenCalledWith({
-			message: 'Invalid date format',
+			message: 'error.generic.update_fail',
+			translate: true,
 		});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Failed to save item property',
+			httpError,
+		);
 	});
 
-	it('should show fallback error when updateStelaRecord fails without error body', async () => {
+	it('should show a translatable generic error when updateStelaRecord fails without error body', async () => {
 		const messageService = TestBed.inject(MessageService);
 		spyOn(messageService, 'showError');
+		spyOn(console, 'error');
 
 		const record = new RecordVO({ recordId: 1, displayTime: 'original-value' });
 
@@ -487,13 +495,15 @@ describe('EditService', () => {
 
 		expect(record.displayTime).toBe('original-value');
 		expect(messageService.showError).toHaveBeenCalledWith({
-			message: 'Failed to save changes',
+			message: 'error.generic.update_fail',
+			translate: true,
 		});
 	});
 
-	it('should revert property and show error when updateStelaFolder fails', async () => {
+	it('should revert property and show a translatable generic error when updateStelaFolder fails', async () => {
 		const messageService = TestBed.inject(MessageService);
 		spyOn(messageService, 'showError');
+		spyOn(console, 'error');
 
 		const folder = new FolderVO({ folderId: 1, displayTime: 'original-value' });
 		const httpError = { error: { error: 'Invalid EDTF string' } };
@@ -512,7 +522,8 @@ describe('EditService', () => {
 
 		expect(folder.displayTime).toBe('original-value');
 		expect(messageService.showError).toHaveBeenCalledWith({
-			message: 'Invalid EDTF string',
+			message: 'error.generic.update_fail',
+			translate: true,
 		});
 	});
 

--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -366,12 +366,10 @@ export class EditService {
 						translate: true,
 					});
 				} else {
+					console.error('Failed to save item property', err);
 					this.message.showError({
-						message:
-							err?.error?.message ||
-							err?.error?.error ||
-							err?.message ||
-							'Failed to save changes',
+						message: 'error.generic.update_fail',
+						translate: true,
 					});
 				}
 			}

--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -356,10 +356,23 @@ export class EditService {
 				item.update(newData);
 				await this.updateItems([item], [property]);
 			} catch (err) {
+				const revertData: Partial<ItemVO> = {};
+				revertData[property] = originalValue;
+				item.update(revertData);
+
 				if (err instanceof FolderResponse || err instanceof RecordResponse) {
-					const revertData: Partial<ItemVO> = {};
-					revertData[property] = originalValue;
-					item.update(revertData);
+					this.message.showError({
+						message: err.getMessage(),
+						translate: true,
+					});
+				} else {
+					this.message.showError({
+						message:
+							err?.error?.message ||
+							err?.error?.error ||
+							err?.message ||
+							'Failed to save changes',
+					});
 				}
 			}
 		}

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.html
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.html
@@ -1,0 +1,109 @@
+<div class="pr-sidebar-date-picker" #sidebarDatePickerContainer>
+	<div class="pr-sidebar-date-picker-header">
+		<span class="pr-sidebar-date-picker-label">Date</span>
+		@if (activeQualifiers().length) {
+			<i class="material-icons pr-header-dot">fiber_manual_record</i>
+			<span class="pr-sidebar-date-picker-qualifiers">
+				{{ activeQualifiers().join(', ') }}:
+			</span>
+		}
+	</div>
+
+	<div
+		class="pr-sidebar-date-picker-rows"
+		[class.can-edit]="!disabled"
+		(click)="toggle()"
+	>
+		<div class="pr-sidebar-date-picker-row">
+			@if (hasEndDate()) {
+				<span class="pr-sidebar-date-picker-row-label">From</span>
+			}
+			@if (hasStartDate()) {
+				<span class="pr-sidebar-date-picker-row-value">
+					<span class="pr-date-part"
+						>{{ formattedStartDate() }}
+						@if (formattedStartTime()) {
+							<i class="material-icons pr-dot">fiber_manual_record</i>
+						}
+					</span>
+					@if (formattedStartTime()) {
+						<span class="pr-time-group">
+							<span class="pr-time-part">{{ formattedStartTime() }}</span>
+							<span class="pr-muted">{{ startMeridian() }}</span>
+							@if (startTimezone()) {
+								<span class="pr-muted">{{ startTimezone() }}</span>
+							}
+						</span>
+					}
+				</span>
+			} @else {
+				<span class="pr-sidebar-date-picker-row-placeholder">
+					{{ disabled ? 'No date' : 'Click to add date' }}
+				</span>
+			}
+			@if (!disabled) {
+				<span class="pr-sidebar-date-picker-edit-icon">
+					<i class="material-icons">edit</i>
+				</span>
+			}
+		</div>
+
+		@if (hasEndDate()) {
+			<div class="pr-sidebar-date-picker-row pr-sidebar-date-picker-to-row">
+				<span class="pr-sidebar-date-picker-row-label">To</span>
+				<span class="pr-sidebar-date-picker-row-value">
+					<span class="pr-date-part"
+						>{{ formattedEndDate() }}
+						@if (formattedEndTime()) {
+							<i class="material-icons pr-dot">fiber_manual_record</i>
+						}
+					</span>
+					@if (formattedEndTime()) {
+						<span class="pr-time-group">
+							<span class="pr-time-part">{{ formattedEndTime() }}</span>
+							<span class="pr-muted">{{ endMeridian() }}</span>
+							@if (endTimezone()) {
+								<span class="pr-muted">{{ endTimezone() }}</span>
+							}
+						</span>
+					}
+				</span>
+			</div>
+		}
+	</div>
+
+	@if (isDropdownOpen()) {
+		<div class="pr-sidebar-date-picker-panel">
+			<div class="pr-sidebar-date-picker-fields">
+				<pr-datepicker-input
+					[date]="_date()"
+					(dateChange)="onDateChange($event)"
+				/>
+
+				<pr-timepicker-input
+					[time]="_time()"
+					(timeChange)="onTimeChange($event)"
+				/>
+
+				<button class="pr-clear-btn" (click)="clearAll()">
+					<i class="material-icons">backspace</i>
+					<span>Clear date and time</span>
+				</button>
+			</div>
+
+			<div class="pr-sidebar-date-picker-footer">
+				<button class="pr-more-options-btn" (click)="onMoreOptions()">
+					<i class="material-icons">tune</i>
+					<span>More options</span>
+				</button>
+
+				<div class="pr-sidebar-date-picker-actions">
+					<button class="pr-btn-cancel" (click)="onCancel()">Cancel</button>
+					<button class="pr-btn-save" (click)="onSave()">
+						<i class="material-icons">keyboard_return</i>
+					</button>
+				</div>
+			</div>
+		</div>
+	}
+</div>

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.scss
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.scss
@@ -1,0 +1,217 @@
+@import 'colors';
+@import 'mixins';
+@import 'variables';
+
+.pr-sidebar-date-picker {
+	position: relative;
+
+	.pr-sidebar-date-picker-header {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		font-size: 13px;
+		color: $PR-blue-600;
+		margin-bottom: 4px;
+
+		.pr-header-dot {
+			font-size: 6px;
+			color: $PR-blue-400;
+			margin: 0 2px;
+		}
+	}
+
+	.pr-sidebar-date-picker-label {
+		font-weight: 600;
+		font-size: $font-size-base;
+		color: $body-color;
+	}
+
+	.pr-sidebar-date-picker-qualifiers {
+		color: $PR-blue-400;
+	}
+
+	.pr-sidebar-date-picker-rows {
+		border-radius: 8px;
+		padding: 4px 8px;
+		transition: background-color 0.15s ease;
+
+		&.can-edit {
+			cursor: pointer;
+
+			&:hover {
+				background-color: $PR-blue-25;
+
+				.pr-sidebar-date-picker-edit-icon {
+					color: $PR-blue;
+				}
+			}
+		}
+	}
+
+	.pr-sidebar-date-picker-row {
+		display: flex;
+		align-items: baseline;
+	}
+
+	.pr-sidebar-date-picker-row-label {
+		font-size: 14px;
+		color: $PR-blue-400;
+		margin-right: 8px;
+		min-width: 36px;
+	}
+
+	.pr-sidebar-date-picker-row-value {
+		flex: 1;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 4px;
+		font-size: 14px;
+		color: $PR-blue;
+		font-weight: 500;
+
+		.pr-time-group {
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			white-space: nowrap;
+		}
+
+		.pr-dot {
+			font-size: 6px;
+			color: $PR-blue;
+			vertical-align: middle;
+			margin-left: 2px;
+		}
+
+		.pr-muted {
+			color: $PR-blue-400;
+		}
+	}
+
+	.pr-sidebar-date-picker-row-placeholder {
+		flex: 1;
+		font-size: 14px;
+		color: $PR-blue-400;
+	}
+
+	.pr-sidebar-date-picker-edit-icon {
+		padding: 4px;
+		color: $PR-blue-400;
+		display: flex;
+		align-items: center;
+
+		.material-icons {
+			font-size: 18px;
+		}
+	}
+
+	.pr-sidebar-date-picker-to-row {
+		cursor: default;
+	}
+
+	// Dropdown panel
+	.pr-sidebar-date-picker-panel {
+		position: absolute;
+		top: 0;
+		left: -16px;
+		right: -16px;
+		z-index: 20;
+		background: $white;
+		border: 1px solid $PR-blue-100;
+		border-radius: 12px;
+		box-shadow: 0 8px 24px rgba($black, 0.12);
+		overflow: visible;
+	}
+
+	.pr-sidebar-date-picker-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 16px;
+	}
+
+	.pr-clear-btn {
+		@include clear-btn;
+		margin-top: 4px;
+		width: 151px;
+
+		i {
+			color: $PR-blue;
+			font-size: 16px;
+		}
+
+		span {
+			color: $PR-blue;
+			font-size: 14px;
+		}
+	}
+
+	.pr-sidebar-date-picker-footer {
+		@include panel-footer;
+		padding: 12px 16px;
+	}
+
+	.pr-more-options-btn {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 14px;
+		font-weight: 500;
+		color: $PR-blue;
+		padding: 0;
+
+		&:hover {
+			color: $PR-blue-800;
+		}
+
+		.material-icons {
+			font-size: 18px;
+		}
+	}
+
+	.pr-sidebar-date-picker-actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.pr-btn-cancel {
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 14px;
+		font-weight: 500;
+		color: $PR-blue;
+		padding: 6px 12px;
+
+		&:hover {
+			color: $PR-blue-800;
+		}
+	}
+
+	.pr-btn-save {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: $PR-blue;
+		border: none;
+		border-radius: 6px;
+		cursor: pointer;
+		color: $white;
+		width: 36px;
+		height: 36px;
+		padding: 0;
+
+		&:hover {
+			background: $PR-blue-800;
+		}
+
+		.material-icons {
+			font-size: 18px;
+		}
+	}
+}

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -1,0 +1,599 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA, Component } from '@angular/core';
+import { DateTimeModel } from '@shared/services/edtf-service/edtf.service';
+import { SidebarDatePickerComponent } from './sidebar-date-picker.component';
+
+@Component({
+	template: `
+		<pr-sidebar-date-picker
+			[displayTime]="displayTime"
+			[disabled]="disabled"
+			(saveClicked)="onSaveClicked($event)"
+			(moreOptionsClicked)="onMoreOptionsClicked($event)"
+		/>
+	`,
+	standalone: false,
+})
+class TestHostComponent {
+	displayTime: DateTimeModel | null = null;
+	disabled = false;
+	savedValue: DateTimeModel | null = null;
+	moreOptionsData: DateTimeModel | null = null;
+
+	onSaveClicked(value: DateTimeModel) {
+		this.savedValue = value;
+	}
+	onMoreOptionsClicked(data: DateTimeModel) {
+		this.moreOptionsData = data;
+	}
+}
+
+describe('SidebarDatePickerComponent', () => {
+	let host: TestHostComponent;
+	let fixture: ComponentFixture<TestHostComponent>;
+	let component: SidebarDatePickerComponent;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [SidebarDatePickerComponent],
+			declarations: [TestHostComponent],
+			schemas: [CUSTOM_ELEMENTS_SCHEMA],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(TestHostComponent);
+		host = fixture.componentInstance;
+		fixture.detectChanges();
+		component = fixture.debugElement.children[0].componentInstance;
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+
+	describe('display', () => {
+		it('should show placeholder when no date is set', () => {
+			const placeholder = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-placeholder',
+			);
+
+			expect(placeholder).toBeTruthy();
+			expect(placeholder.textContent.trim()).toBe('Click to add date');
+		});
+
+		it('should show "No date" placeholder when disabled and no date', () => {
+			host.disabled = true;
+			fixture.detectChanges();
+
+			const placeholder = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-placeholder',
+			);
+
+			expect(placeholder.textContent.trim()).toBe('No date');
+		});
+
+		it('should display formatted date when displayTime is set', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value).toBeTruthy();
+			expect(value.textContent.trim()).toBe('May 1985');
+		});
+
+		it('should display year-only date', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent.trim()).toBe('1985');
+		});
+
+		it('should display full date with day', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent.trim()).toBe('May 20, 1985');
+		});
+
+		it('should display date with time', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '02',
+					minutes: '30',
+					seconds: '00',
+					am: false,
+					pm: true,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent).toContain('May 20, 1985');
+			expect(value.textContent).toContain('02:30:00');
+			expect(value.textContent).toContain('PM');
+		});
+
+		it('should display "Unknown date and time" when unknown qualifier is set', () => {
+			host.displayTime = {
+				qualifiers: { approximate: false, uncertain: false, unknown: true },
+				date: { year: '', month: '', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const value = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-row-value',
+			);
+
+			expect(value.textContent).toContain('Unknown date and time');
+		});
+
+		it('should not show To row when no end date', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const toRow = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-to-row',
+			);
+
+			expect(toRow).toBeFalsy();
+		});
+
+		it('should show To row when end date is set', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+				endDate: { year: '1990', month: '06', day: '' },
+				endTime: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const toRow = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-to-row',
+			);
+
+			expect(toRow).toBeTruthy();
+			const toValue = toRow.querySelector('.pr-sidebar-date-picker-row-value');
+
+			expect(toValue.textContent.trim()).toBe('June 1990');
+		});
+
+		it('should show a browser-default timezone label when time is entered', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '02',
+					minutes: '30',
+					seconds: '00',
+					am: false,
+					pm: true,
+				},
+			};
+			fixture.detectChanges();
+
+			expect(component.startTimezone()).not.toBe('');
+		});
+
+		it('should not show a timezone label when no time is entered', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			expect(component.startTimezone()).toBe('');
+		});
+	});
+
+	describe('qualifiers', () => {
+		it('should not show qualifiers when none are active', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const qualifiers = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-qualifiers',
+			);
+
+			expect(qualifiers).toBeFalsy();
+		});
+
+		it('should display Approximate qualifier', () => {
+			host.displayTime = {
+				qualifiers: { approximate: true, uncertain: false, unknown: false },
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const qualifiers = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-qualifiers',
+			);
+
+			expect(qualifiers).toBeTruthy();
+			expect(qualifiers.textContent).toContain('Approximate');
+		});
+
+		it('should display Uncertain qualifier', () => {
+			host.displayTime = {
+				qualifiers: { approximate: false, uncertain: true, unknown: false },
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			const qualifiers = fixture.nativeElement.querySelector(
+				'.pr-sidebar-date-picker-qualifiers',
+			);
+
+			expect(qualifiers).toBeTruthy();
+			expect(qualifiers.textContent).toContain('Uncertain');
+		});
+	});
+
+	describe('toggle and dropdown', () => {
+		it('should not open when disabled', () => {
+			host.disabled = true;
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+
+		it('should open dropdown on toggle', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeTrue();
+		});
+
+		it('should close dropdown on second toggle', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeTrue();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+
+		it('should open modal instead of dropdown when end date is present', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+				endDate: { year: '1990', month: '06', day: '' },
+				endTime: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+			expect(host.moreOptionsData).toBeTruthy();
+		});
+
+		it('should open modal instead of dropdown when unknown qualifier is set', () => {
+			host.displayTime = {
+				qualifiers: { approximate: false, uncertain: false, unknown: true },
+				date: { year: '', month: '', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+			expect(host.moreOptionsData).toBeTruthy();
+		});
+	});
+
+	describe('clearAll', () => {
+		it('should clear all fields but keep dropdown open', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '10',
+					minutes: '30',
+					seconds: '00',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.open();
+			component.clearAll();
+
+			expect(component._date().year).toBe('');
+			expect(component._time().hours).toBe('');
+			expect(component._qualifiers().unknown).toBeFalse();
+			expect(component.isDropdownOpen()).toBeTrue();
+		});
+	});
+
+	describe('onSave', () => {
+		it('should emit saveClicked and close dropdown', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '20' },
+				time: {
+					hours: '02',
+					minutes: '30',
+					seconds: '00',
+					am: false,
+					pm: true,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+
+			component.onSave();
+			fixture.detectChanges();
+
+			expect(host.savedValue).toBeTruthy();
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+	});
+
+	describe('onCancel', () => {
+		it('should close dropdown and reset to input values', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+
+			component.onDateChange({ year: '2000', month: '01', day: '15' });
+			fixture.detectChanges();
+
+			component.onCancel();
+			fixture.detectChanges();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+			expect(component._date().year).toBe('1985');
+			expect(component._date().month).toBe('05');
+		});
+	});
+
+	describe('onMoreOptions', () => {
+		it('should emit moreOptionsClicked with current data', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+			component.onMoreOptions();
+
+			expect(host.moreOptionsData).toBeTruthy();
+			expect(host.moreOptionsData.date.year).toBe('1985');
+			expect(host.moreOptionsData.date.month).toBe('05');
+		});
+
+		it('should close dropdown when emitting', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+			fixture.detectChanges();
+			component.onMoreOptions();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+	});
+
+	describe('outside click', () => {
+		it('should close dropdown on outside click', () => {
+			host.displayTime = {
+				date: { year: '1985', month: '05', day: '' },
+				time: {
+					hours: '',
+					minutes: '',
+					seconds: '',
+					am: true,
+					pm: false,
+				},
+			};
+			fixture.detectChanges();
+
+			component.toggle();
+
+			expect(component.isDropdownOpen()).toBeTrue();
+
+			const outsideEl = document.createElement('div');
+			document.body.appendChild(outsideEl);
+
+			component.onDocumentClick({ target: outsideEl } as any);
+			outsideEl.remove();
+
+			expect(component.isDropdownOpen()).toBeFalse();
+		});
+	});
+
+	describe('field updates', () => {
+		it('should update date on onDateChange', () => {
+			component.onDateChange({ year: '2000', month: '01', day: '15' });
+
+			expect(component._date().year).toBe('2000');
+			expect(component._date().month).toBe('01');
+			expect(component._date().day).toBe('15');
+		});
+
+		it('should update time on onTimeChange', () => {
+			component.onTimeChange({
+				hours: '10',
+				minutes: '30',
+				seconds: '00',
+				am: false,
+				pm: true,
+			});
+
+			expect(component._time().hours).toBe('10');
+			expect(component._time().minutes).toBe('30');
+			expect(component._time().pm).toBe(true);
+		});
+	});
+});

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -259,6 +259,64 @@ describe('SidebarDatePickerComponent', () => {
 		});
 	});
 
+	describe('formattedStartDate with X-padding', () => {
+		const setDate = (year: string, month: string, day: string): void => {
+			host.displayTime = {
+				date: { year, month, day },
+				time: { hours: '', minutes: '', seconds: '', format: 'am' },
+			};
+			fixture.detectChanges();
+		};
+
+		it('should pad partial year with X (year only)', () => {
+			setDate('198', '', '');
+
+			expect(component.formattedStartDate()).toBe('198X');
+		});
+
+		it('should display "May XXXX" when only month is set', () => {
+			setDate('', '05', '');
+
+			expect(component.formattedStartDate()).toBe('May XXXX');
+		});
+
+		it('should display "May 20, 198X" with partial year and full month/day', () => {
+			setDate('198', '05', '20');
+
+			expect(component.formattedStartDate()).toBe('May 20, 198X');
+		});
+
+		it('should display "May 2X, 1985" with partial day', () => {
+			setDate('1985', '05', '2');
+
+			expect(component.formattedStartDate()).toBe('May 2X, 1985');
+		});
+
+		it('should fall back to ISO style "1985-XX-20" when month is missing', () => {
+			setDate('1985', '', '20');
+
+			expect(component.formattedStartDate()).toBe('1985-XX-20');
+		});
+
+		it('should fall back to ISO style "1985-1X-20" when month is partial', () => {
+			setDate('1985', '1', '20');
+
+			expect(component.formattedStartDate()).toBe('1985-1X-20');
+		});
+
+		it('should fall back to ISO style "XXXX-XX-20" when only day is set', () => {
+			setDate('', '', '20');
+
+			expect(component.formattedStartDate()).toBe('XXXX-XX-20');
+		});
+
+		it('should still display fully-specified date with month name (regression)', () => {
+			setDate('1985', '05', '20');
+
+			expect(component.formattedStartDate()).toBe('May 20, 1985');
+		});
+	});
+
 	describe('qualifiers', () => {
 		it('should not show qualifiers when none are active', () => {
 			host.displayTime = {

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -276,10 +276,10 @@ describe('SidebarDatePickerComponent', () => {
 			expect(component.formattedStartDate()).toBe('May 20, 198X');
 		});
 
-		it('should display "May 2X, 1985" with partial day', () => {
+		it('should zero-pad a single-digit day on the left ("May 02, 1985")', () => {
 			setDate('1985', '05', '2');
 
-			expect(component.formattedStartDate()).toBe('May 2X, 1985');
+			expect(component.formattedStartDate()).toBe('May 02, 1985');
 		});
 
 		it('should fall back to ISO style "1985-XX-20" when month is missing', () => {

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -78,8 +78,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -99,8 +98,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -119,8 +117,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -139,8 +136,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '02',
 					minutes: '30',
 					seconds: '00',
-					am: false,
-					pm: true,
+					format: 'pm',
 				},
 			};
 			fixture.detectChanges();
@@ -162,8 +158,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -182,8 +177,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -202,16 +196,14 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 				endDate: { year: '1990', month: '06', day: '' },
 				endTime: {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -233,8 +225,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '02',
 					minutes: '30',
 					seconds: '00',
-					am: false,
-					pm: true,
+					format: 'pm',
 				},
 			};
 			fixture.detectChanges();
@@ -249,8 +240,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -325,8 +315,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -346,8 +335,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -368,8 +356,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -400,8 +387,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -418,8 +404,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -440,16 +425,14 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 				endDate: { year: '1990', month: '06', day: '' },
 				endTime: {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -468,8 +451,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -489,8 +471,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '10',
 					minutes: '30',
 					seconds: '00',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -513,8 +494,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '02',
 					minutes: '30',
 					seconds: '00',
-					am: false,
-					pm: true,
+					format: 'pm',
 				},
 			};
 			fixture.detectChanges();
@@ -538,8 +518,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -567,8 +546,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -589,8 +567,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -611,8 +588,7 @@ describe('SidebarDatePickerComponent', () => {
 					hours: '',
 					minutes: '',
 					seconds: '',
-					am: true,
-					pm: false,
+					format: 'am',
 				},
 			};
 			fixture.detectChanges();
@@ -645,13 +621,12 @@ describe('SidebarDatePickerComponent', () => {
 				hours: '10',
 				minutes: '30',
 				seconds: '00',
-				am: false,
-				pm: true,
+				format: 'pm',
 			});
 
 			expect(component._time().hours).toBe('10');
 			expect(component._time().minutes).toBe('30');
-			expect(component._time().pm).toBe(true);
+			expect(component._time().format).toBe('pm');
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -16,7 +16,7 @@ import { CommonModule } from '@angular/common';
 import { format } from 'date-fns';
 import {
 	EdtfService,
-	Meridian,
+	TIME_FORMAT_LABEL,
 	DateTimeModel,
 	DateModel,
 	TimeModel,
@@ -31,8 +31,7 @@ const EMPTY_TIME: TimeModel = {
 	hours: '',
 	minutes: '',
 	seconds: '',
-	am: true,
-	pm: false,
+	format: 'am',
 };
 
 const EMPTY_QUALIFIERS: DateQualifierFlags = {
@@ -94,9 +93,11 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 	});
 
 	formattedStartTime = computed(() => this.formatTime(this._time()));
-	startMeridian = computed(() =>
-		this._time().hours ? (this._time().pm ? Meridian.PM : Meridian.AM) : '',
-	);
+	startMeridian = computed(() => {
+		const time = this._time();
+		if (!time.hours || time.format === 'h24') return '';
+		return TIME_FORMAT_LABEL[time.format];
+	});
 
 	startTimezone = computed(() =>
 		this.edtfService.browserTimezoneAbbreviation(this._date(), this._time()),
@@ -115,13 +116,11 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 	});
 
 	formattedEndTime = computed(() => this.formatTime(this._endTime()));
-	endMeridian = computed(() =>
-		this._endTime().hours
-			? this._endTime().pm
-				? Meridian.PM
-				: Meridian.AM
-			: '',
-	);
+	endMeridian = computed(() => {
+		const time = this._endTime();
+		if (!time.hours || time.format === 'h24') return '';
+		return TIME_FORMAT_LABEL[time.format];
+	});
 
 	endTimezone = computed(() =>
 		this.edtfService.browserTimezoneAbbreviation(

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -1,0 +1,315 @@
+import {
+	Component,
+	Input,
+	Output,
+	EventEmitter,
+	signal,
+	computed,
+	OnInit,
+	OnChanges,
+	SimpleChanges,
+	HostListener,
+	ViewChild,
+	ElementRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { format, setYear } from 'date-fns';
+import {
+	EdtfService,
+	Meridian,
+	DateTimeModel,
+	DateModel,
+	TimeModel,
+	DateQualifierFlags,
+} from '@shared/services/edtf-service/edtf.service';
+import { DatepickerInputComponent } from '@shared/components/datepicker-input/datepicker-input.component';
+import { TimepickerInputComponent } from '@shared/components/timepicker-input/timepicker-input.component';
+
+const EMPTY_DATE: DateModel = { year: '', month: '', day: '' };
+
+const EMPTY_TIME: TimeModel = {
+	hours: '',
+	minutes: '',
+	seconds: '',
+	am: true,
+	pm: false,
+};
+
+const EMPTY_QUALIFIERS: DateQualifierFlags = {
+	approximate: false,
+	uncertain: false,
+	unknown: false,
+};
+
+@Component({
+	selector: 'pr-sidebar-date-picker',
+	standalone: true,
+	imports: [CommonModule, DatepickerInputComponent, TimepickerInputComponent],
+	templateUrl: './sidebar-date-picker.component.html',
+	styleUrls: ['./sidebar-date-picker.component.scss'],
+})
+export class SidebarDatePickerComponent implements OnInit, OnChanges {
+	@Input() displayTime: DateTimeModel | null;
+	@Input() disabled = false;
+
+	@Output() saveClicked = new EventEmitter<DateTimeModel>();
+	@Output() moreOptionsClicked = new EventEmitter<DateTimeModel>();
+
+	@ViewChild('sidebarDatePickerContainer')
+	container?: ElementRef<HTMLElement>;
+
+	constructor(private readonly edtfService: EdtfService) {}
+
+	isDropdownOpen = signal(false);
+
+	_date = signal<DateModel>({ ...EMPTY_DATE });
+	_time = signal<TimeModel>({ ...EMPTY_TIME });
+	_endDate = signal<DateModel>({ ...EMPTY_DATE });
+	_endTime = signal<TimeModel>({ ...EMPTY_TIME });
+	_qualifiers = signal<DateQualifierFlags>({ ...EMPTY_QUALIFIERS });
+	_isOpenStart = signal(false);
+	_isOpenEnd = signal(false);
+
+	activeQualifiers = computed(() => {
+		const q = this._qualifiers();
+		const active: string[] = [];
+		if (q.approximate) active.push('Approximate');
+		if (q.uncertain) active.push('Uncertain');
+		if (q.unknown) active.push('Unknown');
+		return active;
+	});
+
+	// Start date/time computed properties
+	hasStartDate = computed(() => {
+		if (this._qualifiers().unknown) return true;
+		if (this._isOpenStart()) return true;
+		const date = this._date();
+		return !!(date.year || date.month || date.day);
+	});
+
+	formattedStartDate = computed(() => {
+		if (this._qualifiers().unknown) return 'Unknown date and time';
+		if (this._isOpenStart()) return '..';
+		return this.formatDate(this._date());
+	});
+
+	formattedStartTime = computed(() => this.formatTime(this._time()));
+	startMeridian = computed(() =>
+		this._time().hours ? (this._time().pm ? Meridian.PM : Meridian.AM) : '',
+	);
+
+	startTimezone = computed(() =>
+		this.edtfService.browserTimezoneAbbreviation(this._date(), this._time()),
+	);
+
+	// End date/time computed properties
+	hasEndDate = computed(() => {
+		if (this._isOpenEnd()) return true;
+		const date = this._endDate();
+		return !!(date.year || date.month || date.day);
+	});
+
+	formattedEndDate = computed(() => {
+		if (this._isOpenEnd()) return '..';
+		return this.formatDate(this._endDate());
+	});
+
+	formattedEndTime = computed(() => this.formatTime(this._endTime()));
+	endMeridian = computed(() =>
+		this._endTime().hours
+			? this._endTime().pm
+				? Meridian.PM
+				: Meridian.AM
+			: '',
+	);
+
+	endTimezone = computed(() =>
+		this.edtfService.browserTimezoneAbbreviation(
+			this._endDate(),
+			this._endTime(),
+		),
+	);
+
+	ngOnInit(): void {
+		this.updateFromDisplayTime();
+	}
+
+	ngOnChanges(changes: SimpleChanges): void {
+		if (changes.displayTime && !this.isDropdownOpen()) {
+			this.updateFromDisplayTime();
+		}
+	}
+
+	@HostListener('document:click', ['$event'])
+	onDocumentClick(event: MouseEvent): void {
+		const target = event.target as Node;
+		if (
+			this.isDropdownOpen() &&
+			this.container &&
+			target.isConnected &&
+			!this.container.nativeElement.contains(target)
+		) {
+			this.onCancel();
+		}
+	}
+
+	toggle(): void {
+		if (this.disabled) return;
+		const q = this._qualifiers();
+		if (this.hasEndDate() || q.unknown || q.approximate || q.uncertain) {
+			this.onMoreOptions();
+			return;
+		}
+		if (this.isDropdownOpen()) {
+			this.onCancel();
+		} else {
+			this.open();
+		}
+	}
+
+	open(): void {
+		if (this.disabled) return;
+		this.updateFromDisplayTime();
+		this.isDropdownOpen.set(true);
+	}
+
+	onDateChange(newDate: DateModel): void {
+		this._date.set(newDate);
+	}
+
+	onTimeChange(newTime: TimeModel): void {
+		this._time.update((t) => ({
+			...t,
+			...newTime,
+		}));
+	}
+
+	clearAll(): void {
+		this._date.set({ ...EMPTY_DATE });
+		this._time.set({ ...EMPTY_TIME });
+		this._endDate.set({ ...EMPTY_DATE });
+		this._endTime.set({ ...EMPTY_TIME });
+		this._qualifiers.set({ ...EMPTY_QUALIFIERS });
+		this._isOpenStart.set(false);
+		this._isOpenEnd.set(false);
+	}
+
+	onMoreOptions(): void {
+		this.isDropdownOpen.set(false);
+
+		const modalData: DateTimeModel = {
+			qualifiers: { ...this._qualifiers() },
+			date: { ...this._date() },
+			time: { ...this._time() },
+		};
+
+		const endDate = this._endDate();
+		if (endDate.year || endDate.month || endDate.day || this._isOpenEnd()) {
+			modalData.endDate = { ...endDate };
+			modalData.endTime = { ...this._endTime() };
+		}
+
+		this.moreOptionsClicked.emit(modalData);
+	}
+
+	onCancel(): void {
+		this.updateFromDisplayTime();
+		this.isDropdownOpen.set(false);
+	}
+
+	onSave(): void {
+		const dateTimeModel: DateTimeModel = {
+			qualifiers: { ...this._qualifiers() },
+			date: { ...this._date() },
+			time: { ...this._time() },
+		};
+
+		const endDate = this._endDate();
+		if (endDate.year || endDate.month || endDate.day || this._isOpenEnd()) {
+			dateTimeModel.endDate = { ...endDate };
+			dateTimeModel.endTime = { ...this._endTime() };
+		}
+
+		this.saveClicked.emit(dateTimeModel);
+		this.isDropdownOpen.set(false);
+	}
+
+	private updateFromDisplayTime(): void {
+		if (!this.displayTime) {
+			this._date.set({ ...EMPTY_DATE });
+			this._time.set({ ...EMPTY_TIME });
+			this._endDate.set({ ...EMPTY_DATE });
+			this._endTime.set({ ...EMPTY_TIME });
+			this._qualifiers.set({ ...EMPTY_QUALIFIERS });
+			this._isOpenStart.set(false);
+			this._isOpenEnd.set(false);
+			return;
+		}
+
+		const startDate = this.displayTime.date ?? { ...EMPTY_DATE };
+		const endDate = this.displayTime.endDate;
+		const isInterval = !!endDate;
+		const isStartEmpty = !startDate.year && !startDate.month && !startDate.day;
+		const isEndEmpty =
+			isInterval && !endDate.year && !endDate.month && !endDate.day;
+
+		this._isOpenStart.set(isInterval && isStartEmpty);
+		this._isOpenEnd.set(isEndEmpty);
+
+		this._date.set({ ...startDate });
+		this._time.set(
+			this.displayTime.time ? { ...this.displayTime.time } : { ...EMPTY_TIME },
+		);
+		this._qualifiers.set(
+			this.displayTime.qualifiers
+				? { ...this.displayTime.qualifiers }
+				: { ...EMPTY_QUALIFIERS },
+		);
+		this._endDate.set(endDate ? { ...endDate } : { ...EMPTY_DATE });
+		this._endTime.set(
+			this.displayTime.endTime
+				? { ...this.displayTime.endTime }
+				: { ...EMPTY_TIME },
+		);
+	}
+
+	private formatDate(date: DateModel): string {
+		const hasYear = !!date.year;
+		const hasMonth = !!date.month;
+		const hasDay = !!date.day && parseInt(date.day, 10) > 0;
+
+		if (!hasYear && !hasMonth && !hasDay) return '';
+
+		if (hasYear) {
+			const yearNum = parseInt(date.year, 10);
+			const monthNum = hasMonth ? parseInt(date.month, 10) - 1 : 0;
+			const dayNum = hasDay ? parseInt(date.day, 10) : 1;
+
+			// setYear avoids the JS Date quirk where years 0-99 are interpreted as 1900-1999
+			const dateObj = setYear(new Date(2000, monthNum, dayNum), yearNum);
+
+			if (hasMonth && hasDay) return format(dateObj, 'MMMM d, yyyy');
+			if (hasMonth) return format(dateObj, 'MMMM yyyy');
+			return format(dateObj, 'yyyy');
+		}
+
+		const dateParts: string[] = [];
+		if (hasMonth) {
+			const monthIdx = parseInt(date.month, 10) - 1;
+			if (monthIdx >= 0 && monthIdx < 12) {
+				dateParts.push(format(new Date(2000, monthIdx), 'MMMM'));
+			}
+		}
+		if (hasDay) dateParts.push(date.day);
+		return dateParts.join(' ');
+	}
+
+	private formatTime(time: TimeModel): string {
+		if (!time?.hours) return '';
+
+		const h = time.hours.padStart(2, '0');
+		const m = (time.minutes || '00').padStart(2, '0');
+		const s = (time.seconds || '00').padStart(2, '0');
+		return `${h}:${m}:${s}`;
+	}
+}

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -293,7 +293,9 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 		const monthName = monthComplete
 			? format(new Date(2000, parseInt(monthRaw, 10) - 1), 'MMMM')
 			: null;
-		const dayDisplay = hasDay ? this.padDigitsWithX(dayRaw, 2) : '';
+		// A day is a discrete value, not a range, so a single digit is
+		// zero-padded on the left ("2" -> "02") rather than X-padded.
+		const dayDisplay = hasDay ? dayRaw.padStart(2, '0') : '';
 
 		if (monthName && hasDay)
 			return `${monthName} ${dayDisplay}, ${yearDisplay}`;

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -13,7 +13,7 @@ import {
 	ElementRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { format, setYear } from 'date-fns';
+import { format } from 'date-fns';
 import {
 	EdtfService,
 	Meridian,
@@ -273,35 +273,38 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 		);
 	}
 
+	private padDigitsWithX(value: string, width: number): string {
+		const v = value ?? '';
+		return v.length >= width ? v : v + 'X'.repeat(width - v.length);
+	}
+
 	private formatDate(date: DateModel): string {
-		const hasYear = !!date.year;
-		const hasMonth = !!date.month;
-		const hasDay = !!date.day && parseInt(date.day, 10) > 0;
+		const yearRaw = date.year ?? '';
+		const monthRaw = date.month ?? '';
+		const dayRaw = date.day ?? '';
+
+		const hasYear = !!yearRaw;
+		const hasMonth = !!monthRaw;
+		const hasDay = !!dayRaw && parseInt(dayRaw, 10) !== 0;
 
 		if (!hasYear && !hasMonth && !hasDay) return '';
 
-		if (hasYear) {
-			const yearNum = parseInt(date.year, 10);
-			const monthNum = hasMonth ? parseInt(date.month, 10) - 1 : 0;
-			const dayNum = hasDay ? parseInt(date.day, 10) : 1;
+		const yearDisplay = this.padDigitsWithX(yearRaw, 4);
+		const monthComplete = /^\d{2}$/.test(monthRaw);
+		const monthName = monthComplete
+			? format(new Date(2000, parseInt(monthRaw, 10) - 1), 'MMMM')
+			: null;
+		const dayDisplay = hasDay ? this.padDigitsWithX(dayRaw, 2) : '';
 
-			// setYear avoids the JS Date quirk where years 0-99 are interpreted as 1900-1999
-			const dateObj = setYear(new Date(2000, monthNum, dayNum), yearNum);
+		if (monthName && hasDay)
+			return `${monthName} ${dayDisplay}, ${yearDisplay}`;
+		if (monthName) return `${monthName} ${yearDisplay}`;
+		if (!hasMonth && !hasDay) return yearDisplay;
 
-			if (hasMonth && hasDay) return format(dateObj, 'MMMM d, yyyy');
-			if (hasMonth) return format(dateObj, 'MMMM yyyy');
-			return format(dateObj, 'yyyy');
-		}
-
-		const dateParts: string[] = [];
-		if (hasMonth) {
-			const monthIdx = parseInt(date.month, 10) - 1;
-			if (monthIdx >= 0 && monthIdx < 12) {
-				dateParts.push(format(new Date(2000, monthIdx), 'MMMM'));
-			}
-		}
-		if (hasDay) dateParts.push(date.day);
-		return dateParts.join(' ');
+		const monthDisplay = hasMonth ? this.padDigitsWithX(monthRaw, 2) : 'XX';
+		const parts: string[] = [yearDisplay, monthDisplay];
+		if (hasDay) parts.push(dayDisplay);
+		return parts.join('-');
 	}
 
 	private formatTime(time: TimeModel): string {

--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -106,35 +106,13 @@
 			</div>
 		</div>
 		<div class="sidebar-item">
-			<label>{{ selectedItem.isFolder ? 'Start date' : 'Date' }}</label>
-			<pr-inline-value-edit
-				[displayValue]="displayTime"
-				[canEdit]="canEdit"
-				[item]="selectedItem"
-				[itemId]="selectedItem.folder_linkId"
-				emptyMessage="Click to add date"
-				[readOnlyEmptyMessage]="
-					selectedItem.isFolder ? 'No start date' : 'No date'
-				"
-				(doneEditing)="onDateEditing('start', $event)"
-				type="date"
-			></pr-inline-value-edit>
+			<pr-sidebar-date-picker
+				[displayTime]="displayTimeObject"
+				[disabled]="!canEdit"
+				(saveClicked)="onDateSaved($event)"
+				(moreOptionsClicked)="onDateMoreOptions($event)"
+			/>
 		</div>
-		@if (selectedItem.isFolder) {
-			<div class="sidebar-item">
-				<label>End date</label>
-				<pr-inline-value-edit
-					[displayValue]="displayEndTime"
-					[canEdit]="canEdit"
-					[item]="selectedItem"
-					[itemId]="selectedItem.folder_linkId"
-					emptyMessage="Click to add date"
-					readOnlyEmptyMessage="No end date"
-					(doneEditing)="onDateEditing('end', $event)"
-					type="date"
-				></pr-inline-value-edit>
-			</div>
-		}
 		<div class="sidebar-item">
 			<label>Location</label>
 			<div

--- a/src/app/file-browser/components/sidebar/sidebar.component.html
+++ b/src/app/file-browser/components/sidebar/sidebar.component.html
@@ -105,14 +105,47 @@
 				></pr-edit-tags>
 			</div>
 		</div>
-		<div class="sidebar-item">
-			<pr-sidebar-date-picker
-				[displayTime]="displayTimeObject"
-				[disabled]="!canEdit"
-				(saveClicked)="onDateSaved($event)"
-				(moreOptionsClicked)="onDateMoreOptions($event)"
-			/>
-		</div>
+		@if (showEdtfDatePicker) {
+			<div class="sidebar-item">
+				<pr-sidebar-date-picker
+					[displayTime]="displayTimeObject"
+					[disabled]="!canEdit"
+					(saveClicked)="onDateSaved($event)"
+					(moreOptionsClicked)="onDateMoreOptions($event)"
+				/>
+			</div>
+		} @else {
+			<div class="sidebar-item">
+				<label>{{ selectedItem.isFolder ? 'Start date' : 'Date' }}</label>
+				<pr-inline-value-edit
+					[displayValue]="displayTime"
+					[canEdit]="canEdit"
+					[item]="selectedItem"
+					[itemId]="selectedItem.folder_linkId"
+					emptyMessage="Click to add date"
+					[readOnlyEmptyMessage]="
+						selectedItem.isFolder ? 'No start date' : 'No date'
+					"
+					(doneEditing)="onDateEditing('start', $event)"
+					type="date"
+				></pr-inline-value-edit>
+			</div>
+			@if (selectedItem.isFolder) {
+				<div class="sidebar-item">
+					<label>End date</label>
+					<pr-inline-value-edit
+						[displayValue]="displayEndTime"
+						[canEdit]="canEdit"
+						[item]="selectedItem"
+						[itemId]="selectedItem.folder_linkId"
+						emptyMessage="Click to add date"
+						readOnlyEmptyMessage="No end date"
+						(doneEditing)="onDateEditing('end', $event)"
+						type="date"
+					></pr-inline-value-edit>
+				</div>
+			}
+		}
 		<div class="sidebar-item">
 			<label>Location</label>
 			<div

--- a/src/app/file-browser/components/sidebar/sidebar.component.scss
+++ b/src/app/file-browser/components/sidebar/sidebar.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 $sidebar-border: $file-list-border;
 $sidebar-thumb-height: 200px;

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -7,6 +7,7 @@ import { ArchiveVO, RecordVO } from '@models/index';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
 import { BehaviorSubject } from 'rxjs';
 import { MessageService } from '@shared/services/message/message.service';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 import { SidebarComponent } from './sidebar.component';
 
 @Pipe({ name: 'prTooltip', standalone: false })
@@ -120,6 +121,10 @@ class MockAccountService {
 	}
 }
 
+const mockFeatureFlagService = {
+	isEnabled: (_flag: string) => false,
+};
+
 describe('SidebarComponent', () => {
 	let component: SidebarComponent;
 	let fixture: ComponentFixture<SidebarComponent>;
@@ -169,6 +174,10 @@ describe('SidebarComponent', () => {
 						showError: () => {},
 						showMessage: () => {},
 					},
+				},
+				{
+					provide: FeatureFlagService,
+					useValue: mockFeatureFlagService,
 				},
 			],
 			schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -273,6 +282,23 @@ describe('SidebarComponent', () => {
 			component.selectedItem.displayTime || component.selectedItem.displayDT;
 
 		expect(displayValue).toBe('2024-01-01T00:00:00.000Z');
+	});
+
+	describe('edtf-date feature flag', () => {
+		it('should set showEdtfDatePicker to false when edtf-date flag is disabled', () => {
+			expect(component.showEdtfDatePicker).toBe(false);
+		});
+
+		it('should set showEdtfDatePicker to true when edtf-date flag is enabled', () => {
+			spyOn(mockFeatureFlagService, 'isEnabled').and.callFake(
+				(flag: string) => flag === 'edtf-date',
+			);
+
+			const enabledFixture = TestBed.createComponent(SidebarComponent);
+			enabledFixture.detectChanges();
+
+			expect(enabledFixture.componentInstance.showEdtfDatePicker).toBe(true);
+		});
 	});
 
 	it('should hide the original format for folders', () => {

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -4,8 +4,9 @@ import { DataService } from '@shared/services/data/data.service';
 import { EditService } from '@core/services/edit/edit.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { ArchiveVO, RecordVO } from '@models/index';
-import { of } from 'rxjs';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
+import { BehaviorSubject } from 'rxjs';
+import { MessageService } from '@shared/services/message/message.service';
 import { SidebarComponent } from './sidebar.component';
 
 @Pipe({ name: 'prTooltip', standalone: false })
@@ -92,15 +93,10 @@ class MockSelectedItemPipe implements PipeTransform {
 	}
 }
 
+let selectedItemsSubject: BehaviorSubject<Set<any>>;
+
 const mockDataService = {
-	selectedItems$: () =>
-		of(
-			new Set([
-				new RecordVO({
-					accessRole: 'access.role.owner',
-				}),
-			]),
-		),
+	selectedItems$: () => selectedItemsSubject.asObservable(),
 	fetchFullItems: (_: any) => {},
 	currentFolder: {
 		type: 'folder',
@@ -109,9 +105,7 @@ const mockDataService = {
 
 const mockEditService = {
 	openLocationDialog: (_: any) => {},
-	saveItemVoProperty: jasmine
-		.createSpy('saveItemVoProperty')
-		.and.returnValue(Promise.resolve()),
+	saveItemVoProperty: (_item: any, _prop: any, _value: any) => {},
 };
 
 class MockAccountService {
@@ -131,6 +125,14 @@ describe('SidebarComponent', () => {
 	let fixture: ComponentFixture<SidebarComponent>;
 
 	beforeEach(async () => {
+		selectedItemsSubject = new BehaviorSubject<Set<any>>(
+			new Set([
+				new RecordVO({
+					accessRole: 'access.role.owner',
+				}),
+			]),
+		);
+
 		await TestBed.configureTestingModule({
 			declarations: [
 				SidebarComponent,
@@ -160,6 +162,13 @@ describe('SidebarComponent', () => {
 				{
 					provide: AccountService,
 					useClass: MockAccountService,
+				},
+				{
+					provide: MessageService,
+					useValue: {
+						showError: () => {},
+						showMessage: () => {},
+					},
 				},
 			],
 			schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -335,72 +344,6 @@ describe('SidebarComponent', () => {
 			component.selectedItem = item;
 
 			expect(component.displayEndTime).toBe('');
-		});
-	});
-
-	describe('onDateEditing', () => {
-		beforeEach(() => {
-			mockEditService.saveItemVoProperty.calls.reset();
-		});
-
-		it('should build EDTF interval when setting start date and end date exists', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('start', '2000-01-01');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				'2000-01-01/1990-06-15',
-			);
-		});
-
-		it('should build EDTF interval when setting end date and start date exists', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('end', '2025-12-31');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				'1985-05-20/2025-12-31',
-			);
-		});
-
-		it('should set only start date when no end date is provided', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('start', '2000-01-01');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				'2000-01-01',
-			);
-		});
-
-		it('should set displayTime to null when start date is cleared', async () => {
-			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
-			component.selectedItem = item;
-
-			await component.onDateEditing('start', '');
-
-			expect(mockEditService.saveItemVoProperty).toHaveBeenCalledWith(
-				item,
-				'displayTime',
-				null,
-			);
-		});
-
-		it('should not call saveItemVoProperty when selectedItem is null', async () => {
-			component.selectedItem = null;
-
-			await component.onDateEditing('start', '2000-01-01');
-
-			expect(mockEditService.saveItemVoProperty).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -492,5 +492,22 @@ describe('SidebarComponent', () => {
 			expect(component.displayTimeObject).toBeNull();
 			expect(showErrorSpy).toHaveBeenCalledTimes(1);
 		});
+
+		it('should recompute the display time object when saving an invalid date fails, so the picker re-syncs to the stored value', async () => {
+			const messageService = TestBed.inject(MessageService);
+			const showErrorSpy = spyOn(messageService, 'showError');
+			const edtfService = TestBed.inject(EdtfService);
+			spyOn(edtfService, 'toEdtfDate').and.throwError('invalid date');
+
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: 'not-a-year' } as never,
+				time: { format: 'am' },
+			});
+
+			expect(showErrorSpy).toHaveBeenCalledTimes(1);
+			expect(component.displayTimeObject?.date.year).toBe('1985');
+		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -8,6 +8,7 @@ import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
 import { BehaviorSubject } from 'rxjs';
 import { MessageService } from '@shared/services/message/message.service';
 import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
+import { EdtfService } from '@shared/services/edtf-service/edtf.service';
 import { SidebarComponent } from './sidebar.component';
 
 @Pipe({ name: 'prTooltip', standalone: false })
@@ -370,6 +371,126 @@ describe('SidebarComponent', () => {
 			component.selectedItem = item;
 
 			expect(component.displayEndTime).toBe('');
+		});
+	});
+
+	describe('onDateEditing', () => {
+		let saveItemVoPropertySpy: jasmine.Spy;
+
+		beforeEach(() => {
+			saveItemVoPropertySpy = spyOn(mockEditService, 'saveItemVoProperty');
+		});
+
+		it('should build EDTF interval when setting start date and end date exists', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('start', '2000-01-01');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				'2000-01-01/1990-06-15',
+			);
+		});
+
+		it('should build EDTF interval when setting end date and start date exists', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('end', '2025-12-31');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				'1985-05-20/2025-12-31',
+			);
+		});
+
+		it('should set only start date when no end date is provided', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('start', '2000-01-01');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				'2000-01-01',
+			);
+		});
+
+		it('should set displayTime to null when start date is cleared', async () => {
+			const item = new RecordVO({ displayTime: '1985-05-20/1990-06-15' });
+			component.selectedItem = item;
+
+			await component.onDateEditing('start', '');
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				item,
+				'displayTime',
+				null,
+			);
+		});
+
+		it('should not call saveItemVoProperty when selectedItem is null', async () => {
+			component.selectedItem = null;
+
+			await component.onDateEditing('start', '2000-01-01');
+
+			expect(saveItemVoPropertySpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('displayTimeObject', () => {
+		it('should keep a stable reference across reads instead of creating a new object each time', async () => {
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: '1985', month: '05', day: '20' },
+				time: { format: 'am' },
+			});
+
+			const firstRead = component.displayTimeObject;
+			const secondRead = component.displayTimeObject;
+
+			expect(firstRead).not.toBeNull();
+			expect(secondRead).toBe(firstRead);
+		});
+
+		it('should recompute the display time object when a new date is saved', async () => {
+			const editService = TestBed.inject(EditService);
+			spyOn(editService, 'saveItemVoProperty').and.callFake(
+				async (item: any, prop: any, value: any) => {
+					item[prop] = value;
+				},
+			);
+
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: '1990', month: '06', day: '15' },
+				time: { format: 'am' },
+			});
+
+			expect(component.displayTimeObject?.date.year).toBe('1990');
+		});
+
+		it('should null the display time object and show one error when parsing fails', async () => {
+			const messageService = TestBed.inject(MessageService);
+			const showErrorSpy = spyOn(messageService, 'showError');
+			const edtfService = TestBed.inject(EdtfService);
+			spyOn(edtfService, 'toDateTimeModel').and.throwError('bad date');
+
+			component.selectedItem = new RecordVO({ displayTime: 'not-a-date' });
+
+			await component.onDateSaved({
+				date: { year: '1990', month: '06', day: '15' },
+				time: { format: 'am' },
+			});
+
+			expect(component.displayTimeObject).toBeNull();
+			expect(showErrorSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -18,6 +18,7 @@ import {
 	EdtfService,
 } from '@shared/services/edtf-service/edtf.service';
 import { MessageService } from '@shared/services/message/message.service';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 
 type SidebarTab = 'info' | 'details' | 'sharing' | 'views';
 @Component({
@@ -45,6 +46,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	canUseViews: boolean;
 
 	originalFileExtension: string = '';
+
+	showEdtfDatePicker: boolean;
 
 	get displayTimeObject(): DateTimeModel | null {
 		try {
@@ -91,8 +94,10 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		private message: MessageService,
 		private accountService: AccountService,
 		private cdr: ChangeDetectorRef,
+		private feature: FeatureFlagService,
 	) {
 		this.currentArchive = this.accountService.getArchive();
+		this.showEdtfDatePicker = this.feature.isEnabled('edtf-date');
 
 		this.subscriptions.push(
 			this.dataService.selectedItems$().subscribe(async (selectedItems) => {

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -49,14 +49,18 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 
 	showEdtfDatePicker: boolean;
 
-	get displayTimeObject(): DateTimeModel | null {
+	displayTimeObject: DateTimeModel | null = null;
+
+	private updateDisplayTimeObject(): void {
+		const timeSource =
+			this.selectedItem?.displayTime || this.selectedItem?.displayDT;
 		try {
-			const timeSource =
-				this.selectedItem?.displayTime || this.selectedItem?.displayDT;
-			return timeSource ? this.edtfService.toDateTimeModel(timeSource) : null;
+			this.displayTimeObject = timeSource
+				? this.edtfService.toDateTimeModel(timeSource)
+				: null;
 		} catch (err) {
+			this.displayTimeObject = null;
 			this.message.showError({ message: err?.message });
-			return null;
 		}
 	}
 
@@ -162,6 +166,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 					this.isRecord = !this.selectedItem.isFolder;
 				}
 
+				this.updateDisplayTimeObject();
+
 				this.cdr.markForCheck();
 			}),
 		);
@@ -245,6 +251,7 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		try {
 			const newDisplayTime = this.edtfService.toEdtfDate(result);
 			await this.onFinishEditing('displayTime', newDisplayTime);
+			this.updateDisplayTimeObject();
 		} catch (err) {
 			this.message.showError({ message: err?.message });
 		}

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -251,9 +251,10 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 		try {
 			const newDisplayTime = this.edtfService.toEdtfDate(result);
 			await this.onFinishEditing('displayTime', newDisplayTime);
-			this.updateDisplayTimeObject();
 		} catch (err) {
 			this.message.showError({ message: err?.message });
+		} finally {
+			this.updateDisplayTimeObject();
 		}
 	}
 

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -13,6 +13,11 @@ import { EditService } from '@core/services/edit/edit.service';
 import { AccountService } from '@shared/services/account/account.service';
 
 import type { KeysOfType } from '@shared/utilities/keysoftype';
+import {
+	DateTimeModel,
+	EdtfService,
+} from '@shared/services/edtf-service/edtf.service';
+import { MessageService } from '@shared/services/message/message.service';
 
 type SidebarTab = 'info' | 'details' | 'sharing' | 'views';
 @Component({
@@ -40,6 +45,17 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	canUseViews: boolean;
 
 	originalFileExtension: string = '';
+
+	get displayTimeObject(): DateTimeModel | null {
+		try {
+			const timeSource =
+				this.selectedItem?.displayTime || this.selectedItem?.displayDT;
+			return timeSource ? this.edtfService.toDateTimeModel(timeSource) : null;
+		} catch (err) {
+			this.message.showError({ message: err?.message });
+			return null;
+		}
+	}
 
 	get displayTime(): string {
 		return this.parseEdtfInterval('start');
@@ -71,6 +87,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	constructor(
 		private dataService: DataService,
 		private editService: EditService,
+		private edtfService: EdtfService,
+		private message: MessageService,
 		private accountService: AccountService,
 		private cdr: ChangeDetectorRef,
 	) {
@@ -117,7 +135,13 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 						await this.dataService.fetchFullItems(items);
 						this.isLoading = false;
 					}
+				} else if (
+					this.selectedItem?.isFolder &&
+					!this.selectedItem?.displayTime
+				) {
+					await this.dataService.fetchFullItems([this.selectedItem]);
 				}
+
 				if (
 					this.selectedItem instanceof RecordVO &&
 					this.selectedItem.FileVOs &&
@@ -132,6 +156,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 					this.originalFileExtension = '';
 					this.isRecord = !this.selectedItem.isFolder;
 				}
+
+				this.cdr.markForCheck();
 			}),
 		);
 	}
@@ -202,8 +228,25 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	}
 
 	async onFinishEditing(property: KeysOfType<ItemVO, String>, value: string) {
-		this.editService.saveItemVoProperty(this.selectedItem, property, value);
-		this.cdr.detectChanges();
+		await this.editService.saveItemVoProperty(
+			this.selectedItem,
+			property,
+			value,
+		);
+		this.cdr.markForCheck();
+	}
+
+	async onDateSaved(result: DateTimeModel) {
+		try {
+			const newDisplayTime = this.edtfService.toEdtfDate(result);
+			await this.onFinishEditing('displayTime', newDisplayTime);
+		} catch (err) {
+			this.message.showError({ message: err?.message });
+		}
+	}
+
+	async onDateMoreOptions(): Promise<void> {
+		//TODO: add edit date time modal PER-10642
 	}
 
 	onLocationClick() {

--- a/src/app/file-browser/file-browser-components.module.ts
+++ b/src/app/file-browser/file-browser-components.module.ts
@@ -27,6 +27,7 @@ import { SidebarViewOptionComponent } from './components/sidebar-view-option/sid
 import { SharingDialogComponent } from './components/sharing-dialog/sharing-dialog.component';
 
 import { DownloadButtonComponent } from './components/download-button/download-button.component';
+import { SidebarDatePickerComponent } from './components/sidebar-date-picker/sidebar-date-picker.component';
 
 @NgModule({
 	imports: [
@@ -36,6 +37,7 @@ import { DownloadButtonComponent } from './components/download-button/download-b
 		GoogleMapsModule,
 		InViewportModule,
 		FontAwesomeModule,
+		SidebarDatePickerComponent,
 	],
 	exports: [
 		FileListComponent,

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
@@ -110,6 +110,17 @@ describe('DatepickerInputComponent', () => {
 		expect(hostComponent.lastEmittedDate?.day).toBe('3');
 	});
 
+	it('should allow backspacing a left-padded day down to a single "0" without reverting', () => {
+		hostComponent.date = { year: '2026', month: '01', day: '05' };
+		fixture.detectChanges();
+		const input = { value: '0' } as HTMLInputElement;
+
+		component.updateDay({ target: input } as unknown as Event);
+
+		expect(input.value).toBe('0');
+		expect(hostComponent.lastEmittedDate?.day).toBe('0');
+	});
+
 	it('should not emit day greater than max for month', () => {
 		hostComponent.date = { year: '2026', month: '02', day: '' };
 		fixture.detectChanges();

--- a/src/app/shared/services/api/record.repo.spec.ts
+++ b/src/app/shared/services/api/record.repo.spec.ts
@@ -6,7 +6,11 @@ import {
 import { of } from 'rxjs';
 import { environment } from '@root/environments/environment';
 import { HttpService } from '@shared/services/http/http.service';
-import { RecordRepo, RecordResponse } from '@shared/services/api/record.repo';
+import {
+	convertStelaRecordToRecordVO,
+	RecordRepo,
+	RecordResponse,
+} from '@shared/services/api/record.repo';
 import { RecordVO } from '@root/app/models';
 import {
 	provideHttpClient,
@@ -231,6 +235,7 @@ describe('RecordRepo', () => {
 			displayName: 'Test Record',
 			archiveNumber: 'arch-1',
 			displayDate: '2025-01-01',
+			displayTime: '1985-05-20T10:00:00+05:30',
 			folderLinkId: '1',
 			folderLinkType: 'type.folder_link.private',
 			parentFolderLinkId: '2',
@@ -305,6 +310,46 @@ describe('RecordRepo', () => {
 			const resultRecord = result.getRecordVO();
 
 			expect(resultRecord).toBeInstanceOf(RecordVO);
+		});
+	});
+
+	describe('convertStelaRecordToRecordVO', () => {
+		const baseStelaRecord = {
+			recordId: 42,
+			displayName: 'Test Record',
+			archiveNumber: 'arch-1',
+			displayDate: '2025-01-01',
+			folderLinkId: '1',
+			folderLinkType: 'type.folder_link.private' as any,
+			parentFolderLinkId: '2',
+			thumbUrl200: '',
+			thumbUrl500: '',
+			thumbUrl1000: '',
+			thumbUrl2000: '',
+			location: null,
+			files: [],
+			createdAt: '2025-01-01',
+			updatedAt: '2025-01-01',
+			archive: { id: '1', name: 'Archive', thumbURL200: '' },
+			shares: null,
+			tags: null,
+		};
+
+		it('should map displayTime from the stela record', () => {
+			const record = convertStelaRecordToRecordVO({
+				...baseStelaRecord,
+				displayTime: '1985-05-20T10:00:00+05:30',
+			} as any);
+
+			expect(record.displayTime).toBe('1985-05-20T10:00:00+05:30');
+		});
+
+		it('should leave displayTime undefined when not present in stela record', () => {
+			const record = convertStelaRecordToRecordVO({
+				...baseStelaRecord,
+			} as any);
+
+			expect(record.displayTime).toBeUndefined();
 		});
 	});
 });

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -101,6 +101,7 @@ export type StelaRecord = Omit<RecordVO, 'files'> & {
 	tags: Array<StelaTag> | null;
 	archiveNumber: string;
 	displayDate: string;
+	displayTime?: string;
 	folderLinkId: string;
 	folderLinkType: FolderLinkType;
 	parentFolderLinkId: string;
@@ -180,6 +181,7 @@ export const convertStelaRecordToRecordVO = (
 		),
 		archiveNbr: stelaRecord.archiveNumber,
 		displayDT: stelaRecord.displayDate,
+		displayTime: stelaRecord.displayTime,
 		folder_linkId: Number.parseInt(stelaRecord.folderLinkId, 10),
 		folder_linkType: stelaRecord.folderLinkType,
 		LocnVO: convertStelaLocationToLocnVOData(stelaRecord.location),

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -736,6 +736,71 @@ describe('EdtfService', () => {
 		});
 	});
 
+	describe('browserTimezoneAbbreviation', () => {
+		const stubTimezoneName = (timezoneName: string): void => {
+			spyOn(Intl, 'DateTimeFormat').and.returnValue({
+				formatToParts: () => [{ type: 'timeZoneName', value: timezoneName }],
+			} as unknown as Intl.DateTimeFormat);
+		};
+
+		const sampleDate = { year: '1985', month: '05', day: '20' };
+		const sampleTime = {
+			hours: '02',
+			minutes: '30',
+			seconds: '00',
+			format: 'pm' as const,
+		};
+
+		it('should return empty string when time has no hours', () => {
+			const result = service.browserTimezoneAbbreviation(sampleDate, {
+				hours: '',
+				format: 'am',
+			});
+
+			expect(result).toBe('');
+		});
+
+		it('should keep named abbreviations unchanged', () => {
+			stubTimezoneName('EDT');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'EDT',
+			);
+		});
+
+		it('should pad a whole-hour offset to +/-HH:MM', () => {
+			stubTimezoneName('GMT+3');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT+03:00',
+			);
+		});
+
+		it('should pad a half-hour positive offset to +/-HH:MM', () => {
+			stubTimezoneName('GMT+5:30');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT+05:30',
+			);
+		});
+
+		it('should pad a negative offset to +/-HH:MM', () => {
+			stubTimezoneName('GMT-9:30');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT-09:30',
+			);
+		});
+
+		it('should leave an already-normalized offset unchanged', () => {
+			stubTimezoneName('GMT+03:00');
+
+			expect(service.browserTimezoneAbbreviation(sampleDate, sampleTime)).toBe(
+				'GMT+03:00',
+			);
+		});
+	});
+
 	describe('parseTimeAs24Hour', () => {
 		it('should convert PM time to 24-hour format', () => {
 			const result = service.parseTimeAs24Hour({
@@ -1125,46 +1190,6 @@ describe('EdtfService', () => {
 			const result = service.toEdtfDate(model);
 
 			expect(result).toBe(`1985-05-20T23:23:23${localTimezoneOffset()}`);
-		});
-
-		it('should roundtrip partial year (198X)', () => {
-			const edtfString = '198X';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip month-only with unknown year (XXXX-05)', () => {
-			const edtfString = 'XXXX-05';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip known year and day with unknown month (1985-XX-20)', () => {
-			const edtfString = '1985-XX-20';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip partial day (1985-05-2X)', () => {
-			const edtfString = '1985-05-2X';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
-		});
-
-		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
-			const edtfString = '198X-05-20';
-			const model = service.toDateTimeModel(edtfString);
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe(edtfString);
 		});
 
 		it('should roundtrip partial year (198X)', () => {

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -718,6 +718,24 @@ describe('EdtfService', () => {
 		});
 	});
 
+	describe('isNumeric', () => {
+		it('should return true for digit-only string', () => {
+			expect(service.isNumeric('12345')).toBe(true);
+		});
+
+		it('should return false for string with letters', () => {
+			expect(service.isNumeric('12a5')).toBe(false);
+		});
+
+		it('should return false for empty string', () => {
+			expect(service.isNumeric('')).toBe(false);
+		});
+
+		it('should return false for negative number string', () => {
+			expect(service.isNumeric('-1')).toBe(false);
+		});
+	});
+
 	describe('parseTimeAs24Hour', () => {
 		it('should convert PM time to 24-hour format', () => {
 			const result = service.parseTimeAs24Hour({

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -383,13 +383,22 @@ describe('EdtfService', () => {
 				expect(service.toEdtfDate(model)).toBe('1985-XX-20');
 			});
 
-			it('should pad single-digit day with one X', () => {
+			it('should zero-pad a single-digit day on the left', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '05', day: '2' },
 					time: { format: 'am' },
 				};
 
-				expect(service.toEdtfDate(model)).toBe('1985-05-2X');
+				expect(service.toEdtfDate(model)).toBe('1985-05-02');
+			});
+
+			it('should zero-pad a single-digit day that would be an invalid X-range', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '9' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-09');
 			});
 
 			it('should pad single-digit month with one X', () => {
@@ -1083,6 +1092,10 @@ describe('EdtfService', () => {
 			expect(service.isValidDay('3', '1985', '05')).toBe(true);
 		});
 
+		it('should accept a single "0" as in-progress input so backspace works on a padded day', () => {
+			expect(service.isValidDay('0', '1985', '05')).toBe(true);
+		});
+
 		it('should fall back to leap year 2000 when year is missing', () => {
 			// 2000 is a leap year so Feb 29 is allowed
 			expect(service.isValidDay('29', '', '02')).toBe(true);
@@ -1198,12 +1211,13 @@ describe('EdtfService', () => {
 			expect(result).toBe(edtfString);
 		});
 
-		it('should roundtrip partial day (1985-05-2X)', () => {
-			const edtfString = '1985-05-2X';
-			const model = service.toDateTimeModel(edtfString);
+		it('should normalize a partial day (1985-05-2X) to a discrete zero-padded day', () => {
+			// A day is treated as a discrete value, not an unspecified-digit
+			// range, so 2X collapses to the 2nd rather than round-tripping.
+			const model = service.toDateTimeModel('1985-05-2X');
 			const result = service.toEdtfDate(model);
 
-			expect(result).toBe(edtfString);
+			expect(result).toBe('1985-05-02');
 		});
 
 		it('should roundtrip partial year with full month and day (198X-05-20)', () => {

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -718,24 +718,6 @@ describe('EdtfService', () => {
 		});
 	});
 
-	describe('isNumeric', () => {
-		it('should return true for digit-only string', () => {
-			expect(service.isNumeric('12345')).toBe(true);
-		});
-
-		it('should return false for string with letters', () => {
-			expect(service.isNumeric('12a5')).toBe(false);
-		});
-
-		it('should return false for empty string', () => {
-			expect(service.isNumeric('')).toBe(false);
-		});
-
-		it('should return false for negative number string', () => {
-			expect(service.isNumeric('-1')).toBe(false);
-		});
-	});
-
 	describe('browserTimezoneAbbreviation', () => {
 		const stubTimezoneName = (timezoneName: string): void => {
 			spyOn(Intl, 'DateTimeFormat').and.returnValue({

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -1166,5 +1166,45 @@ describe('EdtfService', () => {
 
 			expect(result).toBe(edtfString);
 		});
+
+		it('should roundtrip partial year (198X)', () => {
+			const edtfString = '198X';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip month-only with unknown year (XXXX-05)', () => {
+			const edtfString = 'XXXX-05';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip known year and day with unknown month (1985-XX-20)', () => {
+			const edtfString = '1985-XX-20';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip partial day (1985-05-2X)', () => {
+			const edtfString = '1985-05-2X';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
+			const edtfString = '198X-05-20';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
 	});
 });

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -359,10 +359,6 @@ export class EdtfService {
 		return model;
 	}
 
-	isNumeric(value: string): boolean {
-		return /^\d+$/.test(value);
-	}
-
 	buildReferenceDate(date: DateModel, time: TimeModel): Date {
 		const year = parseInt(date?.year ?? '', 10);
 		if (Number.isNaN(year)) return new Date();

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -203,7 +203,9 @@ export class EdtfService {
 		const month = hasMonth ? this.padWithX(date.month, 2) : 'XX';
 		if (!hasDay) return `${year}-${month}`;
 
-		const day = this.padWithX(date.day, 2);
+		// A day is a discrete value, so a single digit is zero-padded on the
+		// left ("9" -> "09"); X-padding would produce an invalid day (90-99).
+		const day = date.day.padStart(2, '0');
 		return `${year}-${month}-${day}`;
 	}
 
@@ -470,6 +472,9 @@ export class EdtfService {
 
 	isValidDay(value: string, year: string, month: string): boolean {
 		if (value === '') return true;
+		// A single digit is an in-progress value (e.g. "0" while deleting "05"),
+		// so accept it; full validation runs once two digits are entered.
+		if (/^\d$/.test(value)) return true;
 		// Defaults let day be typed before year/month are filled in.
 		// 2000 is a leap year (allows Feb 29); 01 has 31 days (most permissive).
 		const yearStr = year.length === 4 ? year : '2000';

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -359,6 +359,39 @@ export class EdtfService {
 		return model;
 	}
 
+	isNumeric(value: string): boolean {
+		return /^\d+$/.test(value);
+	}
+
+	buildReferenceDate(date: DateModel, time: TimeModel): Date {
+		const year = parseInt(date?.year ?? '', 10);
+		if (Number.isNaN(year)) return new Date();
+		const month = date.month ? parseInt(date.month, 10) - 1 : 0;
+		const day = date.day ? parseInt(date.day, 10) : 1;
+		const time24 = time?.hours ? this.parseTimeAs24Hour(time) : null;
+		return new Date(
+			year,
+			month,
+			day,
+			time24?.hour ?? 0,
+			time24?.minute ?? 0,
+			time24?.second ?? 0,
+		);
+	}
+
+	browserTimezoneAbbreviation(date: DateModel, time: TimeModel): string {
+		if (!time?.hours) return '';
+		try {
+			const referenceDate = this.buildReferenceDate(date, time);
+			const parts = new Intl.DateTimeFormat('en-US', {
+				timeZoneName: 'short',
+			}).formatToParts(referenceDate);
+			return parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+		} catch {
+			return '';
+		}
+	}
+
 	parseTimeAs24Hour(
 		time: TimeModel,
 	): { hour: number; minute: number; second: number } | null {

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -386,10 +386,22 @@ export class EdtfService {
 			const parts = new Intl.DateTimeFormat('en-US', {
 				timeZoneName: 'short',
 			}).formatToParts(referenceDate);
-			return parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+			const timezoneName =
+				parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+			return this.normalizeTimezoneOffsetDisplay(timezoneName);
 		} catch {
 			return '';
 		}
+	}
+
+	// Intl 'short' renders offset-only zones as e.g. GMT+3 or GMT+5:30;
+	// rewrite the offset part to the canonical +/-HH:MM form (GMT+03:00).
+	private normalizeTimezoneOffsetDisplay(timezoneName: string): string {
+		const offsetMatch = /([+-])(\d{1,2})(?::(\d{2}))?/.exec(timezoneName);
+		if (!offsetMatch) return timezoneName;
+		const [rawOffset, sign, offsetHours, offsetMinutes] = offsetMatch;
+		const normalizedOffset = `${sign}${offsetHours.padStart(2, '0')}:${offsetMinutes ?? '00'}`;
+		return timezoneName.replace(rawOffset, normalizedOffset);
 	}
 
 	parseTimeAs24Hour(

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -13,6 +13,7 @@ $PR-blue-100: #d0d1db;
 $PR-blue-300: #a1a4b7;
 $PR-blue-400: #898da4;
 $PR-blue-600: #5a5f80;
+$PR-blue-800: #2b325c;
 $PR-blue-900: #131b4a;
 
 $PR-orange-light: #ffc779;


### PR DESCRIPTION
# !!! This functionality is hidden under a flag: `edtf-date`. We need to make sure the flag is on only for testing, but not in production.

# Manual test cases — sidebar date dropdown

Setup (run once before the tests):
1. Log in or create a new account.
2. Upload a file.
3. Click the file.
EXPECTED: The sidebar appears with a Date section.

**STEPS TO TEST:**
 **FLAG ON:**
 
**Date and time:**
1. Open the dropdown.
2. Enter April 12, 1985 in the date input.
3. In the time input, enter 02:30:00 and toggle the meridian to PM.
4. Click Save.
EXPECTED: The sidebar shows "April 12, 1985 • 02:30:00 PM" with the browser timezone abbreviation appended (e.g. "EST").

1. Open the dropdown.
2. Click the date picker button and select 22 May 2025.
3. Click the time picker button and enter 10:22:33 and toggle the meridian to AM.
4. Click Save.
EXPECTED: The sidebar shows "May 22, 2025 • 10:22:33 AM" with the browser timezone abbreviation appended (e.g. "EST").

**Date with unspecified digits:**
1. Open the dropdown.
2. Type `1988` in the year input, leave the month empty, and `15` in the day.
3. Click Save.
EXPECTED: The sidebar shows "1988-XX-15".

**Cancel:**
1. With a date already saved (e.g. April 12, 1985), click the Date section to reopen the dropdown.
EXPECTED: The dropdown reopens with the saved date and time pre-filled.
2. Change the year to 1990.
3. Click Cancel.
EXPECTED: The dropdown closes and the sidebar still shows "April 12, 1985". No changes are persisted.

**Check the updated date persisted:**
1. With a date already saved (e.g. April 12, 1985), click the Date section.
2. Change the day to 20.
3. Click Save.
EXPECTED: The sidebar updates to "April 20, 1985".
4. Refresh the page.
EXPECTED: The sidebar still shows "April 20, 1985".

**FLAG OFF:**
1. Select a record.
2. Click the date.
EXPECTED: The datepicker dropdown appears.
3. Modify the date and time.
4. Click the SAVE button.
EXPECTED: The newly selected date and time are shown in the sidebar.
5. Refresh the browser.
EXPECTED: The date that has bin filled is still present.

1. Select a folder.
2. Click the START date.
EXPECTED: The datepicker dropdown appears.
3. Modify the date and time.
4. Click the SAVE button.
5. Click the END date.
EXPECTED: The datepicker dropdown appears.
6. Modify the date and time.
7. Click the SAVE button.
EXPECTED: The newly selected date and time for START and END date are shown in the sidebar.
8. Refresh the browser.
EXPECTED: The date that has been filled is still present.
