### PR TITLE
[PER-10643] Add edtf date and time validation

### DIFF
--- a/src/app/core/services/edit/edit.service.spec.ts
+++ b/src/app/core/services/edit/edit.service.spec.ts
@@ -445,6 +445,72 @@ describe('EditService', () => {
 		expect(apiService.folder.getStelaFolderVOs).not.toHaveBeenCalled();
 	});
 
+	it('should reconcile a folder when the Stela response has a string folderId and no folder_linkId', async () => {
+		// The in-memory folder holds a numeric folderId and a folder_linkId, while
+		// the Stela response VO has a string folderId and no folder_linkId — the
+		// mismatch that previously left the folder unmatched and threw on update.
+		const folder = new FolderVO({
+			folderId: 1,
+			folder_linkId: 100,
+			displayName: 'Test Folder',
+		});
+		const updatedFolderVO = new FolderVO({
+			folderId: '1' as unknown as number,
+			updatedDT: '2024-03-03',
+			displayTime: '1990-07',
+		});
+		const mockFolderResponse = {
+			getFolderVOs: jasmine
+				.createSpy('getFolderVOs')
+				.and.returnValue([updatedFolderVO]),
+		};
+
+		(apiService.folder.updateStelaFolder as jasmine.Spy).and.returnValue(
+			Promise.resolve(mockFolderResponse),
+		);
+		(apiService.folder.getStelaFolderVOs as jasmine.Spy).and.returnValue(
+			Promise.resolve(mockFolderResponse),
+		);
+		folder.update = jasmine.createSpy('update');
+
+		await service.updateItems([folder], ['displayTime']);
+
+		expect(folder.update).toHaveBeenCalledWith(
+			jasmine.objectContaining({
+				updatedDT: '2024-03-03',
+				displayTime: '1990-07',
+			}),
+		);
+	});
+
+	it('should not throw when a response folder matches no in-memory folder', async () => {
+		const folder = new FolderVO({
+			folderId: 1,
+			folder_linkId: 100,
+			displayName: 'Test Folder',
+		});
+		const unmatchedVO = new FolderVO({
+			folderId: '999' as unknown as number,
+			updatedDT: '2024-03-03',
+		});
+		const mockFolderResponse = {
+			getFolderVOs: jasmine
+				.createSpy('getFolderVOs')
+				.and.returnValue([unmatchedVO]),
+		};
+
+		(apiService.folder.updateStelaFolder as jasmine.Spy).and.returnValue(
+			Promise.resolve(mockFolderResponse),
+		);
+		(apiService.folder.getStelaFolderVOs as jasmine.Spy).and.returnValue(
+			Promise.resolve(mockFolderResponse),
+		);
+
+		await expectAsync(
+			service.updateItems([folder], ['displayTime']),
+		).toBeResolved();
+	});
+
 	it('should revert property and show a translatable generic error when updateStelaRecord fails', async () => {
 		const messageService = TestBed.inject(MessageService);
 		spyOn(messageService, 'showError');

--- a/src/app/core/services/edit/edit.service.ts
+++ b/src/app/core/services/edit/edit.service.ts
@@ -386,7 +386,10 @@ export class EditService {
 		const itemsByLinkId: { [key: number]: ItemVO } = {};
 
 		const recordsByRecordId: Map<number, RecordVO> = new Map();
-		const foldersByFolderId: Map<number, FolderVO> = new Map();
+		// Keyed by a stringified folderId: the Stela update response returns
+		// folderId as a string while the in-memory folder holds a number, so we
+		// normalize both sides to match them reliably.
+		const foldersByFolderId: Map<string, FolderVO> = new Map();
 
 		items.forEach((item) => {
 			item.isFolder ? folders.push(item) : records.push(item);
@@ -396,7 +399,7 @@ export class EditService {
 					recordsByRecordId.set(item.recordId, item);
 				}
 			} else if (item.folderId) {
-				foldersByFolderId.set(item.folderId, item);
+				foldersByFolderId.set(String(item.folderId), item);
 			}
 		});
 
@@ -435,8 +438,10 @@ export class EditService {
 
 					const folder =
 						(itemsByLinkId[updatedItem.folder_linkId] as FolderVO) ||
-						foldersByFolderId.get(updatedItem.folderId);
-					folder.update(newData);
+						foldersByFolderId.get(String(updatedItem.folderId));
+					// Guard against a response VO that maps to no in-memory folder so a
+					// lookup miss can never crash an otherwise-successful save.
+					folder?.update(newData);
 				});
 			}
 

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.spec.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.spec.ts
@@ -10,6 +10,7 @@ import { MessageService } from '@shared/services/message/message.service';
 import { AccountService } from '@shared/services/account/account.service';
 import { DragService } from '@shared/services/drag/drag.service';
 import { ShareLinksService } from '@root/app/share-links/services/share-links.service';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 import { EditService } from '@core/services/edit/edit.service';
 import { DeviceService } from '@shared/services/device/device.service';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -66,7 +67,13 @@ describe('FileListItemComponent', () => {
 		isMobileWidth: jasmine.createSpy().and.returnValue(false),
 	};
 
+	const mockFeatureFlagService = {
+		isEnabled: jasmine.createSpy().and.returnValue(false),
+	};
+
 	beforeEach(async () => {
+		mockFeatureFlagService.isEnabled.and.returnValue(false);
+
 		await TestBed.configureTestingModule({
 			imports: [MockItemTypeIconPipe, MockPrDatePipe, MockPrConstantsPipe],
 			declarations: [FileListItemComponent, GetThumbnailPipe],
@@ -131,6 +138,7 @@ describe('FileListItemComponent', () => {
 				},
 				{ provide: EditService, useValue: mockEditService },
 				{ provide: DeviceService, useValue: mockDeviceService },
+				{ provide: FeatureFlagService, useValue: mockFeatureFlagService },
 			],
 		}).compileComponents();
 
@@ -418,5 +426,37 @@ describe('FileListItemComponent', () => {
 		expect(component.date).toContain('2020');
 		expect(component.date).not.toContain('2023');
 		expect(component.date).not.toContain('2026');
+	});
+
+	describe('with the edtf-date feature flag enabled', () => {
+		beforeEach(() => {
+			mockFeatureFlagService.isEnabled.and.callFake(
+				(flag: string) => flag === 'edtf-date',
+			);
+		});
+
+		it('should not fall back to displayDT when displayTime is missing', () => {
+			component.item.displayTime = undefined;
+			component.item.displayDT = '2023-01-01T00:00:00.000Z';
+			fixture.detectChanges();
+
+			expect(component.startDisplayTime).toBe('');
+		});
+
+		it('should show nothing when displayTime was explicitly cleared', () => {
+			component.item.displayTime = null;
+			component.item.displayDT = '2023-01-01T00:00:00.000Z';
+			fixture.detectChanges();
+
+			expect(component.startDisplayTime).toBe('');
+		});
+
+		it('should still show the displayTime start date', () => {
+			component.item.displayTime = '2020-06-10/2026-06-15';
+			component.item.displayDT = '2023-01-01T00:00:00.000Z';
+			fixture.detectChanges();
+
+			expect(component.startDisplayTime).toBe('2020-06-10');
+		});
 	});
 });

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -34,6 +34,7 @@ import {
 import { DataStatus } from '@models/data-status.enum';
 import { EditService } from '@core/services/edit/edit.service';
 import { EdtfService } from '@shared/services/edtf-service/edtf.service';
+import { FeatureFlagService } from '@root/app/feature-flag/services/feature-flag.service';
 import {
 	RecordResponse,
 	FolderResponse,
@@ -249,13 +250,22 @@ export class FileListItemComponent
 		@Inject(DOCUMENT) private document: Document,
 		private shareLinksService: ShareLinksService,
 		private edtfService: EdtfService,
+		private featureFlagService: FeatureFlagService,
 	) {}
 
 	get startDisplayTime(): string {
-		return (
-			this.edtfService.getEdtfIntervalStartDate(this.item.displayTime) ||
-			this.item.displayDT
+		const edtfStartDate = this.edtfService.getEdtfIntervalStartDate(
+			this.item.displayTime,
 		);
+
+		// Once the edtf-date UI ships, displayTime is authoritative (a null
+		// value means the user cleared the date, so nothing is shown). Until
+		// then, items may only have displayDT populated, so keep the fallback.
+		if (this.featureFlagService.isEnabled('edtf-date')) {
+			return edtfStartDate;
+		}
+
+		return edtfStartDate || this.item.displayDT;
 	}
 
 	async ngOnInit() {

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.spec.ts
@@ -292,10 +292,10 @@ describe('SidebarDatePickerComponent', () => {
 			expect(component.formattedStartDate()).toBe('1985-XX-20');
 		});
 
-		it('should fall back to ISO style "1985-1X-20" when month is partial', () => {
+		it('should render a single-digit month as the complete month, matching serialization ("1" -> January)', () => {
 			setDate('1985', '1', '20');
 
-			expect(component.formattedStartDate()).toBe('1985-1X-20');
+			expect(component.formattedStartDate()).toBe('January 20, 1985');
 		});
 
 		it('should fall back to ISO style "XXXX-XX-20" when only day is set', () => {

--- a/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
+++ b/src/app/file-browser/components/sidebar-date-picker/sidebar-date-picker.component.ts
@@ -13,7 +13,6 @@ import {
 	ElementRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { format } from 'date-fns';
 import {
 	EdtfService,
 	TIME_FORMAT_LABEL,
@@ -360,40 +359,8 @@ export class SidebarDatePickerComponent implements OnInit, OnChanges {
 		);
 	}
 
-	private padDigitsWithX(value: string, width: number): string {
-		const v = value ?? '';
-		return v.length >= width ? v : v + 'X'.repeat(width - v.length);
-	}
-
 	private formatDate(date: DateModel): string {
-		const yearRaw = date.year ?? '';
-		const monthRaw = date.month ?? '';
-		const dayRaw = date.day ?? '';
-
-		const hasYear = !!yearRaw;
-		const hasMonth = !!monthRaw;
-		const hasDay = !!dayRaw && parseInt(dayRaw, 10) !== 0;
-
-		if (!hasYear && !hasMonth && !hasDay) return '';
-
-		const yearDisplay = this.padDigitsWithX(yearRaw, 4);
-		const monthComplete = /^\d{2}$/.test(monthRaw);
-		const monthName = monthComplete
-			? format(new Date(2000, parseInt(monthRaw, 10) - 1), 'MMMM')
-			: null;
-		// A day is a discrete value, not a range, so a single digit is
-		// zero-padded on the left ("2" -> "02") rather than X-padded.
-		const dayDisplay = hasDay ? dayRaw.padStart(2, '0') : '';
-
-		if (monthName && hasDay)
-			return `${monthName} ${dayDisplay}, ${yearDisplay}`;
-		if (monthName) return `${monthName} ${yearDisplay}`;
-		if (!hasMonth && !hasDay) return yearDisplay;
-
-		const monthDisplay = hasMonth ? this.padDigitsWithX(monthRaw, 2) : 'XX';
-		const parts: string[] = [yearDisplay, monthDisplay];
-		if (hasDay) parts.push(dayDisplay);
-		return parts.join('-');
+		return this.edtfService.formatDateForDisplay(date);
 	}
 
 	private formatTime(time: TimeModel): string {

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -582,14 +582,14 @@ describe('SidebarComponent', () => {
 			expect(component.displayTimeObject).toBeNull();
 		});
 
-		it('should fall back to displayDT when displayTime is undefined', () => {
+		it('should not fall back to displayDT when displayTime is undefined', () => {
 			component.selectedItem = new RecordVO({
 				displayDT: '1985-05-20T00:00:00Z',
 			});
 
 			(component as any).updateDisplayTimeObject();
 
-			expect(component.displayTimeObject?.date.year).toBe('1985');
+			expect(component.displayTimeObject).toBeNull();
 		});
 	});
 

--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -527,6 +527,72 @@ describe('SidebarComponent', () => {
 		});
 	});
 
+	describe('saveDisplayTime null handling', () => {
+		let saveItemVoPropertySpy: jasmine.Spy;
+
+		beforeEach(() => {
+			saveItemVoPropertySpy = spyOn(
+				mockEditService,
+				'saveItemVoProperty',
+			).and.callFake(async (item: any, prop: any, value: any) => {
+				item[prop] = value;
+			});
+		});
+
+		it('should save null when the date is cleared to empty', async () => {
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: '', month: '', day: '' },
+				time: { format: 'am' },
+			});
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				component.selectedItem,
+				'displayTime',
+				null,
+			);
+		});
+
+		it('should save the EDTF string unchanged for a non-empty date', async () => {
+			component.selectedItem = new RecordVO({ displayTime: '1985-05-20' });
+
+			await component.onDateSaved({
+				date: { year: '1990', month: '06', day: '15' },
+				time: { format: 'am' },
+			});
+
+			expect(saveItemVoPropertySpy).toHaveBeenCalledWith(
+				component.selectedItem,
+				'displayTime',
+				'1990-06-15',
+			);
+		});
+	});
+
+	describe('updateDisplayTimeObject', () => {
+		it('should show an empty date when displayTime is explicitly null, ignoring displayDT', () => {
+			component.selectedItem = new RecordVO({
+				displayTime: null,
+				displayDT: '1985-05-20T00:00:00Z',
+			});
+
+			(component as any).updateDisplayTimeObject();
+
+			expect(component.displayTimeObject).toBeNull();
+		});
+
+		it('should fall back to displayDT when displayTime is undefined', () => {
+			component.selectedItem = new RecordVO({
+				displayDT: '1985-05-20T00:00:00Z',
+			});
+
+			(component as any).updateDisplayTimeObject();
+
+			expect(component.displayTimeObject?.date.year).toBe('1985');
+		});
+	});
+
 	describe('onDateMoreOptions', () => {
 		it('should open the edit date time modal with provided data', () => {
 			const openSpy = spyOn(mockModalService, 'open').and.callThrough();

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -52,12 +52,10 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 
 	displayTimeObject: DateTimeModel | null = null;
 
+	// No displayDT fallback needed here because this feeds the edtf-date picker only,
+	// which is already hidden behind a flag
 	private updateDisplayTimeObject(): void {
-		const edtfDate = this.selectedItem;
-		const hasExplicitlyClearedDate = edtfDate?.displayTime === null;
-		const timeSource = hasExplicitlyClearedDate
-			? null
-			: edtfDate?.displayTime || edtfDate?.displayDT;
+		const timeSource = this.selectedItem?.displayTime;
 		try {
 			this.displayTimeObject = timeSource
 				? this.edtfService.toDateTimeModel(timeSource)

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -53,8 +53,11 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 	displayTimeObject: DateTimeModel | null = null;
 
 	private updateDisplayTimeObject(): void {
-		const timeSource =
-			this.selectedItem?.displayTime || this.selectedItem?.displayDT;
+		const edtfDate = this.selectedItem;
+		const hasExplicitlyClearedDate = edtfDate?.displayTime === null;
+		const timeSource = hasExplicitlyClearedDate
+			? null
+			: edtfDate?.displayTime || edtfDate?.displayDT;
 		try {
 			this.displayTimeObject = timeSource
 				? this.edtfService.toDateTimeModel(timeSource)
@@ -267,7 +270,8 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 
 	private async saveDisplayTime(result: DateTimeModel): Promise<void> {
 		try {
-			const newDisplayTime = this.edtfService.toEdtfDate(result);
+			const edtfDate = this.edtfService.toEdtfDate(result);
+			const newDisplayTime = edtfDate === '' ? null : edtfDate;
 			await this.onFinishEditing('displayTime', newDisplayTime);
 		} catch (err) {
 			this.message.showError({ message: err?.message });

--- a/src/app/models/folder-vo.ts
+++ b/src/app/models/folder-vo.ts
@@ -49,7 +49,7 @@ export class FolderVO
 	public displayName;
 	public displayDT;
 	public displayEndDT;
-	public displayTime?: string;
+	public displayTime?: string | null;
 	public derivedDT;
 	public derivedEndDT;
 	public altText;
@@ -182,7 +182,7 @@ export interface FolderVOData extends BaseVOData {
 	displayName?: any;
 	displayDT?: any;
 	displayEndDT?: any;
-	displayTime?: string;
+	displayTime?: string | null;
 	derivedDT?: any;
 	derivedEndDT?: any;
 	note?: any;

--- a/src/app/models/record-vo.ts
+++ b/src/app/models/record-vo.ts
@@ -54,7 +54,7 @@ export class RecordVO
 	public description;
 	public displayDT;
 	public displayEndDT;
-	public displayTime?: string;
+	public displayTime?: string | null;
 	public derivedDT;
 	public derivedEndDT;
 	public altText;
@@ -186,7 +186,7 @@ export interface RecordVOData extends BaseVOData {
 	description?: any;
 	displayDT?: any;
 	displayEndDT?: any;
-	displayTime?: string;
+	displayTime?: string | null;
 	derivedDT?: any;
 	derivedEndDT?: any;
 	derivedCreatedDT?: any;

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.html
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.html
@@ -1,51 +1,57 @@
-<div class="pr-date-input-group" [class.active]="showDatepicker()">
-	<input
-		#yearInput
-		type="text"
-		class="pr-date-segment year"
-		[value]="date.year"
-		[disabled]="disabled"
-		(input)="updateYear($event)"
-		placeholder="YYYY"
-		maxlength="4"
-	/>
-	<span class="pr-separator">/</span>
-	<input
-		#monthInput
-		type="text"
-		class="pr-date-segment"
-		[value]="date.month ?? ''"
-		[disabled]="disabled"
-		(input)="updateMonth($event)"
-		(keydown)="onMonthKeydown($event)"
-		placeholder="MM"
-		maxlength="2"
-	/>
-	<span class="pr-separator">/</span>
-	<input
-		#dayInput
-		type="text"
-		class="pr-date-segment"
-		[value]="date.day ?? ''"
-		[disabled]="disabled"
-		(input)="updateDay($event)"
-		(keydown)="onDayKeydown($event)"
-		placeholder="DD"
-		maxlength="2"
-	/>
-	<div class="pr-calendar-icon-wrapper">
-		<span
-			class="pr-icon-button"
-			role="button"
-			tabindex="0"
-			[class.disabled]="disabled"
-			(click)="toggleDatepicker()"
-			(keydown.enter)="toggleDatepicker()"
-			(keydown.space)="toggleDatepicker()"
-		>
-			<i class="material-icons">calendar_today</i>
-		</span>
+<div class="pr-date-input-wrap">
+	<div
+		class="pr-date-input-group"
+		[class.active]="showDatepicker()"
+		[class.has-error]="!!currentError()"
+	>
+		<input
+			#yearInput
+			type="text"
+			class="pr-date-segment year"
+			[value]="date.year"
+			[disabled]="disabled"
+			(input)="updateYear($event)"
+			placeholder="YYYY"
+			maxlength="4"
+		/>
+		<span class="pr-separator">/</span>
+		<input
+			#monthInput
+			type="text"
+			class="pr-date-segment"
+			[value]="date.month ?? ''"
+			[disabled]="disabled"
+			(input)="updateMonth($event)"
+			(keydown)="onMonthKeydown($event)"
+			placeholder="MM"
+			maxlength="2"
+		/>
+		<span class="pr-separator">/</span>
+		<input
+			#dayInput
+			type="text"
+			class="pr-date-segment"
+			[value]="date.day ?? ''"
+			[disabled]="disabled"
+			(input)="updateDay($event)"
+			(keydown)="onDayKeydown($event)"
+			placeholder="DD"
+			maxlength="2"
+		/>
+		<div class="pr-calendar-icon-wrapper">
+			<span
+				class="pr-icon-button"
+				[class.disabled]="disabled"
+				(click)="toggleDatepicker()"
+			>
+				<i class="material-icons">calendar_today</i>
+			</span>
+		</div>
 	</div>
+
+	@if (currentError()) {
+		<span class="pr-input-error">{{ currentError() }}</span>
+	}
 </div>
 
 @if (showDatepicker()) {

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.html
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.html
@@ -41,8 +41,12 @@
 		<div class="pr-calendar-icon-wrapper">
 			<span
 				class="pr-icon-button"
+				role="button"
+				tabindex="0"
 				[class.disabled]="disabled"
 				(click)="toggleDatepicker()"
+				(keydown.enter)="toggleDatepicker()"
+				(keydown.space)="toggleDatepicker()"
 			>
 				<i class="material-icons">calendar_today</i>
 			</span>

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.scss
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.scss
@@ -4,7 +4,13 @@
 :host {
 	position: relative;
 	display: block;
-	height: 40px;
+	min-height: 40px;
+}
+
+.pr-date-input-wrap {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 }
 
 .pr-date-input-group {
@@ -15,6 +21,14 @@
 	&.active {
 		@include input-focus-state;
 	}
+
+	&.has-error {
+		@include input-error-state;
+	}
+}
+
+.pr-input-error {
+	@include input-error-message;
 }
 
 .pr-date-segment {

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
@@ -265,6 +265,21 @@ describe('DatepickerInputComponent', () => {
 		expect(component.showDatepicker()).toBeFalse();
 	});
 
+	it('should toggle datepicker via keyboard (Enter and Space)', () => {
+		const iconButton: HTMLElement =
+			fixture.nativeElement.querySelector('.pr-icon-button');
+
+		iconButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+		fixture.detectChanges();
+
+		expect(component.showDatepicker()).toBeTrue();
+
+		iconButton.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+		fixture.detectChanges();
+
+		expect(component.showDatepicker()).toBeFalse();
+	});
+
 	it('should emit date and clear errors on date select', () => {
 		component.showDatepicker.set(true);
 		component.fieldErrors.month.set(MONTH_RANGE_ERROR);

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import {
 	DateModel,
 	DAY_RANGE_ERROR,
+	INVALID_DAY_FOR_MONTH_ERROR,
 	MONTH_RANGE_ERROR,
 } from '@shared/services/edtf-service/edtf.service';
 import {
@@ -138,12 +139,21 @@ describe('DatepickerInputComponent', () => {
 		expect(component.fieldErrors.month()).toBe(INVALID_CHARS_ERROR);
 	});
 
-	it('should emit day 31 in April and surface the day error', () => {
+	it('should emit day 31 in April and surface the day-for-month error', () => {
 		hostComponent.date = { year: '2026', month: '04', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('31'));
 
 		expect(hostComponent.lastEmittedDate?.day).toBe('31');
+		expect(component.fieldErrors.day()).toBe(INVALID_DAY_FOR_MONTH_ERROR);
+	});
+
+	it('should surface the range error for a day greater than 31', () => {
+		hostComponent.date = { year: '2026', month: '01', day: '' };
+		fixture.detectChanges();
+		component.updateDay(mockEvent('32'));
+
+		expect(hostComponent.lastEmittedDate?.day).toBe('32');
 		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
@@ -158,22 +168,31 @@ describe('DatepickerInputComponent', () => {
 		expect(hostComponent.lastEmittedDate?.day).toBe('0');
 	});
 
-	it('should emit day 30 in February and surface the day error', () => {
+	it('should emit day 30 in February and surface the day-for-month error', () => {
 		hostComponent.date = { year: '2026', month: '02', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('30'));
 
 		expect(hostComponent.lastEmittedDate?.day).toBe('30');
-		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
+		expect(component.fieldErrors.day()).toBe(INVALID_DAY_FOR_MONTH_ERROR);
 	});
 
-	it('should emit day 29 in February of a non-leap year and surface the day error', () => {
+	it('should emit day 29 in February of a non-leap year and surface the day-for-month error', () => {
 		hostComponent.date = { year: '2025', month: '02', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('29'));
 
 		expect(hostComponent.lastEmittedDate?.day).toBe('29');
-		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
+		expect(component.fieldErrors.day()).toBe(INVALID_DAY_FOR_MONTH_ERROR);
+	});
+
+	it('should surface the day-for-month error for Feb 29 given a single-digit month', () => {
+		hostComponent.date = { year: '2021', month: '2', day: '' };
+		fixture.detectChanges();
+		component.updateDay(mockEvent('29'));
+
+		expect(hostComponent.lastEmittedDate?.day).toBe('29');
+		expect(component.fieldErrors.day()).toBe(INVALID_DAY_FOR_MONTH_ERROR);
 	});
 
 	it('should re-validate the day when the month changes', () => {
@@ -184,7 +203,32 @@ describe('DatepickerInputComponent', () => {
 
 		component.updateMonth(mockEvent('04'));
 
+		expect(component.fieldErrors.day()).toBe(INVALID_DAY_FOR_MONTH_ERROR);
+	});
+
+	it('should surface the range error inline for a lone "0" month', () => {
+		component.updateMonth(mockEvent('0'));
+
+		expect(hostComponent.lastEmittedDate?.month).toBe('0');
+		expect(component.fieldErrors.month()).toBe(MONTH_RANGE_ERROR);
+	});
+
+	it('should surface the range error inline for a lone "0" day', () => {
+		hostComponent.date = { year: '2026', month: '01', day: '' };
+		fixture.detectChanges();
+		component.updateDay(mockEvent('0'));
+
+		expect(hostComponent.lastEmittedDate?.day).toBe('0');
 		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
+	});
+
+	it('should attribute a lone "0" month to the month field, not the day', () => {
+		hostComponent.date = { year: '2024', month: '', day: '31' };
+		fixture.detectChanges();
+		component.updateMonth(mockEvent('0'));
+
+		expect(component.fieldErrors.month()).toBe(MONTH_RANGE_ERROR);
+		expect(component.fieldErrors.day()).toBeNull();
 	});
 
 	it('should clear the year error when the field is cleared', () => {

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
@@ -1,7 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { DateModel } from '@shared/services/edtf-service/edtf.service';
-import { DatepickerInputComponent } from './datepicker-input.component';
+import {
+	DatepickerInputComponent,
+	DAY_RANGE_ERROR,
+	INVALID_CHARS_ERROR,
+	MONTH_RANGE_ERROR,
+} from './datepicker-input.component';
 
 @Component({
 	standalone: true,
@@ -46,22 +51,20 @@ describe('DatepickerInputComponent', () => {
 	const mockEvent = (value: string): Event =>
 		({ target: { value } }) as unknown as Event;
 
+	// --- Valid input ---
+
 	it('should accept valid 4-digit year and emit', () => {
 		component.updateYear(mockEvent('2026'));
 
 		expect(hostComponent.lastEmittedDate?.year).toBe('2026');
+		expect(component.fieldErrors.year()).toBeNull();
 	});
 
 	it('should emit incomplete year as raw digits (no X in input)', () => {
 		component.updateYear(mockEvent('202'));
 
 		expect(hostComponent.lastEmittedDate?.year).toBe('202');
-	});
-
-	it('should reject non-numeric year', () => {
-		component.updateYear(mockEvent('20ab'));
-
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(component.fieldErrors.year()).toBeNull();
 	});
 
 	it('should accept year padded with leading zeros (ISO 8601)', () => {
@@ -74,40 +77,72 @@ describe('DatepickerInputComponent', () => {
 		component.updateMonth(mockEvent('06'));
 
 		expect(hostComponent.lastEmittedDate?.month).toBe('06');
+		expect(component.fieldErrors.month()).toBeNull();
 	});
 
-	it('should emit single digit month', () => {
+	it('should accept single digit month', () => {
 		component.updateMonth(mockEvent('1'));
 
 		expect(hostComponent.lastEmittedDate?.month).toBe('1');
+		expect(component.fieldErrors.month()).toBeNull();
 	});
 
-	it('should not emit or auto-focus for invalid month', () => {
+	it('should accept day 29 for February in leap year', () => {
+		hostComponent.date = { year: '2024', month: '02', day: '' };
+		fixture.detectChanges();
+		component.updateDay(mockEvent('29'));
+
+		expect(hostComponent.lastEmittedDate?.day).toBe('29');
+		expect(component.fieldErrors.day()).toBeNull();
+	});
+
+	// --- Invalid input now emits AND surfaces an error ---
+
+	it('should emit invalid characters in the year and surface the invalid-characters error', () => {
+		component.updateYear(mockEvent('20ab'));
+
+		expect(hostComponent.lastEmittedDate?.year).toBe('20ab');
+		expect(component.fieldErrors.year()).toBe(INVALID_CHARS_ERROR);
+		expect(component.currentError()).toBe(INVALID_CHARS_ERROR);
+	});
+
+	it('should emit out-of-range month and surface the month error', () => {
 		component.updateMonth(mockEvent('13'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.month).toBe('13');
+		expect(component.fieldErrors.month()).toBe(MONTH_RANGE_ERROR);
 	});
 
-	it('should reject non-numeric month', () => {
+	it('should NOT surface the month range error while only one digit has been typed', () => {
+		component.updateMonth(mockEvent('5'));
+
+		expect(hostComponent.lastEmittedDate?.month).toBe('5');
+		expect(component.fieldErrors.month()).toBeNull();
+	});
+
+	it('should NOT surface the day range error while only one digit has been typed', () => {
+		hostComponent.date = { year: '2026', month: '02', day: '' };
+		fixture.detectChanges();
+		component.updateDay(mockEvent('9'));
+
+		expect(hostComponent.lastEmittedDate?.day).toBe('9');
+		expect(component.fieldErrors.day()).toBeNull();
+	});
+
+	it('should emit invalid characters in the month and surface the invalid-characters error', () => {
 		component.updateMonth(mockEvent('ab'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.month).toBe('ab');
+		expect(component.fieldErrors.month()).toBe(INVALID_CHARS_ERROR);
 	});
 
-	it('should accept valid 2-digit day for month and emit', () => {
-		hostComponent.date = { year: '2026', month: '01', day: '' };
+	it('should emit day 31 in April and surface the day error', () => {
+		hostComponent.date = { year: '2026', month: '04', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('31'));
 
 		expect(hostComponent.lastEmittedDate?.day).toBe('31');
-	});
-
-	it('should emit single digit day', () => {
-		hostComponent.date = { year: '2026', month: '01', day: '' };
-		fixture.detectChanges();
-		component.updateDay(mockEvent('3'));
-
-		expect(hostComponent.lastEmittedDate?.day).toBe('3');
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
 	it('should allow backspacing a left-padded day down to a single "0" without reverting', () => {
@@ -121,55 +156,84 @@ describe('DatepickerInputComponent', () => {
 		expect(hostComponent.lastEmittedDate?.day).toBe('0');
 	});
 
-	it('should not emit day greater than max for month', () => {
+	it('should emit day 30 in February and surface the day error', () => {
 		hostComponent.date = { year: '2026', month: '02', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('30'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.day).toBe('30');
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
-	it('should accept day 29 for February in leap year', () => {
-		hostComponent.date = { year: '2024', month: '02', day: '' };
-		fixture.detectChanges();
-		component.updateDay(mockEvent('29'));
-
-		expect(hostComponent.lastEmittedDate?.day).toBe('29');
-	});
-
-	it('should not emit day 29 for February in non-leap year', () => {
+	it('should emit day 29 in February of a non-leap year and surface the day error', () => {
 		hostComponent.date = { year: '2025', month: '02', day: '' };
 		fixture.detectChanges();
 		component.updateDay(mockEvent('29'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(hostComponent.lastEmittedDate?.day).toBe('29');
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
-	it('should not emit day 31 for 30-day months', () => {
-		hostComponent.date = { year: '2026', month: '04', day: '' };
+	it('should re-validate the day when the month changes', () => {
+		hostComponent.date = { year: '2026', month: '01', day: '31' };
 		fixture.detectChanges();
-		component.updateDay(mockEvent('31'));
 
-		expect(hostComponent.lastEmittedDate).toBeNull();
+		expect(component.fieldErrors.day()).toBeNull();
+
+		component.updateMonth(mockEvent('04'));
+
+		expect(component.fieldErrors.day()).toBe(DAY_RANGE_ERROR);
 	});
 
-	it('should allow typing first digit 0 or 1 for month', () => {
-		const input = { value: '0' } as HTMLInputElement;
-		component.updateMonth({ target: input } as unknown as Event);
+	it('should clear the year error when the field is cleared', () => {
+		component.updateYear(mockEvent('20ab'));
 
-		expect(input.value).toBe('0');
+		expect(component.fieldErrors.year()).not.toBeNull();
+
+		component.updateYear(mockEvent(''));
+
+		expect(component.fieldErrors.year()).toBeNull();
 	});
 
-	it('should reject first digit > 1 for month', () => {
-		hostComponent.date = { year: '', month: '', day: '' };
-		fixture.detectChanges();
-		const input = { value: '5' } as HTMLInputElement;
-		component.updateMonth({ target: input } as unknown as Event);
+	// --- Auto-focus behavior ---
 
-		expect(input.value).toBe('');
+	it('should auto-focus the month input after a valid 4-digit year', () => {
+		const focusSpy = spyOn(
+			component.monthInput.nativeElement,
+			'focus',
+		).and.callThrough();
+		component.updateYear(mockEvent('2026'));
+
+		expect(focusSpy).toHaveBeenCalled();
 	});
 
-	it('should emit when clearing year field', () => {
+	it('should NOT auto-focus the month input when the year has invalid characters', () => {
+		const focusSpy = spyOn(component.monthInput.nativeElement, 'focus');
+		component.updateYear(mockEvent('20ab'));
+
+		expect(focusSpy).not.toHaveBeenCalled();
+	});
+
+	it('should auto-focus the day input after a valid 2-digit month', () => {
+		const focusSpy = spyOn(
+			component.dayInput.nativeElement,
+			'focus',
+		).and.callThrough();
+		component.updateMonth(mockEvent('06'));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('should NOT auto-focus the day input when the month is out of range', () => {
+		const focusSpy = spyOn(component.dayInput.nativeElement, 'focus');
+		component.updateMonth(mockEvent('13'));
+
+		expect(focusSpy).not.toHaveBeenCalled();
+	});
+
+	// --- Misc ---
+
+	it('should emit when clearing the year field', () => {
 		hostComponent.date = { year: '2026', month: '02', day: '18' };
 		fixture.detectChanges();
 		component.updateYear(mockEvent(''));
@@ -201,8 +265,9 @@ describe('DatepickerInputComponent', () => {
 		expect(component.showDatepicker()).toBeFalse();
 	});
 
-	it('should emit date and close datepicker on date select', () => {
+	it('should emit date and clear errors on date select', () => {
 		component.showDatepicker.set(true);
+		component.fieldErrors.month.set(MONTH_RANGE_ERROR);
 		component.onDateSelect({ year: 2026, month: 3, day: 15 });
 
 		expect(hostComponent.lastEmittedDate).toEqual({
@@ -212,6 +277,7 @@ describe('DatepickerInputComponent', () => {
 		});
 
 		expect(component.showDatepicker()).toBeFalse();
+		expect(component.currentError()).toBeNull();
 	});
 
 	it('should return null datepickerModel for incomplete date', () => {
@@ -228,5 +294,12 @@ describe('DatepickerInputComponent', () => {
 		} as unknown as MouseEvent);
 
 		expect(component.showDatepicker()).toBeFalse();
+	});
+
+	it('should refresh errors from incoming @Input date on changes', () => {
+		hostComponent.date = { year: '2026', month: '13', day: '' };
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.month()).toBe(MONTH_RANGE_ERROR);
 	});
 });

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.spec.ts
@@ -1,11 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import { DateModel } from '@shared/services/edtf-service/edtf.service';
+import {
+	DateModel,
+	DAY_RANGE_ERROR,
+	MONTH_RANGE_ERROR,
+} from '@shared/services/edtf-service/edtf.service';
 import {
 	DatepickerInputComponent,
-	DAY_RANGE_ERROR,
 	INVALID_CHARS_ERROR,
-	MONTH_RANGE_ERROR,
 } from './datepicker-input.component';
 
 @Component({

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.ts
@@ -17,9 +17,7 @@ import { CommonModule } from '@angular/common';
 import { NgbDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 import {
 	DateModel,
-	DAY_RANGE_ERROR,
 	EdtfService,
-	MONTH_RANGE_ERROR,
 } from '@shared/services/edtf-service/edtf.service';
 
 export const INVALID_CHARS_ERROR = 'The date contains invalid characters.';
@@ -110,19 +108,14 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 	}
 
 	private getMonthError(value: string): string | null {
-		return this.edtfService.getSegmentError(value, {
+		return this.edtfService.getMonthError(value, {
 			invalidCharsMessage: INVALID_CHARS_ERROR,
-			isWithinRange: (month) => this.edtfService.isValidMonth(month),
-			rangeMessage: MONTH_RANGE_ERROR,
 		});
 	}
 
 	private getDayError(value: string, month: string): string | null {
-		return this.edtfService.getSegmentError(value, {
+		return this.edtfService.getDayError(value, this.date.year, month, {
 			invalidCharsMessage: INVALID_CHARS_ERROR,
-			isWithinRange: (day) =>
-				this.edtfService.isValidDay(day, this.date.year, month),
-			rangeMessage: DAY_RANGE_ERROR,
 		});
 	}
 

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.ts
@@ -4,12 +4,14 @@ import {
 	Output,
 	EventEmitter,
 	signal,
+	computed,
 	HostListener,
 	ElementRef,
 	ViewChild,
 	OnChanges,
 	SimpleChanges,
 	OnInit,
+	WritableSignal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgbDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
@@ -17,6 +19,12 @@ import {
 	DateModel,
 	EdtfService,
 } from '@shared/services/edtf-service/edtf.service';
+
+export const INVALID_CHARS_ERROR = 'The date contains invalid characters.';
+export const MONTH_RANGE_ERROR = 'Month must be between 1 and 12.';
+export const DAY_RANGE_ERROR = 'Day must be between 1 and 31.';
+
+type DateFieldKey = keyof DateModel;
 
 @Component({
 	selector: 'pr-datepicker-input',
@@ -38,6 +46,18 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 	showDatepicker = signal(false);
 	datepickerModel = signal<NgbDateStruct | null>(null);
 
+	readonly fieldErrors: Record<DateFieldKey, WritableSignal<string | null>> = {
+		year: signal<string | null>(null),
+		month: signal<string | null>(null),
+		day: signal<string | null>(null),
+	};
+	currentError = computed(
+		() =>
+			this.fieldErrors.year() ??
+			this.fieldErrors.month() ??
+			this.fieldErrors.day(),
+	);
+
 	constructor(
 		private elementRef: ElementRef,
 		private edtfService: EdtfService,
@@ -45,11 +65,13 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 
 	ngOnInit(): void {
 		this.updateDatepickerModel(this.date);
+		this.refreshErrorsFromInput();
 	}
 
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.date) {
 			this.updateDatepickerModel(this.date);
+			this.refreshErrorsFromInput();
 		}
 	}
 
@@ -62,6 +84,46 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 		} else {
 			this.datepickerModel.set(null);
 		}
+	}
+
+	private refreshErrorsFromInput(): void {
+		(Object.keys(this.fieldErrors) as DateFieldKey[]).forEach((datePropKey) =>
+			this.fieldErrors[datePropKey].set(
+				this.getFieldError(datePropKey, this.date[datePropKey] ?? ''),
+			),
+		);
+	}
+
+	private getFieldError(
+		datePropKey: DateFieldKey,
+		value: string,
+	): string | null {
+		if (datePropKey === 'year') return this.getYearError(value);
+		if (datePropKey === 'month') return this.getMonthError(value);
+		return this.getDayError(value, this.date.month ?? '');
+	}
+
+	private getYearError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+		});
+	}
+
+	private getMonthError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (month) => this.edtfService.isValidMonth(month),
+			rangeMessage: MONTH_RANGE_ERROR,
+		});
+	}
+
+	private getDayError(value: string, month: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (day) =>
+				this.edtfService.isValidDay(day, this.date.year, month),
+			rangeMessage: DAY_RANGE_ERROR,
+		});
 	}
 
 	@HostListener('document:click', ['$event'])
@@ -77,45 +139,34 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 	}
 
 	updateYear(event: Event): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (!this.edtfService.isValidYear(value)) {
-			input.value = this.date.year;
-			return;
-		}
+		const value = (event.target as HTMLInputElement).value;
+		const error = this.getFieldError('year', value);
+		this.fieldErrors.year.set(error);
 
 		this.dateChange.emit({ ...this.date, year: value });
-		if (value.length === 4) {
+		if (!error && value.length === 4) {
 			this.monthInput.nativeElement.focus();
 		}
 	}
 
 	updateMonth(event: Event): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (!this.edtfService.isValidMonth(value)) {
-			input.value = this.date.month ?? '';
-			return;
-		}
+		const value = (event.target as HTMLInputElement).value;
+		const error = this.getFieldError('month', value);
+		this.fieldErrors.month.set(error);
 
 		this.dateChange.emit({ ...this.date, month: value });
-		if (value.length === 2) {
+
+		// Re-validate day because its bounds depend on the month.
+		this.fieldErrors.day.set(this.getDayError(this.date.day ?? '', value));
+
+		if (!error && value.length === 2) {
 			this.dayInput.nativeElement.focus();
 		}
 	}
 
 	updateDay(event: Event): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (
-			!this.edtfService.isValidDay(value, this.date.year, this.date.month ?? '')
-		) {
-			input.value = this.date.day ?? '';
-			return;
-		}
+		const value = (event.target as HTMLInputElement).value;
+		this.fieldErrors.day.set(this.getFieldError('day', value));
 
 		this.dateChange.emit({ ...this.date, day: value });
 	}
@@ -126,6 +177,7 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newYear = (this.date.year ?? '').slice(0, -1);
+		this.fieldErrors.year.set(this.getFieldError('year', newYear));
 		this.dateChange.emit({ ...this.date, year: newYear });
 		this.yearInput.nativeElement.focus();
 	}
@@ -136,6 +188,8 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newMonth = (this.date.month ?? '').slice(0, -1);
+		this.fieldErrors.month.set(this.getFieldError('month', newMonth));
+		this.fieldErrors.day.set(this.getDayError(this.date.day ?? '', newMonth));
 		this.dateChange.emit({ ...this.date, month: newMonth });
 		this.monthInput.nativeElement.focus();
 	}
@@ -148,6 +202,9 @@ export class DatepickerInputComponent implements OnInit, OnChanges {
 			day: String(newDate.day).padStart(2, '0'),
 		};
 		this.date = updatedDate;
+		Object.values(this.fieldErrors).forEach((fieldError) =>
+			fieldError.set(null),
+		);
 		this.dateChange.emit(updatedDate);
 		this.showDatepicker.set(false);
 	}

--- a/src/app/shared/components/datepicker-input/datepicker-input.component.ts
+++ b/src/app/shared/components/datepicker-input/datepicker-input.component.ts
@@ -17,12 +17,12 @@ import { CommonModule } from '@angular/common';
 import { NgbDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 import {
 	DateModel,
+	DAY_RANGE_ERROR,
 	EdtfService,
+	MONTH_RANGE_ERROR,
 } from '@shared/services/edtf-service/edtf.service';
 
 export const INVALID_CHARS_ERROR = 'The date contains invalid characters.';
-export const MONTH_RANGE_ERROR = 'Month must be between 1 and 12.';
-export const DAY_RANGE_ERROR = 'Day must be between 1 and 31.';
 
 type DateFieldKey = keyof DateModel;
 

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.html
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.html
@@ -48,8 +48,12 @@
 		<div class="pr-time-icon-wrapper">
 			<span
 				class="pr-icon-button"
+				role="button"
+				tabindex="0"
 				[class.disabled]="disabled"
 				(click)="toggleTimepicker()"
+				(keydown.enter)="toggleTimepicker()"
+				(keydown.space)="toggleTimepicker()"
 			>
 				<i class="material-icons">access_time</i>
 			</span>

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.html
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.html
@@ -1,54 +1,64 @@
-<div class="pr-time-input-group" [class.active]="showTimepicker()">
-	<input
-		#hoursInput
-		type="text"
-		class="pr-time-segment"
-		[value]="time.hours ?? ''"
-		[disabled]="disabled"
-		(input)="updateTime($event, 'hours', minutesInput)"
-		placeholder="hh"
-		maxlength="2"
-	/>
-	<span class="pr-colon">:</span>
-	<input
-		#minutesInput
-		type="text"
-		class="pr-time-segment"
-		[value]="time.minutes ?? ''"
-		[disabled]="disabled"
-		(input)="updateTime($event, 'minutes', secondsInput?.nativeElement)"
-		(keydown)="onMinutesKeydown($event)"
-		placeholder="mm"
-		maxlength="2"
-	/>
-	<span class="pr-colon">:</span>
-	<input
-		#secondsInput
-		type="text"
-		class="pr-time-segment"
-		[value]="time.seconds ?? ''"
-		[disabled]="disabled"
-		(input)="updateTime($event, 'seconds')"
-		(keydown)="onSecondsKeydown($event)"
-		placeholder="ss"
-		maxlength="2"
-	/>
-	<button class="pr-am-pm-toggle" [disabled]="disabled" (click)="cycleFormat()">
-		{{ formatLabel() }}
-	</button>
-	<div class="pr-time-icon-wrapper">
-		<span
-			class="pr-icon-button"
-			role="button"
-			tabindex="0"
-			[class.disabled]="disabled"
-			(click)="toggleTimepicker()"
-			(keydown.enter)="toggleTimepicker()"
-			(keydown.space)="toggleTimepicker()"
+<div class="pr-time-input-wrap">
+	<div
+		class="pr-time-input-group"
+		[class.active]="showTimepicker()"
+		[class.has-error]="!!currentError()"
+	>
+		<input
+			#hoursInput
+			type="text"
+			class="pr-time-segment"
+			[value]="time.hours ?? ''"
+			[disabled]="disabled"
+			(input)="updateTime($event, 'hours', minutesInput)"
+			placeholder="hh"
+			maxlength="2"
+		/>
+		<span class="pr-colon">:</span>
+		<input
+			#minutesInput
+			type="text"
+			class="pr-time-segment"
+			[value]="time.minutes ?? ''"
+			[disabled]="disabled"
+			(input)="updateTime($event, 'minutes', secondsInput)"
+			(keydown)="onMinutesKeydown($event)"
+			placeholder="mm"
+			maxlength="2"
+		/>
+		<span class="pr-colon">:</span>
+		<input
+			#secondsInput
+			type="text"
+			class="pr-time-segment"
+			[value]="time.seconds ?? ''"
+			[disabled]="disabled"
+			(input)="updateTime($event, 'seconds')"
+			(keydown)="onSecondsKeydown($event)"
+			placeholder="ss"
+			maxlength="2"
+		/>
+		<button
+			class="pr-am-pm-toggle"
+			[disabled]="disabled"
+			(click)="cycleFormat()"
 		>
-			<i class="material-icons">access_time</i>
-		</span>
+			{{ formatLabel() }}
+		</button>
+		<div class="pr-time-icon-wrapper">
+			<span
+				class="pr-icon-button"
+				[class.disabled]="disabled"
+				(click)="toggleTimepicker()"
+			>
+				<i class="material-icons">access_time</i>
+			</span>
+		</div>
 	</div>
+
+	@if (currentError()) {
+		<span class="pr-input-error">{{ currentError() }}</span>
+	}
 </div>
 
 @if (showTimepicker()) {

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.scss
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.scss
@@ -4,7 +4,13 @@
 :host {
 	position: relative;
 	display: block;
-	height: 40px;
+	min-height: 40px;
+}
+
+.pr-time-input-wrap {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 }
 
 .pr-time-input-group {
@@ -15,6 +21,14 @@
 	&.active {
 		@include input-focus-state;
 	}
+
+	&.has-error {
+		@include input-error-state;
+	}
+}
+
+.pr-input-error {
+	@include input-error-message;
 }
 
 .pr-time-segment {

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.spec.ts
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.spec.ts
@@ -1,7 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { TimeModel } from '@shared/services/edtf-service/edtf.service';
-import { TimepickerInputComponent } from './timepicker-input.component';
+import {
+	HOUR_12_RANGE_ERROR,
+	HOUR_24_RANGE_ERROR,
+	INVALID_CHARS_ERROR,
+	MINUTES_RANGE_ERROR,
+	SECONDS_RANGE_ERROR,
+	TimepickerInputComponent,
+} from './timepicker-input.component';
 
 @Component({
 	template: `<pr-timepicker-input
@@ -47,6 +54,16 @@ describe('TimepickerInputComponent', () => {
 	const mockEvent = (value: string): Event =>
 		({ target: { value } }) as unknown as Event;
 
+	const switchToH24 = (): void => {
+		hostComponent.time = {
+			hours: '',
+			minutes: '',
+			seconds: '',
+			format: 'h24',
+		};
+		fixture.detectChanges();
+	};
+
 	// --- Basic rendering ---
 
 	it('should create', () => {
@@ -80,107 +97,120 @@ describe('TimepickerInputComponent', () => {
 		expect(component.showTimepicker()).toBeFalse();
 	});
 
-	// --- Hour validation (12-hour) ---
+	// --- Hour validation (12-hour mode) ---
 
-	it('should accept valid hour', () => {
+	it('should accept valid hour and clear hours error', () => {
 		component.updateTime(mockEvent('10'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('10');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	it('should reject hour greater than 12', () => {
+	it('should emit hour > 12 in 12-hour mode AND surface 1-12 error', () => {
 		component.updateTime(mockEvent('13'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('13');
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
 	});
 
-	it('should reject non-numeric hour', () => {
+	it('should emit non-numeric hour AND surface the invalid-characters error', () => {
 		component.updateTime(mockEvent('ab'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('ab');
+		expect(component.fieldErrors.hours()).toBe(INVALID_CHARS_ERROR);
 	});
 
-	it('should accept single digit 0 or 1 for hours', () => {
+	it('should accept single digit 0 or 1 for hours in 12-hour mode', () => {
 		component.updateTime(mockEvent('1'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('1');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	it('should reject single digit greater than 1 for hours', () => {
+	it('should NOT surface the hours range error while only one digit has been typed', () => {
 		component.updateTime(mockEvent('2'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('2');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	// --- Hour validation (24-hour) ---
+	it('should NOT surface the minutes range error while only one digit has been typed', () => {
+		component.updateTime(mockEvent('9'), 'minutes');
+
+		expect(hostComponent.lastEmittedTime?.minutes).toBe('9');
+		expect(component.fieldErrors.minutes()).toBeNull();
+	});
+
+	it('should NOT surface the seconds range error while only one digit has been typed', () => {
+		component.updateTime(mockEvent('9'), 'seconds');
+
+		expect(hostComponent.lastEmittedTime?.seconds).toBe('9');
+		expect(component.fieldErrors.seconds()).toBeNull();
+	});
+
+	// --- Hour validation (24-hour mode) ---
 
 	it('should accept hours 00-23 in h24 mode', () => {
-		hostComponent.time = {
-			hours: '',
-			minutes: '',
-			seconds: '',
-			format: 'h24',
-		};
-		fixture.detectChanges();
+		switchToH24();
 
 		component.updateTime(mockEvent('00'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('00');
-
-		component.updateTime(mockEvent('13'), 'hours');
-
-		expect(hostComponent.lastEmittedTime?.hours).toBe('13');
+		expect(component.fieldErrors.hours()).toBeNull();
 
 		component.updateTime(mockEvent('23'), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('23');
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
-	it('should reject hours 24 and above in h24 mode', () => {
-		hostComponent.time = {
-			hours: '12',
-			minutes: '',
-			seconds: '',
-			format: 'h24',
-		};
-		fixture.detectChanges();
-		hostComponent.lastEmittedTime = null;
+	it('should emit hour 24 in h24 mode AND surface 0-23 error', () => {
+		switchToH24();
 
 		component.updateTime(mockEvent('24'), 'hours');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
-
-		component.updateTime(mockEvent('30'), 'hours');
-
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.hours).toBe('24');
+		expect(component.fieldErrors.hours()).toBe(HOUR_24_RANGE_ERROR);
 	});
 
-	it('should accept single digit 0-2 for hours in h24 mode', () => {
+	it('should re-validate the hour when the format toggles (15 valid in h24, invalid in 12-hour)', () => {
 		hostComponent.time = {
-			hours: '',
+			hours: '15',
 			minutes: '',
 			seconds: '',
 			format: 'h24',
 		};
 		fixture.detectChanges();
 
-		component.updateTime(mockEvent('2'), 'hours');
+		expect(component.fieldErrors.hours()).toBeNull();
 
-		expect(hostComponent.lastEmittedTime?.hours).toBe('2');
+		component.cycleFormat();
+
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
 	});
 
-	it('should reject single digit greater than 2 for hours in h24 mode', () => {
+	it('should clear the hour error when the format toggles to one where the value is valid', () => {
 		hostComponent.time = {
-			hours: '',
+			hours: '15',
 			minutes: '',
 			seconds: '',
-			format: 'h24',
+			format: 'am',
 		};
 		fixture.detectChanges();
 
-		component.updateTime(mockEvent('3'), 'hours');
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		// am -> pm: still 12-hour, still invalid
+		component.cycleFormat();
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.hours()).toBe(HOUR_12_RANGE_ERROR);
+
+		// pm -> h24: now valid
+		component.cycleFormat();
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.hours()).toBeNull();
 	});
 
 	// --- Minute validation ---
@@ -189,24 +219,21 @@ describe('TimepickerInputComponent', () => {
 		component.updateTime(mockEvent('30'), 'minutes');
 
 		expect(hostComponent.lastEmittedTime?.minutes).toBe('30');
+		expect(component.fieldErrors.minutes()).toBeNull();
 	});
 
-	it('should reject minutes greater than 59', () => {
+	it('should emit minutes 60 AND surface the minutes error', () => {
 		component.updateTime(mockEvent('60'), 'minutes');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.minutes).toBe('60');
+		expect(component.fieldErrors.minutes()).toBe(MINUTES_RANGE_ERROR);
 	});
 
-	it('should accept single digit 0-5 for minutes', () => {
-		component.updateTime(mockEvent('5'), 'minutes');
+	it('should emit non-numeric minutes AND surface the invalid-characters error', () => {
+		component.updateTime(mockEvent('a5'), 'minutes');
 
-		expect(hostComponent.lastEmittedTime?.minutes).toBe('5');
-	});
-
-	it('should reject single digit greater than 5 for minutes', () => {
-		component.updateTime(mockEvent('6'), 'minutes');
-
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.minutes).toBe('a5');
+		expect(component.fieldErrors.minutes()).toBe(INVALID_CHARS_ERROR);
 	});
 
 	// --- Second validation ---
@@ -215,17 +242,19 @@ describe('TimepickerInputComponent', () => {
 		component.updateTime(mockEvent('45'), 'seconds');
 
 		expect(hostComponent.lastEmittedTime?.seconds).toBe('45');
+		expect(component.fieldErrors.seconds()).toBeNull();
 	});
 
-	it('should reject seconds greater than 59', () => {
+	it('should emit seconds 60 AND surface the seconds error', () => {
 		component.updateTime(mockEvent('60'), 'seconds');
 
-		expect(hostComponent.lastEmittedTime).toBeNull();
+		expect(hostComponent.lastEmittedTime?.seconds).toBe('60');
+		expect(component.fieldErrors.seconds()).toBe(SECONDS_RANGE_ERROR);
 	});
 
-	// --- Empty values ---
+	// --- Empty values clear errors ---
 
-	it('should allow clearing fields', () => {
+	it('should allow clearing fields and clear errors', () => {
 		hostComponent.time = {
 			hours: '10',
 			minutes: '30',
@@ -236,6 +265,69 @@ describe('TimepickerInputComponent', () => {
 		component.updateTime(mockEvent(''), 'hours');
 
 		expect(hostComponent.lastEmittedTime?.hours).toBe('');
+		expect(component.fieldErrors.hours()).toBeNull();
+	});
+
+	// --- currentError priority ---
+
+	it('should surface hours error first when both hours and minutes are invalid', () => {
+		component.updateTime(mockEvent('13'), 'hours');
+		component.updateTime(mockEvent('60'), 'minutes');
+
+		expect(component.currentError()).toBe(HOUR_12_RANGE_ERROR);
+	});
+
+	// --- Auto-focus ---
+
+	it('should auto-focus the next field after a valid 2-digit hour', () => {
+		const focusSpy = spyOn(
+			component.minutesInput.nativeElement,
+			'focus',
+		).and.callThrough();
+		component.updateTime(
+			mockEvent('10'),
+			'hours',
+			component.minutesInput.nativeElement,
+		);
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('should NOT auto-focus the next field when the value is out of range', () => {
+		const focusSpy = spyOn(component.minutesInput.nativeElement, 'focus');
+		component.updateTime(
+			mockEvent('13'),
+			'hours',
+			component.minutesInput.nativeElement,
+		);
+
+		expect(focusSpy).not.toHaveBeenCalled();
+	});
+
+	// Dispatches real DOM input events so the template bindings themselves are
+	// exercised — a regression test for the minutes -> seconds focus jump.
+	it('should auto-focus the seconds input after a valid 2-digit minutes value via the template', () => {
+		const [, minutesElement, secondsElement] = Array.from<HTMLInputElement>(
+			fixture.nativeElement.querySelectorAll('.pr-time-segment'),
+		);
+		const focusSpy = spyOn(secondsElement, 'focus');
+
+		minutesElement.value = '30';
+		minutesElement.dispatchEvent(new Event('input'));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('should auto-focus the minutes input after a valid 2-digit hour via the template', () => {
+		const [hoursElement, minutesElement] = Array.from<HTMLInputElement>(
+			fixture.nativeElement.querySelectorAll('.pr-time-segment'),
+		);
+		const focusSpy = spyOn(minutesElement, 'focus');
+
+		hoursElement.value = '10';
+		hoursElement.dispatchEvent(new Event('input'));
+
+		expect(focusSpy).toHaveBeenCalled();
 	});
 
 	// --- Format cycle ---
@@ -503,5 +595,18 @@ describe('TimepickerInputComponent', () => {
 		component.onTimeSelect({ hour: 14, minute: 45, second: 0 });
 
 		expect(hostComponent.lastEmittedTime?.timezoneOffset).toBe('+05:30');
+	});
+	// --- Initial / @Input-driven error sync ---
+
+	it('should surface errors derived from incoming @Input time', () => {
+		hostComponent.time = {
+			hours: '25',
+			minutes: '',
+			seconds: '',
+			format: 'h24',
+		};
+		fixture.detectChanges();
+
+		expect(component.fieldErrors.hours()).toBe(HOUR_24_RANGE_ERROR);
 	});
 });

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.spec.ts
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.spec.ts
@@ -97,6 +97,21 @@ describe('TimepickerInputComponent', () => {
 		expect(component.showTimepicker()).toBeFalse();
 	});
 
+	it('should toggle timepicker via keyboard (Enter and Space)', () => {
+		const iconButton: HTMLElement =
+			fixture.nativeElement.querySelector('.pr-icon-button');
+
+		iconButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+		fixture.detectChanges();
+
+		expect(component.showTimepicker()).toBeTrue();
+
+		iconButton.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+		fixture.detectChanges();
+
+		expect(component.showTimepicker()).toBeFalse();
+	});
+
 	// --- Hour validation (12-hour mode) ---
 
 	it('should accept valid hour and clear hours error', () => {

--- a/src/app/shared/components/timepicker-input/timepicker-input.component.ts
+++ b/src/app/shared/components/timepicker-input/timepicker-input.component.ts
@@ -12,6 +12,7 @@ import {
 	OnDestroy,
 	ViewChild,
 	ElementRef,
+	WritableSignal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
@@ -24,6 +25,14 @@ import {
 	DEFAULT_TIME,
 	EdtfService,
 } from '@shared/services/edtf-service/edtf.service';
+
+export const INVALID_CHARS_ERROR = 'The time contains invalid characters.';
+export const HOUR_24_RANGE_ERROR = 'Hour must be between 0 and 23.';
+export const HOUR_12_RANGE_ERROR = 'Hour must be between 1 and 12.';
+export const MINUTES_RANGE_ERROR = 'Minutes must be between 0 and 59.';
+export const SECONDS_RANGE_ERROR = 'Seconds must be between 0 and 59.';
+
+type TimeFieldKey = keyof Pick<TimeModel, 'hours' | 'minutes' | 'seconds'>;
 
 @Component({
 	selector: 'pr-timepicker-input',
@@ -51,6 +60,18 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 	formatLabel = computed(() => TIME_FORMAT_LABEL[this.timeSignal().format]);
 	is24Hour = computed(() => this.timeSignal().format === 'h24');
 
+	readonly fieldErrors: Record<TimeFieldKey, WritableSignal<string | null>> = {
+		hours: signal<string | null>(null),
+		minutes: signal<string | null>(null),
+		seconds: signal<string | null>(null),
+	};
+	currentError = computed(
+		() =>
+			this.fieldErrors.hours() ??
+			this.fieldErrors.minutes() ??
+			this.fieldErrors.seconds(),
+	);
+
 	private destroy$ = new Subject<void>();
 
 	constructor(
@@ -62,6 +83,7 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		this.timepickerControl.valueChanges
 			.pipe(takeUntil(this.destroy$))
 			.subscribe((ngbTime) => this.onTimeSelect(ngbTime));
+		this.refreshErrorsFromInput();
 	}
 
 	ngOnChanges(changes: SimpleChanges): void {
@@ -72,12 +94,58 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 			if (!this.ngbTimeEquals(model, current)) {
 				this.timepickerControl.setValue(model, { emitEvent: false });
 			}
+			this.refreshErrorsFromInput();
 		}
 	}
 
 	ngOnDestroy(): void {
 		this.destroy$.next();
 		this.destroy$.complete();
+	}
+
+	private refreshErrorsFromInput(): void {
+		(Object.keys(this.fieldErrors) as TimeFieldKey[]).forEach((timePropKey) =>
+			this.fieldErrors[timePropKey].set(
+				this.getFieldError(timePropKey, this.time[timePropKey] ?? ''),
+			),
+		);
+	}
+
+	private getFieldError(
+		timePropKey: TimeFieldKey,
+		value: string,
+	): string | null {
+		if (timePropKey === 'hours') {
+			return this.getHoursError(value, this.is24Hour());
+		}
+		if (timePropKey === 'minutes') return this.getMinutesError(value);
+		return this.getSecondsError(value);
+	}
+
+	private getHoursError(value: string, is24Hour: boolean): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (hours) => this.edtfService.isValidHour(hours, is24Hour),
+			rangeMessage: is24Hour ? HOUR_24_RANGE_ERROR : HOUR_12_RANGE_ERROR,
+		});
+	}
+
+	private getMinutesError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (minutes) =>
+				this.edtfService.isValidMinutesSeconds(minutes),
+			rangeMessage: MINUTES_RANGE_ERROR,
+		});
+	}
+
+	private getSecondsError(value: string): string | null {
+		return this.edtfService.getSegmentError(value, {
+			invalidCharsMessage: INVALID_CHARS_ERROR,
+			isWithinRange: (seconds) =>
+				this.edtfService.isValidMinutesSeconds(seconds),
+			rangeMessage: SECONDS_RANGE_ERROR,
+		});
 	}
 
 	@HostListener('document:click', ['$event'])
@@ -126,6 +194,10 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		const nextFormat =
 			this.FORMAT_CYCLE[(currentIndex + 1) % this.FORMAT_CYCLE.length];
 		this.timeChange.emit({ ...this.time, format: nextFormat });
+		// Hour validity depends on the format — re-check against the new format.
+		this.fieldErrors.hours.set(
+			this.getHoursError(this.time.hours ?? '', nextFormat === 'h24'),
+		);
 	}
 
 	onMinutesKeydown(event: KeyboardEvent): void {
@@ -134,6 +206,7 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newHours = (this.time.hours ?? '').slice(0, -1);
+		this.fieldErrors.hours.set(this.getFieldError('hours', newHours));
 		this.timeChange.emit({ ...this.time, hours: newHours });
 		this.hoursInput.nativeElement.focus();
 	}
@@ -144,37 +217,24 @@ export class TimepickerInputComponent implements OnInit, OnChanges, OnDestroy {
 		if (target.value !== '') return;
 		event.preventDefault();
 		const newMinutes = (this.time.minutes ?? '').slice(0, -1);
+		this.fieldErrors.minutes.set(this.getFieldError('minutes', newMinutes));
 		this.timeChange.emit({ ...this.time, minutes: newMinutes });
 		this.minutesInput.nativeElement.focus();
 	}
 
 	updateTime(
 		event: Event,
-		timePropKey: keyof Pick<TimeModel, 'hours' | 'minutes' | 'seconds'>,
+		timePropKey: TimeFieldKey,
 		nextField?: HTMLInputElement,
 	): void {
-		const input = event.target as HTMLInputElement;
-		const value = input.value;
-
-		if (value !== '') {
-			const isValid =
-				timePropKey === 'hours'
-					? this.edtfService.isValidHour(value, this.is24Hour())
-					: this.edtfService.isValidMinutesSeconds(value);
-			if (!isValid) {
-				input.value = this.time[timePropKey] ?? '';
-				return;
-			}
-		}
+		const value = (event.target as HTMLInputElement).value;
+		const error = this.getFieldError(timePropKey, value);
+		this.fieldErrors[timePropKey].set(error);
 
 		this.timeChange.emit({ ...this.time, [timePropKey]: value });
 
-		if (nextField && value.length === 2) {
-			const isComplete =
-				timePropKey === 'hours'
-					? this.edtfService.isValidHour(value, this.is24Hour())
-					: this.edtfService.isValidMinutesSeconds(value);
-			if (isComplete) nextField.focus();
+		if (!error && nextField && value.length === 2) {
+			nextField.focus();
 		}
 	}
 

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -335,6 +335,51 @@ describe('EdtfService', () => {
 
 				expect(service.toEdtfDate(model)).toBe('1985-05-20');
 			});
+
+			it('should left-pad a single-digit month with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '5' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05');
+			});
+
+			it('should left-pad a single-digit month with zero when a day is present', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '5', day: '20' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-20');
+			});
+
+			it('should left-pad single-digit month 1 with zero (January)', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '1' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-01');
+			});
+
+			it('should left-pad a single-digit day with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '2' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-02');
+			});
+
+			it('should left-pad single-digit day 1 with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '1' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05-01');
+			});
 		});
 
 		describe('unspecified-digit (X-padding)', () => {
@@ -383,33 +428,6 @@ describe('EdtfService', () => {
 				expect(service.toEdtfDate(model)).toBe('1985-XX-20');
 			});
 
-			it('should zero-pad a single-digit day on the left', () => {
-				const model: DateTimeModel = {
-					date: { year: '1985', month: '05', day: '2' },
-					time: { format: 'am' },
-				};
-
-				expect(service.toEdtfDate(model)).toBe('1985-05-02');
-			});
-
-			it('should zero-pad a single-digit day that would be an invalid X-range', () => {
-				const model: DateTimeModel = {
-					date: { year: '1985', month: '05', day: '9' },
-					time: { format: 'am' },
-				};
-
-				expect(service.toEdtfDate(model)).toBe('1985-05-09');
-			});
-
-			it('should pad single-digit month with one X', () => {
-				const model: DateTimeModel = {
-					date: { year: '1985', month: '1' },
-					time: { format: 'am' },
-				};
-
-				expect(service.toEdtfDate(model)).toBe('1985-1X');
-			});
-
 			it('should combine partial year, full month, and full day', () => {
 				const model: DateTimeModel = {
 					date: { year: '198', month: '05', day: '20' },
@@ -421,6 +439,34 @@ describe('EdtfService', () => {
 		});
 
 		describe('time building', () => {
+			it('should left-pad single-digit hour, minute and second with zero', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '20' },
+					time: {
+						hours: '5',
+						minutes: '7',
+						seconds: '9',
+						format: 'am',
+					},
+				};
+
+				expect(service.toEdtfDate(model)).toContain('T05:07:09');
+			});
+
+			it('should left-pad a single-digit hour in 24-hour mode', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '20' },
+					time: {
+						hours: '5',
+						minutes: '30',
+						seconds: '00',
+						format: 'h24',
+					},
+				};
+
+				expect(service.toEdtfDate(model)).toContain('T05:30:00');
+			});
+
 			it('should build date with PM time', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '05', day: '20' },
@@ -778,6 +824,48 @@ describe('EdtfService', () => {
 				expect(() => service.toEdtfDate(model)).toThrowError(
 					/Please check the values/,
 				);
+			});
+
+			it('should throw when time is filled but the date is missing the day', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '' },
+					time: { hours: '10', minutes: '30', seconds: '00', format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/complete date is required/i,
+				);
+			});
+
+			it('should throw when time is filled but the date is missing the month', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '', day: '20' },
+					time: { hours: '10', minutes: '30', seconds: '00', format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/complete date is required/i,
+				);
+			});
+
+			it('should throw when time is filled but the date has only a year', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '', day: '' },
+					time: { hours: '10', minutes: '30', seconds: '00', format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/complete date is required/i,
+				);
+			});
+
+			it('should still emit a partial date when no time is provided', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('1985-05');
 			});
 		});
 	});
@@ -1161,6 +1249,44 @@ describe('EdtfService', () => {
 		});
 	});
 
+	describe('getSegmentError', () => {
+		const INVALID_MESSAGE = 'invalid characters';
+		const RANGE_MESSAGE = 'out of range';
+		const rangeOptions = {
+			invalidCharsMessage: INVALID_MESSAGE,
+			isWithinRange: (value: string): boolean => parseInt(value, 10) <= 12,
+			rangeMessage: RANGE_MESSAGE,
+		};
+
+		it('should return null for an empty value', () => {
+			expect(service.getSegmentError('', rangeOptions)).toBeNull();
+		});
+
+		it('should flag non-numeric characters with the provided message', () => {
+			expect(service.getSegmentError('a5', rangeOptions)).toBe(INVALID_MESSAGE);
+		});
+
+		it('should NOT range-check a partially-typed single digit', () => {
+			expect(service.getSegmentError('9', rangeOptions)).toBeNull();
+		});
+
+		it('should flag a complete out-of-range value with the provided message', () => {
+			expect(service.getSegmentError('13', rangeOptions)).toBe(RANGE_MESSAGE);
+		});
+
+		it('should return null for a complete in-range value', () => {
+			expect(service.getSegmentError('12', rangeOptions)).toBeNull();
+		});
+
+		it('should skip the range check when no range options are provided', () => {
+			expect(
+				service.getSegmentError('9999', {
+					invalidCharsMessage: INVALID_MESSAGE,
+				}),
+			).toBeNull();
+		});
+	});
+
 	describe('roundtrip', () => {
 		it('should roundtrip a full date', () => {
 			const edtfString = '1985-05-20';
@@ -1266,21 +1392,21 @@ describe('EdtfService', () => {
 			expect(result).toBe(edtfString);
 		});
 
-		it('should normalize a partial day (1985-05-2X) to a discrete zero-padded day', () => {
-			// A day is treated as a discrete value, not an unspecified-digit
-			// range, so 2X collapses to the 2nd rather than round-tripping.
-			const model = service.toDateTimeModel('1985-05-2X');
-			const result = service.toEdtfDate(model);
-
-			expect(result).toBe('1985-05-02');
-		});
-
 		it('should roundtrip partial year with full month and day (198X-05-20)', () => {
 			const edtfString = '198X-05-20';
 			const model = service.toDateTimeModel(edtfString);
 			const result = service.toEdtfDate(model);
 
 			expect(result).toBe(edtfString);
+		});
+
+		it('should canonicalize a partial day from "1985-05-2X" to "1985-05-02"', () => {
+			// The parser strips the trailing X, leaving day "2"; the serializer now
+			// treats a single 1–9 digit as a complete day and left-pads with zero.
+			const model = service.toDateTimeModel('1985-05-2X');
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe('1985-05-02');
 		});
 	});
 

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -1,4 +1,9 @@
-import { EdtfService, DateTimeModel } from './edtf.service';
+import {
+	EdtfService,
+	DateTimeModel,
+	MONTH_RANGE_ERROR,
+	DAY_RANGE_ERROR,
+} from './edtf.service';
 
 // Mirrors the service's local-offset stamping so the expectations stay
 // green in any timezone the tests run in.
@@ -435,6 +440,26 @@ describe('EdtfService', () => {
 				};
 
 				expect(service.toEdtfDate(model)).toBe('198X-05-20');
+			});
+		});
+
+		describe('rejecting a lone zero', () => {
+			it('should reject a month of "0" instead of serializing it to "0X"', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '0', day: '20' },
+					time: { format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(MONTH_RANGE_ERROR);
+			});
+
+			it('should reject a day of "0" instead of serializing it to "0X"', () => {
+				const model: DateTimeModel = {
+					date: { year: '1985', month: '05', day: '0' },
+					time: { format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(DAY_RANGE_ERROR);
 			});
 		});
 
@@ -1445,6 +1470,61 @@ describe('EdtfService', () => {
 			expect(service.getEdtfIntervalStartDate('1985-05-20/..')).toBe(
 				'1985-05-20',
 			);
+		});
+
+		it('should return an empty string for a null input', () => {
+			expect(service.getEdtfIntervalStartDate(null)).toBe('');
+		});
+	});
+
+	describe('formatDateForDisplay', () => {
+		it('should return an empty string when no field has a value', () => {
+			expect(
+				service.formatDateForDisplay({ year: '', month: '', day: '' }),
+			).toBe('');
+		});
+
+		it('should render a complete date with the month name', () => {
+			expect(
+				service.formatDateForDisplay({ year: '1985', month: '05', day: '20' }),
+			).toBe('May 20, 1985');
+		});
+
+		it('should X-pad a partial year like serialization does', () => {
+			expect(
+				service.formatDateForDisplay({ year: '198', month: '', day: '' }),
+			).toBe('198X');
+		});
+
+		it('should interpret a single-digit month the same way serialization does ("1" -> January)', () => {
+			expect(
+				service.formatDateForDisplay({ year: '1985', month: '1', day: '20' }),
+			).toBe('January 20, 1985');
+
+			expect(
+				service.toEdtfDate({
+					date: { year: '1985', month: '1', day: '20' },
+					time: { format: 'am' },
+				}),
+			).toBe('1985-01-20');
+		});
+
+		it('should zero-pad a single-digit day like serialization does', () => {
+			expect(
+				service.formatDateForDisplay({ year: '1985', month: '05', day: '2' }),
+			).toBe('May 02, 1985');
+		});
+
+		it('should show XX for a missing month when a day is present', () => {
+			expect(
+				service.formatDateForDisplay({ year: '1985', month: '', day: '20' }),
+			).toBe('1985-XX-20');
+		});
+
+		it('should treat an in-progress "0" day as absent instead of guessing', () => {
+			expect(
+				service.formatDateForDisplay({ year: '1985', month: '05', day: '0' }),
+			).toBe('May 1985');
 		});
 	});
 });

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -267,6 +267,26 @@ describe('EdtfService', () => {
 				expect(result.qualifiers.uncertain).toBe(false);
 				expect(result.qualifiers.unknown).toBe(false);
 			});
+
+			it('should detect approximate qualifier combined with an unspecified month', () => {
+				const result = service.toDateTimeModel('2026-XX-11~');
+
+				expect(result.qualifiers.approximate).toBe(true);
+				expect(result.qualifiers.uncertain).toBe(false);
+				expect(result.date.year).toBe('2026');
+				expect(result.date.month).toBe('');
+				expect(result.date.day).toBe('11');
+			});
+
+			it('should detect combined qualifier alongside an unspecified year digit', () => {
+				const result = service.toDateTimeModel('198X-05-20%');
+
+				expect(result.qualifiers.approximate).toBe(true);
+				expect(result.qualifiers.uncertain).toBe(true);
+				expect(result.date.year).toBe('198');
+				expect(result.date.month).toBe('05');
+				expect(result.date.day).toBe('20');
+			});
 		});
 
 		describe('interval (range)', () => {
@@ -667,6 +687,36 @@ describe('EdtfService', () => {
 
 				expect(service.toEdtfDate(model)).toBe('XXXX-XX-XX');
 			});
+
+			it('should add approximate qualifier with an unspecified month', () => {
+				const model: DateTimeModel = {
+					date: { year: '2026', month: '', day: '11' },
+					time: { format: 'am' },
+					qualifiers: { approximate: true, uncertain: false, unknown: false },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('2026-XX-11~');
+			});
+
+			it('should add uncertain qualifier on a month with an unspecified year', () => {
+				const model: DateTimeModel = {
+					date: { year: '', month: '05', day: '' },
+					time: { format: 'am' },
+					qualifiers: { approximate: false, uncertain: true, unknown: false },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('XXXX-05?');
+			});
+
+			it('should add combined qualifier alongside an unspecified year digit', () => {
+				const model: DateTimeModel = {
+					date: { year: '198', month: '05', day: '20' },
+					time: { format: 'am' },
+					qualifiers: { approximate: true, uncertain: true, unknown: false },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('198X-05-20%');
+			});
 		});
 
 		describe('interval output (range)', () => {
@@ -837,6 +887,12 @@ describe('EdtfService', () => {
 
 				expect(result).toBeNull();
 			});
+
+			it('should throw for a qualifier combined with a time (unsupported combination)', () => {
+				expect(() =>
+					service.toDateTimeModel('2026-01-01T10:00:00~'),
+				).toThrowError();
+			});
 		});
 
 		describe('formatting errors', () => {
@@ -844,6 +900,18 @@ describe('EdtfService', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '99' },
 					time: { format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/Please check the values/,
+				);
+			});
+
+			it('should throw for a complete date with a time and a qualifier (unsupported combination)', () => {
+				const model: DateTimeModel = {
+					date: { year: '2026', month: '01', day: '01' },
+					time: { hours: '10', minutes: '30', seconds: '00', format: 'am' },
+					qualifiers: { approximate: true, uncertain: false, unknown: false },
 				};
 
 				expect(() => service.toEdtfDate(model)).toThrowError(
@@ -1432,6 +1500,38 @@ describe('EdtfService', () => {
 			const result = service.toEdtfDate(model);
 
 			expect(result).toBe('1985-05-02');
+		});
+
+		it('should roundtrip approximate qualifier with an unspecified month (2026-XX-11~)', () => {
+			const edtfString = '2026-XX-11~';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip approximate qualifier with unknown year and month (XXXX-XX-20~)', () => {
+			const edtfString = 'XXXX-XX-20~';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip combined qualifier with a partial year (198X-05-20%)', () => {
+			const edtfString = '198X-05-20%';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
+		});
+
+		it('should roundtrip an interval with per-side qualifiers and an unspecified month', () => {
+			const edtfString = '2026-XX-11~/2027-01?';
+			const model = service.toDateTimeModel(edtfString);
+			const result = service.toEdtfDate(model);
+
+			expect(result).toBe(edtfString);
 		});
 	});
 

--- a/src/app/shared/services/edtf-service/edtf.service.spec.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.spec.ts
@@ -3,6 +3,7 @@ import {
 	DateTimeModel,
 	MONTH_RANGE_ERROR,
 	DAY_RANGE_ERROR,
+	INVALID_DAY_FOR_MONTH_ERROR,
 } from './edtf.service';
 
 // Mirrors the service's local-offset stamping so the expectations stay
@@ -464,13 +465,17 @@ describe('EdtfService', () => {
 		});
 
 		describe('rejecting a lone zero', () => {
+			// The specific message is surfaced inline by getMonthError/getDayError;
+			// serialization only needs to reject with the generic footer message.
 			it('should reject a month of "0" instead of serializing it to "0X"', () => {
 				const model: DateTimeModel = {
 					date: { year: '1985', month: '0', day: '20' },
 					time: { format: 'am' },
 				};
 
-				expect(() => service.toEdtfDate(model)).toThrowError(MONTH_RANGE_ERROR);
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/Please check the values/,
+				);
 			});
 
 			it('should reject a day of "0" instead of serializing it to "0X"', () => {
@@ -479,7 +484,55 @@ describe('EdtfService', () => {
 					time: { format: 'am' },
 				};
 
-				expect(() => service.toEdtfDate(model)).toThrowError(DAY_RANGE_ERROR);
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/Please check the values/,
+				);
+			});
+		});
+
+		describe('rejecting an impossible calendar day', () => {
+			// Serialization rejects with the generic footer message; the specific
+			// day-for-month message is surfaced inline by getDayError.
+			it('should reject serializing Feb 29 in a non-leap year instead of rolling it forward', () => {
+				const model: DateTimeModel = {
+					date: { year: '2021', month: '02', day: '29' },
+					time: { format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/Please check the values/,
+				);
+			});
+
+			it('should reject serializing Feb 29 in a non-leap year given a single-digit month', () => {
+				const model: DateTimeModel = {
+					date: { year: '2021', month: '2', day: '29' },
+					time: { format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/Please check the values/,
+				);
+			});
+
+			it('should reject serializing day 31 in a 30-day month', () => {
+				const model: DateTimeModel = {
+					date: { year: '2021', month: '04', day: '31' },
+					time: { format: 'am' },
+				};
+
+				expect(() => service.toEdtfDate(model)).toThrowError(
+					/Please check the values/,
+				);
+			});
+
+			it('should accept serializing Feb 29 in a leap year', () => {
+				const model: DateTimeModel = {
+					date: { year: '2024', month: '02', day: '29' },
+					time: { format: 'am' },
+				};
+
+				expect(service.toEdtfDate(model)).toBe('2024-02-29');
 			});
 		});
 
@@ -1340,6 +1393,14 @@ describe('EdtfService', () => {
 		it('should fall back to month 01 (31 days) when month is missing', () => {
 			expect(service.isValidDay('31', '1985', '')).toBe(true);
 		});
+
+		it('should reject Feb 29 in a non-leap year given a single-digit month', () => {
+			expect(service.isValidDay('29', '2021', '2')).toBe(false);
+		});
+
+		it('should accept Feb 29 in a leap year given a single-digit month', () => {
+			expect(service.isValidDay('29', '2024', '2')).toBe(true);
+		});
 	});
 
 	describe('getSegmentError', () => {
@@ -1377,6 +1438,92 @@ describe('EdtfService', () => {
 					invalidCharsMessage: INVALID_MESSAGE,
 				}),
 			).toBeNull();
+		});
+	});
+
+	describe('getDayError', () => {
+		const options = { invalidCharsMessage: 'invalid characters' };
+
+		it('should return null for a valid day in the month', () => {
+			expect(service.getDayError('20', '1985', '05', options)).toBeNull();
+		});
+
+		it('should return null while only a single digit has been typed', () => {
+			expect(service.getDayError('9', '2021', '02', options)).toBeNull();
+		});
+
+		it('should flag non-numeric day characters with the provided message', () => {
+			expect(service.getDayError('a5', '1985', '05', options)).toBe(
+				options.invalidCharsMessage,
+			);
+		});
+
+		it('should return the range error for a day greater than 31', () => {
+			expect(service.getDayError('32', '1985', '01', options)).toBe(
+				DAY_RANGE_ERROR,
+			);
+		});
+
+		it('should return the range error for day 00', () => {
+			expect(service.getDayError('00', '1985', '05', options)).toBe(
+				DAY_RANGE_ERROR,
+			);
+		});
+
+		it('should return the day-for-month error for Feb 29 in a non-leap year', () => {
+			expect(service.getDayError('29', '2021', '02', options)).toBe(
+				INVALID_DAY_FOR_MONTH_ERROR,
+			);
+		});
+
+		it('should return the day-for-month error given a single-digit month', () => {
+			expect(service.getDayError('29', '2021', '2', options)).toBe(
+				INVALID_DAY_FOR_MONTH_ERROR,
+			);
+		});
+
+		it('should return null for Feb 29 in a leap year', () => {
+			expect(service.getDayError('29', '2024', '02', options)).toBeNull();
+		});
+
+		it('should return the range error for a lone "0" day', () => {
+			expect(service.getDayError('0', '2024', '01', options)).toBe(
+				DAY_RANGE_ERROR,
+			);
+		});
+
+		it('should not report a day-for-month error when the month is a lone "0"', () => {
+			expect(service.getDayError('31', '2024', '0', options)).toBeNull();
+		});
+
+		it('should not report a day-for-month error when the month is out of range', () => {
+			expect(service.getDayError('31', '2024', '13', options)).toBeNull();
+		});
+	});
+
+	describe('getMonthError', () => {
+		const options = { invalidCharsMessage: 'invalid characters' };
+
+		it('should return null for a valid two-digit month', () => {
+			expect(service.getMonthError('12', options)).toBeNull();
+		});
+
+		it('should return null while only a valid single digit has been typed', () => {
+			expect(service.getMonthError('1', options)).toBeNull();
+		});
+
+		it('should flag non-numeric month characters with the provided message', () => {
+			expect(service.getMonthError('a5', options)).toBe(
+				options.invalidCharsMessage,
+			);
+		});
+
+		it('should return the range error for a month greater than 12', () => {
+			expect(service.getMonthError('13', options)).toBe(MONTH_RANGE_ERROR);
+		});
+
+		it('should return the range error for a lone "0" month', () => {
+			expect(service.getMonthError('0', options)).toBe(MONTH_RANGE_ERROR);
 		});
 	});
 

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -34,6 +34,8 @@ export const UNKNOWN_VALUE = 'XXXX-XX-XX';
 
 export const MONTH_RANGE_ERROR = 'Month must be between 1 and 12.';
 export const DAY_RANGE_ERROR = 'Day must be between 1 and 31.';
+export const INVALID_DAY_FOR_MONTH_ERROR =
+	'That day does not exist in the selected month and year.';
 
 const DIGITS_ONLY = /^\d*$/;
 
@@ -336,7 +338,26 @@ export class EdtfService {
 		if (!hasDay) return `${year}-${month}`;
 
 		const day = this.padMonthOrDay(date.day);
-		return `${year}-${month}-${day}`;
+		const dateStr = `${year}-${month}-${day}`;
+
+		// A fully-numeric date with an in-range month and day can still be an
+		// impossible calendar day (e.g. Feb 29 in a non-leap year, or Apr 31). The
+		// edtf library silently rolls those forward (2021-02-29 becomes 2021-03-01),
+		// so reject them here instead of storing the shift
+		const monthNumber = parseInt(month, 10);
+		const dayNumber = parseInt(day, 10);
+		if (
+			/^\d{4}-\d{2}-\d{2}$/.test(dateStr) &&
+			monthNumber >= 1 &&
+			monthNumber <= 12 &&
+			dayNumber >= 1 &&
+			dayNumber <= 31 &&
+			!isValid(parse(dateStr, 'yyyy-MM-dd', new Date()))
+		) {
+			throw new Error(INVALID_DAY_FOR_MONTH_ERROR);
+		}
+
+		return dateStr;
 	}
 
 	// Shared by serialization (toEdtfDate) and display (formatDateForDisplay)
@@ -510,11 +531,10 @@ export class EdtfService {
 			return 'A complete date is required when time is provided.';
 		}
 
-		if (message.includes('must be between')) {
-			// Already a human-readable segment range message (month/day).
-			return (error as Error).message;
-		}
-
+		// Segment errors (month/day range, day-for-month) are shown inline under
+		// the offending field, so the footer/toast only needs the generic message —
+		// no need to duplicate the specific one here. Errors without an inline
+		// counterpart (the date-range and complete-date cases above) keep theirs.
 		return 'The date entered is not valid. Please check the values and try again.';
 	}
 
@@ -681,8 +701,11 @@ export class EdtfService {
 		if (/^\d$/.test(value)) return true;
 		// Defaults let day be typed before year/month are filled in.
 		// 2000 is a leap year (allows Feb 29); 01 has 31 days (most permissive).
+		// A single-digit month is a complete value (e.g. '2' is February), so pad
+		// it rather than discarding it — otherwise a bad day like Feb 29 would be
+		// validated against January and wrongly pass.
 		const yearStr = year.length === 4 ? year : '2000';
-		const monthStr = month.length === 2 ? month : '01';
+		const monthStr = month ? month.padStart(2, '0') : '01';
 		const dayStr = value.padStart(2, '0');
 		return isValid(
 			parse(`${yearStr}-${monthStr}-${dayStr}`, 'yyyy-MM-dd', new Date()),
@@ -704,5 +727,71 @@ export class EdtfService {
 			return options.rangeMessage ?? null;
 		}
 		return null;
+	}
+
+	getMonthError(
+		value: string,
+		options: { invalidCharsMessage: string },
+	): string | null {
+		// A lone "0" is an unfinished value ("05" minus a keystroke), not a valid
+		// month — flag it inline instead of leaving it to serialization.
+		if (value === '0') return MONTH_RANGE_ERROR;
+
+		return this.getSegmentError(value, {
+			invalidCharsMessage: options.invalidCharsMessage,
+			isWithinRange: (month) => this.isValidMonth(month),
+			rangeMessage: MONTH_RANGE_ERROR,
+		});
+	}
+
+	// Validates a day segment in tiers so each failure gets a specific message:
+	// a lone "0", then the plain 1–31 range, then whether that day actually
+	// exists in the selected month/year (e.g. Feb 29 in a non-leap year).
+	getDayError(
+		value: string,
+		year: string,
+		month: string,
+		options: { invalidCharsMessage: string },
+	): string | null {
+		// A lone "0" is an unfinished value ("05" minus a keystroke), not a valid
+		// day — flag it inline instead of leaving it to serialization.
+		if (value === '0') return DAY_RANGE_ERROR;
+
+		const rangeError = this.getSegmentError(value, {
+			invalidCharsMessage: options.invalidCharsMessage,
+			isWithinRange: (day) => this.isDayInRange(day),
+			rangeMessage: DAY_RANGE_ERROR,
+		});
+		if (rangeError) return rangeError;
+
+		// Only cross-check the day against the month when the month is itself a
+		// valid month; when it is not (e.g. "0" or "13"), the error belongs to the
+		// month field, so we must not mislabel it as a day-for-month problem.
+		if (
+			value.length === 2 &&
+			this.isResolvableMonth(month) &&
+			!this.isValidDay(value, year, month)
+		) {
+			return INVALID_DAY_FOR_MONTH_ERROR;
+		}
+
+		return null;
+	}
+
+	// The plain 1–31 numeric range, independent of month/year — the first tier of
+	// getDayError, kept separate from the calendar check so an out-of-range day
+	// and a day that does not exist in the month get different messages.
+	private isDayInRange(value: string): boolean {
+		const dayNumber = parseInt(value, 10);
+		return dayNumber >= 1 && dayNumber <= 31;
+	}
+
+	// A month that resolves to a real 1–12 value (single digit or two digits).
+	// Used to gate the day-for-month check so an invalid month does not surface
+	// as a day error.
+	private isResolvableMonth(month: string): boolean {
+		if (!/^\d{1,2}$/.test(month)) return false;
+		const monthNumber = parseInt(month, 10);
+		return monthNumber >= 1 && monthNumber <= 12;
 	}
 }

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -25,6 +25,8 @@ export enum EdtfPrecision {
 
 export const UNKNOWN_VALUE = 'XXXX-XX-XX';
 
+const DIGITS_ONLY = /^\d*$/;
+
 export const DEFAULT_TIME: TimeModel = {
 	hours: '',
 	minutes: '',
@@ -197,13 +199,19 @@ export class EdtfService {
 		time: TimeModel,
 		qualifiers?: DateQualifierFlags,
 	): string {
+		const hasCompleteDate = !!(date.year && date.month && date.day);
+		const hasTime = !!time?.hours;
+
+		if (hasTime && !hasCompleteDate) {
+			throw new Error('A complete date is required when time is provided.');
+		}
+
 		const dateStr = this.buildDateString(date);
 		const edtfObject = edtf(dateStr);
 		// Strip any time/timezone the library may append (e.g. T00:00:00.000Z)
 		let result = edtfObject.toEDTF().replace(/T.*$/, '');
 
-		const hasCompleteDate = !!(date.year && date.month && date.day);
-		const timeStr = hasCompleteDate ? this.buildTimeString(time) : '';
+		const timeStr = hasTime ? this.buildTimeString(time) : '';
 
 		if (timeStr) {
 			result = `${result}${timeStr}`;
@@ -231,13 +239,18 @@ export class EdtfService {
 		const year = this.padWithX(date.year, 4);
 		if (!hasMonth && !hasDay) return year;
 
-		const month = hasMonth ? this.padWithX(date.month, 2) : 'XX';
+		const month = hasMonth ? this.padMonthOrDay(date.month) : 'XX';
 		if (!hasDay) return `${year}-${month}`;
 
-		// A day is a discrete value, so a single digit is zero-padded on the
-		// left ("9" -> "09"); X-padding would produce an invalid day (90-99).
-		const day = date.day.padStart(2, '0');
+		const day = this.padMonthOrDay(date.day);
 		return `${year}-${month}-${day}`;
+	}
+
+	private padMonthOrDay(value: string): string {
+		// A single 1–9 digit is treated as a complete value (e.g. '5' → '05'),
+		// since the user can't be mid-typing a two-digit value starting with 2–9.
+		if (/^[1-9]$/.test(value)) return `0${value}`;
+		return this.padWithX(value, 2);
 	}
 
 	private padWithX(value: string, width: number): string {
@@ -360,6 +373,10 @@ export class EdtfService {
 			message.includes('invalid upper bound')
 		) {
 			return 'The date range is not valid. Please make sure the start date is before the end date.';
+		}
+
+		if (message.includes('complete date is required')) {
+			return 'A complete date is required when time is provided.';
 		}
 
 		return 'The date entered is not valid. Please check the values and try again.';
@@ -534,5 +551,22 @@ export class EdtfService {
 		return isValid(
 			parse(`${yearStr}-${monthStr}-${dayStr}`, 'yyyy-MM-dd', new Date()),
 		);
+	}
+
+	getSegmentError(
+		value: string,
+		options: {
+			invalidCharsMessage: string;
+			isWithinRange?: (completeValue: string) => boolean;
+			rangeMessage?: string;
+		},
+	): string | null {
+		if (value === '') return null;
+		if (!DIGITS_ONLY.test(value)) return options.invalidCharsMessage;
+		if (value.length < 2) return null;
+		if (options.isWithinRange && !options.isWithinRange(value)) {
+			return options.rangeMessage ?? null;
+		}
+		return null;
 	}
 }

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@angular/core';
 import edtf, { Date as EdtfDate, Interval as EdtfInterval } from 'edtf';
-import { getHours, getMinutes, getSeconds, isValid, parse } from 'date-fns';
+import {
+	format,
+	getHours,
+	getMinutes,
+	getSeconds,
+	isValid,
+	parse,
+} from 'date-fns';
 
 export enum DateQualifier {
 	Approximate = 'approximate',
@@ -24,6 +31,9 @@ export enum EdtfPrecision {
 }
 
 export const UNKNOWN_VALUE = 'XXXX-XX-XX';
+
+export const MONTH_RANGE_ERROR = 'Month must be between 1 and 12.';
+export const DAY_RANGE_ERROR = 'Day must be between 1 and 31.';
 
 const DIGITS_ONLY = /^\d*$/;
 
@@ -104,7 +114,7 @@ export class EdtfService {
 		}
 	}
 
-	getEdtfIntervalStartDate(edtfString: string | undefined): string {
+	getEdtfIntervalStartDate(edtfString: string | null | undefined): string {
 		if (!edtfString) {
 			return '';
 		}
@@ -236,6 +246,11 @@ export class EdtfService {
 
 		if (!hasYear && !hasMonth && !hasDay) return '';
 
+		// A lone '0' is an unfinished value ('05' minus a keystroke), never a
+		// month or day on its own — reject it instead of guessing ('0X').
+		if (date.month === '0') throw new Error(MONTH_RANGE_ERROR);
+		if (date.day === '0') throw new Error(DAY_RANGE_ERROR);
+
 		const year = this.padWithX(date.year, 4);
 		if (!hasMonth && !hasDay) return year;
 
@@ -246,9 +261,13 @@ export class EdtfService {
 		return `${year}-${month}-${day}`;
 	}
 
+	// Shared by serialization (toEdtfDate) and display (formatDateForDisplay)
+	// so a saved value always reads back the way the preview rendered it.
 	private padMonthOrDay(value: string): string {
-		// A single 1–9 digit is treated as a complete value (e.g. '5' → '05'),
-		// since the user can't be mid-typing a two-digit value starting with 2–9.
+		// A single digit is zero-padded ('1' → '01', i.e. January / the 1st).
+		// '1' could in principle be the start of '10'–'12', but this runs on a
+		// finished value, not mid-keystroke, and the digits-only inputs give no
+		// way to type an unspecified digit — so '1X' is not expressible intent.
 		if (/^[1-9]$/.test(value)) return `0${value}`;
 		return this.padWithX(value, 2);
 	}
@@ -256,6 +275,40 @@ export class EdtfService {
 	private padWithX(value: string, width: number): string {
 		const v = value ?? '';
 		return v.length >= width ? v : v + 'X'.repeat(width - v.length);
+	}
+
+	// Human-readable counterpart of buildDateString: both share padWithX and
+	// padMonthOrDay, so the preview always shows what serialization will write.
+	// Unlike serialization it must tolerate in-progress values (it renders
+	// live while the user types), so it never throws.
+	formatDateForDisplay(date: DateModel): string {
+		const yearRaw = date.year ?? '';
+		const monthRaw = date.month ?? '';
+		const dayRaw = date.day ?? '';
+
+		const hasYear = !!yearRaw;
+		const hasMonth = !!monthRaw;
+		// A lone '0' day is an unfinished value ('05' minus a keystroke), so
+		// the preview treats it as absent rather than guessing.
+		const hasDay = !!dayRaw && parseInt(dayRaw, 10) !== 0;
+
+		if (!hasYear && !hasMonth && !hasDay) return '';
+
+		const yearDisplay = this.padWithX(yearRaw, 4);
+		const monthPadded = hasMonth ? this.padMonthOrDay(monthRaw) : 'XX';
+		const monthName = /^\d{2}$/.test(monthPadded)
+			? format(new Date(2000, parseInt(monthPadded, 10) - 1), 'MMMM')
+			: null;
+		const dayDisplay = hasDay ? this.padMonthOrDay(dayRaw) : '';
+
+		if (monthName && hasDay)
+			return `${monthName} ${dayDisplay}, ${yearDisplay}`;
+		if (monthName) return `${monthName} ${yearDisplay}`;
+		if (!hasMonth && !hasDay) return yearDisplay;
+
+		const parts: string[] = [yearDisplay, monthPadded];
+		if (hasDay) parts.push(dayDisplay);
+		return parts.join('-');
 	}
 
 	private buildTimeString(time: TimeModel): string {
@@ -377,6 +430,11 @@ export class EdtfService {
 
 		if (message.includes('complete date is required')) {
 			return 'A complete date is required when time is provided.';
+		}
+
+		if (message.includes('must be between')) {
+			// Already a human-readable segment range message (month/day).
+			return (error as Error).message;
 		}
 
 		return 'The date entered is not valid. Please check the values and try again.';

--- a/src/app/shared/services/edtf-service/edtf.service.ts
+++ b/src/app/shared/services/edtf-service/edtf.service.ts
@@ -89,7 +89,19 @@ export class EdtfService {
 				return null;
 			}
 
-			if (/^X{4}-X{2}-X{2}$/i.test(edtfString)) {
+			if (edtfString.includes('/')) {
+				return this.parseInterval(edtfString);
+			}
+
+			// The library can't parse a qualifier alongside unspecified (X) digits,
+			// so for those strings we strip the trailing qualifier, parse the base,
+			// and reattach the flags below.
+			const hasUnspecified = this.hasUnspecifiedDigits(edtfString);
+			const { base, approximate, uncertain } = hasUnspecified
+				? this.parseTrailingQualifier(edtfString)
+				: { base: edtfString, approximate: false, uncertain: false };
+
+			if (/^X{4}-X{2}-X{2}$/i.test(base)) {
 				return {
 					qualifiers: { ...DEFAULT_DATE_QUALIFIERS, unknown: true },
 					date: { year: '', month: '', day: '' },
@@ -97,18 +109,19 @@ export class EdtfService {
 				};
 			}
 
-			if (edtfString.includes('/')) {
-				return this.parseInterval(edtfString);
-			}
-
-			const normalizedString = this.normalizeForParsing(edtfString);
+			const normalizedString = this.normalizeForParsing(base);
 			const edtfObject = edtf(normalizedString);
 
 			if (!(edtfObject instanceof EdtfDate)) {
 				return null;
 			}
 
-			return this.extDateToDateTimeModel(edtfObject, edtfString);
+			const model = this.extDateToDateTimeModel(edtfObject, base);
+			if (hasUnspecified && model.qualifiers && !model.qualifiers.unknown) {
+				model.qualifiers.approximate = approximate;
+				model.qualifiers.uncertain = uncertain;
+			}
+			return model;
 		} catch (error) {
 			throw new Error(this.toHumanReadableError(error));
 		}
@@ -128,16 +141,27 @@ export class EdtfService {
 	}
 
 	private parseInterval(edtfString: string): DateTimeModel | null {
-		const [startPart, endPart] = edtfString.split('/');
+		const [rawStart, rawEnd] = edtfString.split('/');
+
+		// Only the unspecified-digit (X) case needs the strip-and-reattach
+		// workaround; without X the library parses per-side qualifiers natively
+		// (and rejects a qualifier combined with a time, which we keep blocking).
+		const hasUnspecified = this.hasUnspecifiedDigits(edtfString);
+		const start = hasUnspecified
+			? this.parseTrailingQualifier(rawStart ?? '')
+			: { base: rawStart ?? '', approximate: false, uncertain: false };
+		const end = hasUnspecified
+			? this.parseTrailingQualifier(rawEnd ?? '')
+			: { base: rawEnd ?? '', approximate: false, uncertain: false };
 
 		const normalizedStart =
-			startPart === '..' || startPart === ''
-				? startPart
-				: this.normalizeForParsing(startPart);
+			start.base === '..' || start.base === ''
+				? start.base
+				: this.normalizeForParsing(start.base);
 		const normalizedEnd =
-			endPart === '..' || endPart === ''
-				? endPart
-				: this.normalizeForParsing(endPart);
+			end.base === '..' || end.base === ''
+				? end.base
+				: this.normalizeForParsing(end.base);
 
 		try {
 			const edtfObject = edtf(`${normalizedStart}/${normalizedEnd}`);
@@ -146,7 +170,24 @@ export class EdtfService {
 				return null;
 			}
 
-			return this.intervalToDateTimeModel(edtfObject, startPart, endPart);
+			const model = this.intervalToDateTimeModel(
+				edtfObject,
+				start.base,
+				end.base,
+			);
+
+			if (hasUnspecified) {
+				if (model.qualifiers && !model.qualifiers.unknown) {
+					model.qualifiers.approximate = start.approximate;
+					model.qualifiers.uncertain = start.uncertain;
+				}
+				if (model.endQualifiers && !model.endQualifiers.unknown) {
+					model.endQualifiers.approximate = end.approximate;
+					model.endQualifiers.uncertain = end.uncertain;
+				}
+			}
+
+			return model;
 		} catch {
 			return null;
 		}
@@ -197,7 +238,14 @@ export class EdtfService {
 
 			const stringDate =
 				endPart === null ? startPart : `${startPart}/${endPart}`;
-			edtf(stringDate);
+			// The edtf library's grammar rejects a qualifier (~/?/%) combined with
+			// unspecified (X) digits, but that combination is valid EDTF the backend
+			// accepts, so for those we validate the qualifier-stripped base instead.
+			edtf(
+				this.hasUnspecifiedDigits(stringDate)
+					? this.stripGroupQualifiers(stringDate)
+					: stringDate,
+			);
 			return stringDate;
 		} catch (error) {
 			throw new Error(this.toHumanReadableError(error));
@@ -228,15 +276,45 @@ export class EdtfService {
 		}
 
 		// Add qualifiers after the complete date-time string
-		if (qualifiers?.approximate && qualifiers?.uncertain) {
-			result += '%';
-		} else if (qualifiers?.approximate) {
-			result += '~';
-		} else if (qualifiers?.uncertain) {
-			result += '?';
-		}
+		result += this.buildQualifierSuffix(qualifiers);
 
 		return result;
+	}
+
+	private hasUnspecifiedDigits(edtfString: string): boolean {
+		return /X/i.test(edtfString);
+	}
+
+	private buildQualifierSuffix(qualifiers?: DateQualifierFlags): string {
+		if (qualifiers?.approximate && qualifiers?.uncertain) return '%';
+		if (qualifiers?.approximate) return '~';
+		if (qualifiers?.uncertain) return '?';
+		return '';
+	}
+
+	// Inverse of buildQualifierSuffix: split a trailing group qualifier off a
+	// single date
+	private parseTrailingQualifier(part: string): {
+		base: string;
+		approximate: boolean;
+		uncertain: boolean;
+	} {
+		const suffix = part.slice(-1);
+		if (suffix === '%')
+			return { base: part.slice(0, -1), approximate: true, uncertain: true };
+		if (suffix === '~')
+			return { base: part.slice(0, -1), approximate: true, uncertain: false };
+		if (suffix === '?')
+			return { base: part.slice(0, -1), approximate: false, uncertain: true };
+		return { base: part, approximate: false, uncertain: false };
+	}
+
+	// Remove group qualifiers (~/?/%) that sit at the end of the whole string or
+	// at an interval boundary, leaving a base string the edtf library can parse
+	// even when it contains unspecified (X) digits. Used for serialize-time
+	// validation only.
+	private stripGroupQualifiers(edtfString: string): string {
+		return edtfString.replace(/[%~?](?=\/|$)/g, '');
 	}
 
 	private buildDateString(date: DateModel): string {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -44,6 +44,17 @@
 	box-shadow: 0px 0px 0px 4px #131b4a08;
 }
 
+@mixin input-error-state {
+	border-color: $red;
+	background: rgba($red, 0.06);
+}
+
+@mixin input-error-message {
+	display: block;
+	font-size: 12px;
+	color: $red;
+}
+
 @mixin icon-wrapper {
 	background: $PR-blue-25;
 	border-radius: 0 8px 8px 0;


### PR DESCRIPTION
# Manual test cases — EDTF date/time input

**Setup:** log in, upload a file, click it.
**EXPECTED:** sidebar with a Date section. Unless a test says "inline picker", open the edit modal via **More options** for each test. The modal footer shows a live preview of the resulting EDTF string when valid, or a red error message when invalid, and the **Save** button is disabled while invalid.

> [!WARNING]
> The date and time inputs are the **same shared component** in both the inline sidebar picker and the **More options** modal. Every test that only exercises those fields — **Basic date entry, Single-digit month/day, Invalid characters, Out-of-range values, Impossible calendar days, and Time** — must be run in **both** places, because their commit behavior differs: the modal disables **Save** while invalid, whereas the inline picker lets you attempt the save and surfaces the error as a toast. Qualifiers, Unknown, and Date ranges exist only in the modal.

> [!NOTE]
> Field-specific messages (invalid characters, out-of-range month/day/hours/minutes/seconds, day-for-month) appear **inline below the offending input**, with that input highlighted red. The modal footer separately shows the generic `The date entered is not valid. Please check the values and try again.` whenever anything is invalid (with **Save** disabled) — the specific message is not duplicated there. Two exceptions with no inline field surface keep their specific text in the footer: `A complete date is required when time is provided.` and `The date range is not valid. Please make sure the start date is before the end date.`

---

## Basic date entry
*(run in both the inline picker and the modal)*

### Year only

1. Type `2026` in the year, leave month and day empty.
   - **EXPECTED:** No error. Preview shows `2026`. Save is enabled.

### Year and month

1. Type `2026` in the year, `05` in the month, leave day empty.
   - **EXPECTED:** No error. Preview shows `2026-05`. Save is enabled.

### Full date

1. Type `2026`, `05`, `20`.
   - **EXPECTED:** No error. Preview shows `2026-05-20`. Save is enabled.

### Auto-advance between segments

1. Type `2026` in the year.
   - **EXPECTED:** Focus jumps to the month input once 4 digits are entered.
2. Type `05` in the month.
   - **EXPECTED:** Focus jumps to the day input once 2 digits are entered.

### Backspace navigation between segments

1. Enter `2026` / `05` / `20`, then place the cursor in the empty day input and press Backspace until day is empty, then Backspace again.
   - **EXPECTED:** Focus moves back to the month input and removes its last digit.
2. Continue pressing Backspace with the month empty.
   - **EXPECTED:** Focus moves back to the year input and removes its last digit.

### Calendar picker

1. Click the calendar icon; select a date.
   - **EXPECTED:** The picker fills year/month/day, clears any field errors, and closes. Preview reflects the selected date.
2. Focus the calendar icon and press Enter or Space.
   - **EXPECTED:** The calendar opens/closes (keyboard toggle works).

---

## Single-digit month/day (entered without zero-padding)
*(run in both the inline picker and the modal)*

### Single-digit month is accepted and zero-padded

1. Enter year `2026`, month `2` (single digit), day `15`.
   - **EXPECTED:** No error. Preview shows `2026-02-15` — the month is zero-padded automatically even though you typed `2`. Save is enabled.
2. Save, then reopen the item.
   - **EXPECTED:** The date persists and the month field now shows `02`.

### Single-digit day is accepted and zero-padded

1. Enter year `2026`, month `05`, day `5` (single digit).
   - **EXPECTED:** No error. Preview shows `2026-05-05`. Save is enabled.

### Both month and day single-digit

1. Enter year `2026`, month `3`, day `7`.
   - **EXPECTED:** No error. Preview shows `2026-03-07`.

### Single-digit month, year-month only (no day)

1. Enter year `2026`, month `4`, leave day empty.
   - **EXPECTED:** No error. Preview shows `2026-04`.

### No premature error while a single digit is typed

1. Type `2` in the month input and stop.
   - **EXPECTED:** No error appears — validation waits until the value is complete. Focus does **not** auto-advance to the day (auto-advance only fires after 2 digits are entered), so you must move to the day input yourself.

### Single-digit month is used for day validation

1. Enter year `2026`, month `2` (single digit), day `30`.
   - **EXPECTED:** `That day does not exist in the selected month and year.` below the day input — the day is validated against **February**, not January. (This is the regression that was fixed: an un-padded month must not be treated as `01`.)
2. Enter year `2021`, month `2`, day `29`.
   - **EXPECTED:** `That day does not exist in the selected month and year.`

### Single-digit `1` month is treated as January

1. Enter year `2026`, month `1` (single digit), day `31`.
   - **EXPECTED:** No error (January has 31 days). Preview shows `2026-01-31`.

### Lone `0` month is rejected (inline, on the month field)

1. Enter year `2026`, month `0` (just a zero), day `15`.
   - **EXPECTED:** `Month must be between 1 and 12.` appears **below the month input** and the month field is highlighted red. A lone `0` is treated as an unfinished value, not a valid month. In the modal the footer shows the generic error and **Save** is disabled; in the inline picker a save attempt surfaces the error.

### Lone `0` day is rejected (inline, on the day field)

1. Enter year `2026`, month `05`, day `0` (just a zero).
   - **EXPECTED:** `Day must be between 1 and 31.` appears **below the day input** and the day field is highlighted red (same behavior as above).

### Lone `0` month is attributed to the month field, not the day

1. Enter year `2024`, month `0`, day `31`.
   - **EXPECTED:** Only `Month must be between 1 and 12.` appears (on the month field). The day field does **not** show `That day does not exist…` — an invalid month is not mislabeled as a day error.

---

## Invalid characters
*(run in both the inline picker and the modal)*

### Invalid characters in date and time

1. Type `19ab` in the year, then `ab` in the hours.
   - **EXPECTED:** The values stay visible (not silently reverted), with `The date contains invalid characters.` / `The time contains invalid characters.` below the inputs and red styling.
2. Clear the inputs.
   - **EXPECTED:** Errors disappear.

---

## Out-of-range values
*(run in both the inline picker and the modal)*

### Out-of-range month

1. Type `13` in the month input.
   - **EXPECTED:** The value stays visible and `Month must be between 1 and 12.` appears below the input.
2. Change the month to `12`.
   - **EXPECTED:** The error disappears.

### Out-of-range day

1. Enter year `2026`, month `01`, then type `32` in the day input.
   - **EXPECTED:** `Day must be between 1 and 31.` appears below the input.
2. Change the day to `31`.
   - **EXPECTED:** The error disappears.

### Out-of-range hours (AM/PM mode)

1. With the format toggle on `AM` or `PM`, type `13` in the hours input.
   - **EXPECTED:** The value stays visible and `Hour must be between 1 and 12.` appears below the time input.
2. Change the hours to `10`.
   - **EXPECTED:** The error disappears.
3. Type `13` again (error reappears), then toggle the format until it shows `24H` (leave the hours as `13`).
   - **EXPECTED:** The error disappears — `13` is valid in 24-hour mode — without editing the hours value. Toggling back to `AM`/`PM` makes `Hour must be between 1 and 12.` reappear.

### Out-of-range hours (24H mode)

1. Toggle the format until it shows `24H`, type `24` in the hours input.
   - **EXPECTED:** `Hour must be between 0 and 23.` appears below the time input.
2. Change the hours to `23`.
   - **EXPECTED:** The error disappears.
3. Type `24` again (error reappears), then toggle the format to `AM` (leave the hours as `24`).
   - **EXPECTED:** The message changes to `Hour must be between 1 and 12.` — `24` is invalid in both modes, but the message reflects the active format's range. (A 12-hour clock's valid hours are `1`–`12`; midnight is `12 AM` and noon is `12 PM`, so there is no `0` and the range is intentionally 1–12, not 0–12.)

### Out-of-range minutes

1. Type `60` in the minutes input.
   - **EXPECTED:** `Minutes must be between 0 and 59.` appears below the time input.
2. Change the minutes to `59`.
   - **EXPECTED:** The error disappears.

### Out-of-range seconds

1. Type `60` in the seconds input.
   - **EXPECTED:** `Seconds must be between 0 and 59.` appears below the time input.
2. Change the seconds to `59`.
   - **EXPECTED:** The error disappears.

---

## Impossible calendar days
*(run in both the inline picker and the modal)*

### Feb 29 in a non-leap year

1. Enter year `2021`, month `02`, then type `29` in the day input.
   - **EXPECTED:** `That day does not exist in the selected month and year.` appears below the day input (the value is **not** silently autocorrected to `2021-03-01`). Save is disabled.
2. Change the year to `2024`.
   - **EXPECTED:** The error disappears (2024 is a leap year). Preview shows `2024-02-29`.

### Feb 29 with a single-digit month

1. Enter year `2021`, month `2` (single digit), then type `29` in the day input.
   - **EXPECTED:** Same as above — `That day does not exist in the selected month and year.` (this previously slipped through with a single-digit month).

### Re-validation when month changes

1. Enter year `2026`, month `01`, day `31` (valid).
   - **EXPECTED:** No error.
2. Change the month to `04`.
   - **EXPECTED:** `That day does not exist in the selected month and year.` appears (the day is re-checked against the new month).

---

## Time
*(run in both the inline picker and the modal)*

### Format toggle (AM / PM / 24H)

1. Enter a time, then click the format toggle repeatedly.
   - **EXPECTED:** It cycles `AM` → `PM` → `24H` → `AM`. The hour is re-validated against the new format (e.g. `13` is invalid in AM/PM but valid in 24H).

### Midnight and noon

1. Enter time `12:00:00` with `AM`.
   - **EXPECTED:** Preview stores midnight (`T00:00:00…`).
2. Enter time `12:00:00` with `PM`.
   - **EXPECTED:** Preview stores noon (`T12:00:00…`).

### Seconds optional

1. Enter hours and minutes only, leave seconds empty.
   - **EXPECTED:** No error; seconds default to `00` in the saved value.

### Time requires a complete date

1. Enter year `2026` only (no month/day), then enter a time.
   - **EXPECTED:** `A complete date is required when time is provided.` in the footer and Save is disabled.
2. Fill in month and day.
   - **EXPECTED:** The error disappears.

---

## Unspecified digits (X)
*(modal only)*

### Unknown month with a known day

1. Enter year `2026`, leave month empty, enter day `11`.
   - **EXPECTED:** No error. Preview shows `2026-XX-11`. Save enabled.

### Partial year

1. Enter `198` in the year (3 digits), leave month/day empty.
   - **EXPECTED:** Preview shows `198X`.
2. Enter `19` in the year (2 digits).
   - **EXPECTED:** Preview shows `19XX`.

### Unknown year with a known month

1. Leave year empty, enter month `05`.
   - **EXPECTED:** Preview shows `XXXX-05`.

---

## Qualifiers
*(modal only)*

### Approximate

1. Enter a full date `2026`/`05`/`20`, toggle **Approximate** on.
   - **EXPECTED:** Preview shows `2026-05-20~`. Save enabled.

### Uncertain

1. Enter a full date, toggle **Uncertain** on.
   - **EXPECTED:** Preview shows `2026-05-20?`.

### Approximate + Uncertain (combined)

1. Enter a full date, toggle both **Approximate** and **Uncertain** on.
   - **EXPECTED:** Preview shows `2026-05-20%`.

### Qualifier with unspecified digits

1. Enter year `2026`, leave month empty, enter day `11`, toggle **Approximate** on.
   - **EXPECTED:** No "not valid" error. Preview shows `2026-XX-11~`. Save enabled.
2. Save, then reopen the item.
   - **EXPECTED:** Month is blank, day is `11`, and **Approximate** is still on (the value round-trips).

### Qualifier combined with a time is rejected

1. Enter a full date `2026`/`05`/`20`, enter a time (e.g. `10:30`), then toggle **Approximate** (or **Uncertain**) on.
   - **EXPECTED:** The footer shows `The date entered is not valid. Please check the values and try again.` and Save is disabled (a qualifier with a time is unsupported).

### Unknown

1. Toggle **Unknown** on.
   - **EXPECTED:** The date/time fields become disabled/cleared. Preview shows `XXXX-XX-XX`. Save enabled.
2. Toggle **Unknown** off.
   - **EXPECTED:** The previous field values are restored.

### Unknown is mutually exclusive with Approximate/Uncertain

1. Toggle **Unknown** on.
   - **EXPECTED:** **Approximate/Uncertain** are disabled.

---

## Date ranges
*(modal only)*

### Basic range

1. Toggle **Use a date range** on. Enter start `2026`/`05` and end `2027`/`06`.
   - **EXPECTED:** Preview shows `2026-05/2027-06`. Save enabled.
   
### Range with time on both sides

1. Toggle **Use a date range** on. Enter start `2026`/`05`/`20` with time `10:30:00`, and end `2027`/`06`/`15` with time `14:00:00`.
   - **EXPECTED:** No error. Preview shows the full interval with both times and their timezone offsets, e.g. `2026-05-20T10:30:00+HH:MM/2027-06-15T14:00:00+HH:MM`. Save enabled.
2. Save, then reopen the item.
   - **EXPECTED:** Both sides round-trip — each side shows its own date, wall-clock time, AM/PM (or 24H), and offset unchanged (not shifted to UTC).

### Range with time on only one side

1. With a range, enter start `2026`/`05`/`20` with time `10:30:00`, and end `2027`/`06`/`15` with **no** time.
   - **EXPECTED:** No error. Preview shows `2026-05-20T10:30:00+HH:MM/2027-06-15` (a timed start with a date-only end is allowed). Save enabled.
2. Repeat with the time on the **end** side only (start date-only, end timed).
   - **EXPECTED:** Preview shows `2026-05-20/2027-06-15T14:00:00+HH:MM`. Save enabled.

### A range side with a time still requires a complete date on that side

1. With a range, enter start year `2026` only (no month/day) but add a time to the start, and a valid end date.
   - **EXPECTED:** The footer shows `A complete date is required when time is provided.` and Save is disabled (the requirement applies per side).
2. Fill in the start month and day.
   - **EXPECTED:** The error disappears.

### Range validation (start after end)

1. With a range, enter start `2027` and end `2026`.
   - **EXPECTED:** `The date range is not valid. Please make sure the start date is before the end date.` in the footer and Save is disabled.

### Open-ended range — "sometime after"

1. With a range, enter a start date and leave the end empty.
   - **EXPECTED:** Preview shows `2026-05/..`. In the sidebar it reads **Sometime after**.

### Open-ended range — "sometime before"

1. With a range, leave the start empty and enter an end date.
   - **EXPECTED:** Preview shows `../2027-06`. In the sidebar it reads **Sometime before**.

### Per-side qualifiers on a range

1. With a range, toggle **Approximate** on the start side and **Uncertain** on the end side.
   - **EXPECTED:** Preview shows the qualifier on each side, e.g. `2026-05~/2027-06?`.

### Unspecified digits on one side of a range

1. With a range, enter start `2026`/blank month/`11` with **Approximate**, and end `2027`/`01`.
   - **EXPECTED:** Preview shows `2026-XX-11~/2027-01`. Round-trips on reopen.

### Unknown on one side of a range

1. With a range, toggle **Unknown** on the start side and enter an end date.
   - **EXPECTED:** The start side shows as **Unknown**; Save enabled.

---

## Clearing

### Clear date and time (inline picker)

1. On an item that already has a date, open the inline sidebar picker and click **Clear date and time**, then save.
   - **EXPECTED:** The date is removed from the item (stored value becomes empty/null).

### Clear start / clear end (modal)

1. In the modal with a range, click **Clear start date and time**.
   - **EXPECTED:** Only the start side is cleared.
2. Click **Clear end date and time**.
   - **EXPECTED:** Only the end side is cleared.

---

## Save gating & persistence

### Save disabled while invalid (modal)

1. Enter any invalid value (e.g. month `13`).
   - **EXPECTED:** The **Save** button is disabled, the field shows its specific message inline, and the footer shows the generic error.
2. Correct the value.
   - **EXPECTED:** **Save** becomes enabled and the footer shows the valid preview.

### Cancel discards changes

1. Change a value, then click **Cancel** (or click outside the inline picker).
   - **EXPECTED:** No change is saved; the previously stored value is restored.

### Round-trip persistence

1. For each of: full date, year-only, unspecified month, partial year, approximate/uncertain/combined, unknown, a date range, an open-ended range, and a full date + time — save it, then reopen the item.
   - **EXPECTED:** Each value displays correctly in the sidebar and reopens in the modal with the same fields, qualifiers, and time populated.
  
 ### New folder persistence 
1. Create a new folder and add an edtf date to it.
  - **EXPECTED:** Value displays correctly in the sidebar.
2. Change the date on the folder
  - **EXPECTED:** The new value displays correctly in the sidebar and modal, with no general error or BE error.
