### PR TITLE
PER-10621: use Archivematica thumbnails

### DIFF
--- a/src/app/shared/services/api/base.ts
+++ b/src/app/shared/services/api/base.ts
@@ -105,6 +105,7 @@ export const LeanWhitelist = [
 	'thumbURL500',
 	'thumbURL1000',
 	'thumbURL2000',
+	'thumbnail256',
 	'thumbDT',
 	'refArchiveNbr',
 	'folder_linkId',

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -69,12 +69,12 @@ interface StelaFolder {
 	};
 	publicAt: string;
 	sort: string;
-	thumbnailUrls: {
-		'200': string;
-		'256': string;
-		'500': string;
-		'1000': string;
-		'2000': string;
+	thumbnailUrls?: {
+		'200'?: string;
+		'256'?: string;
+		'500'?: string;
+		'1000'?: string;
+		'2000'?: string;
 	};
 	type: string;
 	status: string;

--- a/src/app/shared/services/api/record.repo.spec.ts
+++ b/src/app/shared/services/api/record.repo.spec.ts
@@ -7,11 +7,11 @@ import { of } from 'rxjs';
 import { environment } from '@root/environments/environment';
 import { HttpService } from '@shared/services/http/http.service';
 import {
+	convertStelaLocationToLocnVOData,
 	convertStelaRecordToRecordVO,
 	RecordRepo,
 	RecordResponse,
 	StelaLocation,
-	convertStelaLocationToLocnVOData,
 } from '@shared/services/api/record.repo';
 import { RecordVO } from '@root/app/models';
 import {
@@ -446,6 +446,25 @@ describe('RecordRepo', () => {
 			} as any);
 
 			expect(record.displayTime).toBeUndefined();
+		});
+
+		it('maps thumbnailUrls to all thumb fields', () => {
+			const record = convertStelaRecordToRecordVO({
+				...baseStelaRecord,
+				thumbnailUrls: {
+					'200': 'https://example.com/200',
+					'256': 'https://example.com/256',
+					'500': 'https://example.com/500',
+					'1000': 'https://example.com/1000',
+					'2000': 'https://example.com/2000',
+				},
+			} as any);
+
+			expect(record.thumbURL200).toBe('https://example.com/200');
+			expect(record.thumbURL500).toBe('https://example.com/500');
+			expect(record.thumbURL1000).toBe('https://example.com/1000');
+			expect(record.thumbURL2000).toBe('https://example.com/2000');
+			expect(record.thumbnail256).toBe('https://example.com/256');
 		});
 	});
 });

--- a/src/app/shared/services/api/record.repo.ts
+++ b/src/app/shared/services/api/record.repo.ts
@@ -114,10 +114,13 @@ export type StelaRecord = Omit<RecordVO, 'files'> & {
 	folderLinkId: string;
 	folderLinkType: FolderLinkType;
 	parentFolderLinkId: string;
-	thumbUrl200: string;
-	thumbUrl500: string;
-	thumbUrl1000: string;
-	thumbUrl2000: string;
+	thumbnailUrls?: {
+		'200'?: string;
+		'256'?: string;
+		'500'?: string;
+		'1000'?: string;
+		'2000'?: string;
+	};
 	location: StelaLocation | null;
 	files: Array<StelaFile>;
 	createdAt: string;
@@ -199,10 +202,14 @@ export const convertStelaRecordToRecordVO = (
 ): RecordVO =>
 	new RecordVO({
 		...stelaRecord,
-		thumbURL200: stelaRecord.thumbUrl200,
-		thumbURL500: stelaRecord.thumbUrl500,
-		thumbURL1000: stelaRecord.thumbUrl1000,
-		thumbURL2000: stelaRecord.thumbUrl2000,
+		thumbURL200: stelaRecord.thumbnailUrls?.['200'] ?? stelaRecord.thumbURL200,
+		thumbURL500: stelaRecord.thumbnailUrls?.['500'] ?? stelaRecord.thumbURL500,
+		thumbURL1000:
+			stelaRecord.thumbnailUrls?.['1000'] ?? stelaRecord.thumbURL1000,
+		thumbURL2000:
+			stelaRecord.thumbnailUrls?.['2000'] ?? stelaRecord.thumbURL2000,
+		thumbnail256:
+			stelaRecord.thumbnailUrls?.['256'] ?? stelaRecord.thumbnail256,
 		TagVOs: (stelaRecord.tags ?? []).map((stelaTag) =>
 			convertStelaTagToTagVO(stelaTag, stelaRecord.archiveId),
 		),

--- a/src/app/shared/services/data/data.service.spec.ts
+++ b/src/app/shared/services/data/data.service.spec.ts
@@ -282,4 +282,78 @@ describe('DataService', () => {
 			})
 			.catch(done.fail);
 	});
+
+	it('should not add a lean item to thumbRefreshQueue when it has any thumbnail size', (done) => {
+		const service = TestBed.inject(DataService);
+		const api = TestBed.inject(ApiService);
+		const navigateResponse = new FolderResponse(navigateMinData);
+		const currentFolder = navigateResponse.getFolderVO(true) as FolderVO;
+		service.setCurrentFolder(currentFolder);
+
+		const record = currentFolder.ChildItemVOs.find(
+			(item) => item.isRecord,
+		) as RecordVO;
+		service.registerItem(record);
+
+		spyOn(api.folder, 'getWithChildren').and.returnValue(
+			Promise.resolve({
+				isSuccessful: true,
+				getFolderVO: () => ({
+					ChildItemVOs: [
+						{
+							folder_linkId: record.folder_linkId,
+							archiveNbr: record.archiveNbr,
+							parentFolderId: currentFolder.folderId,
+							thumbURL500: 'https://example.com/500',
+						},
+					],
+				}),
+			} as unknown as FolderResponse),
+		);
+
+		service
+			.fetchLeanItems([record])
+			.then(() => {
+				expect(record.thumbURL500).toBe('https://example.com/500');
+				expect(service.getThumbRefreshQueue()).not.toContain(record);
+				done();
+			})
+			.catch(done.fail);
+	});
+
+	it('should add a lean item to thumbRefreshQueue when no thumbnail size is present', (done) => {
+		const service = TestBed.inject(DataService);
+		const api = TestBed.inject(ApiService);
+		const navigateResponse = new FolderResponse(navigateMinData);
+		const currentFolder = navigateResponse.getFolderVO(true) as FolderVO;
+		service.setCurrentFolder(currentFolder);
+
+		const record = currentFolder.ChildItemVOs.find(
+			(item) => item.isRecord,
+		) as RecordVO;
+		service.registerItem(record);
+
+		spyOn(api.folder, 'getWithChildren').and.returnValue(
+			Promise.resolve({
+				isSuccessful: true,
+				getFolderVO: () => ({
+					ChildItemVOs: [
+						{
+							folder_linkId: record.folder_linkId,
+							archiveNbr: record.archiveNbr,
+							parentFolderId: currentFolder.folderId,
+						},
+					],
+				}),
+			} as unknown as FolderResponse),
+		);
+
+		service
+			.fetchLeanItems([record])
+			.then(() => {
+				expect(service.getThumbRefreshQueue()).toContain(record);
+				done();
+			})
+			.catch(done.fail);
+	});
 });

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -11,6 +11,7 @@ import {
 	RecordVOData,
 } from '@root/app/models';
 import { DataStatus } from '@models/data-status.enum';
+import { GetThumbnail } from '@models/get-thumbnail';
 import {
 	FolderResponse,
 	RecordResponse,
@@ -252,7 +253,7 @@ export class DataService {
 
 						if (
 							!item.isFolder &&
-							!item.thumbURL200 &&
+							!GetThumbnail(item) &&
 							item.parentFolderId === this.currentFolder.folderId
 						) {
 							this.debug('thumbRefreshQueue push %s', item.archiveNbr);


### PR DESCRIPTION
Use the 256 size thumbnails wherever possible in the web-app. This is a followup to #923, which changed the way we load thumbnails in general. With this change, thumbnails will appear even if the other sizes are not available. 

For thumbnails to appear in the file list, it needs companion PR https://github.com/PermanentOrg/back-end/pull/881. This one alone fixes the thumbnail in the sidebar editing modal.

I tested this by uploading a record on dev, checking to make sure that it got an Archivematica thumbnail (`thumbnail256` was not null), then running `update record set thumburl200 = null, thumburl500 = null, thumburl1000 = null, thumburl2000 = null where recordid = _ID_OF_NEW_RECORD` in the database directly. 

I mentioned this in the commit message, but I'm not sure this test is particularly useful - I just wanted to guard against a regression here somehow. Suggestions welcome!