### PR TITLE
[PER-10476] Skip folder fetches for synthetic folders without a folderId

### DIFF
--- a/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DataService } from '@shared/services/data/data.service';
 import { EditService } from '@core/services/edit/edit.service';
 import { AccountService } from '@shared/services/account/account.service';
-import { ArchiveVO, RecordVO } from '@models/index';
+import { ArchiveVO, FolderVO, RecordVO } from '@models/index';
 import { GetThumbnailPipe } from '@shared/pipes/get-thumbnail.pipe';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { DateTimeModel } from '@shared/services/edtf-service/edtf.service';
@@ -653,6 +653,47 @@ describe('SidebarComponent', () => {
 			closedSubject.next(undefined);
 
 			expect(saveSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('current folder full-data fetch', () => {
+		const originalCurrentFolder = mockDataService.currentFolder;
+		let fetchFullItemsSpy: jasmine.Spy;
+
+		beforeEach(() => {
+			fetchFullItemsSpy = spyOn(mockDataService, 'fetchFullItems');
+		});
+
+		afterEach(() => {
+			mockDataService.currentFolder = originalCurrentFolder;
+		});
+
+		it('should not fetch a synthetic root folder that has no folderId', async () => {
+			mockDataService.currentFolder = new FolderVO({
+				displayName: 'Shares',
+				pathAsText: ['Shares'],
+				type: 'type.folder.root.share',
+				ChildItemVOs: [],
+			});
+
+			selectedItemsSubject.next(new Set());
+			await fixture.whenStable();
+
+			expect(fetchFullItemsSpy).not.toHaveBeenCalled();
+		});
+
+		it('should fetch the current folder when it has a folderId and no displayTime', async () => {
+			mockDataService.currentFolder = new FolderVO({
+				folderId: 42,
+				type: 'type.folder.private',
+			});
+
+			selectedItemsSubject.next(new Set());
+			await fixture.whenStable();
+
+			expect(fetchFullItemsSpy).toHaveBeenCalledWith([
+				mockDataService.currentFolder,
+			]);
 		});
 	});
 });

--- a/src/app/file-browser/components/sidebar/sidebar.component.ts
+++ b/src/app/file-browser/components/sidebar/sidebar.component.ts
@@ -147,8 +147,11 @@ export class SidebarComponent implements OnDestroy, HasSubscriptions {
 						this.isLoading = false;
 					}
 				} else if (
+					// Synthetic root folders (e.g. the Shares workspace) have no
+					// folderId, so there is nothing to fetch for them.
 					this.selectedItem?.isFolder &&
-					!this.selectedItem?.displayTime
+					this.selectedItem.folderId &&
+					!this.selectedItem.displayTime
 				) {
 					await this.dataService.fetchFullItems([this.selectedItem]);
 				}

--- a/src/app/shared/services/api/folder.repo.spec.ts
+++ b/src/app/shared/services/api/folder.repo.spec.ts
@@ -372,5 +372,27 @@ describe('Folder repo', () => {
 
 			expect(folders[0]).toBeDefined();
 		});
+
+		it('should not issue a request when no folder has a folderId', async () => {
+			const syntheticFolder = new FolderVO({ type: 'type.folder.root.share' });
+
+			const result = await folderRepo.getStelaFolderVOs([syntheticFolder]);
+
+			expect(httpV2Spy.get).not.toHaveBeenCalled();
+			expect(result.getFolderVOs().length).toBe(0);
+		});
+
+		it('should query only the folders that have a folderId', async () => {
+			const folderWithId = new FolderVO({ folderId: 123 });
+			const folderWithoutId = new FolderVO({ type: 'type.folder.root.share' });
+
+			httpV2Spy.get.and.returnValue(of([{ items: [mockStelaFolder] }]));
+
+			await folderRepo.getStelaFolderVOs([folderWithId, folderWithoutId]);
+
+			expect(httpV2Spy.get).toHaveBeenCalledWith('v2/folder', {
+				folderIds: [123],
+			});
+		});
 	});
 });

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -198,8 +198,14 @@ export class FolderRepo extends BaseRepo {
 		folderVOs: FolderVO[],
 		shareToken: string = null,
 	): Promise<StelaFolder[]> {
+		const validFolderIds = folderVOs
+			.map((currentFolder) => currentFolder.folderId)
+			.filter((folderId) => folderId != null);
+		if (!validFolderIds.length) {
+			return [];
+		}
 		const queryData = {
-			folderIds: folderVOs.map((currentFolder) => currentFolder.folderId),
+			folderIds: validFolderIds,
 		};
 		let folderResponse: PagedStelaResponse<StelaFolder>;
 		if (shareToken) {


### PR DESCRIPTION
Opening /app/shares triggered GET /api/v2/folder?folderIds[]=undefined (500): the sidebar fetched the current folder to get its displayTime, but the Shares workspace is a synthetic FolderVO with no folderId. Guard the sidebar fetch so only folders with a real folderId are requested, and filter invalid ids in FolderRepo.getStelaFolders, skipping the request entirely when none remain.

This is just a small bug that I found, not the full story.

Issue: PER-10476
Subtask: [PER-10676](https://permanent.atlassian.net/browse/PER-10676)

# Manual test cases — Shares page `folderIds[]=undefined` fix need

### Shares page load

1. Navigate to `/app/shares`(make sure you have no shared items) and filter the Network tab(after you inspected the element) by `v2/folder`.
   - **EXPECTED:** no request containing `folderIds[]=undefined` is sent, no 500 response
2. Look at the page content.

### Sidebar on the Shares page

1. With nothing selected on `/app/shares`, open the sidebar.
   - **EXPECTED:** the sidebar shows the Shares workspace info without triggering any folder request or console error.
2. Click a shared **folder** in the list.
   - **EXPECTED:** the sidebar loads its full details (name, date, size) via a request with a real numeric id, e.g. `folderIds[]=149939` — never `undefined`.
3. Click a shared **file** in the list.
   - **EXPECTED:** the sidebar loads the record details normally, with no `v2/folder` request at all.

### Regression — My Files

1. Go to `/app/private`, open any folder, and leave nothing selected so the sidebar shows the current folder.
   - **EXPECTED:** the sidebar still shows the folder's date; if a fetch is needed it uses the folder's real id in `folderIds[]`.
2. Set a date on a folder via the sidebar, then clear it.
   - **EXPECTED:** saving and clearing still work; after clearing, the date field shows empty without console errors.


[PER-10676]: https://permanent.atlassian.net/browse/PER-10676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ