### PR TITLE
[PER-10476] [3] Migrate publish dialog and fix title crash for Stela folders

### DIFF
--- a/src/app/file-browser/components/publish/publish.component.html
+++ b/src/app/file-browser/components/publish/publish.component.html
@@ -1,11 +1,7 @@
 <div class="dialog-content">
 	<div class="dialog-body">
 		<div class="page-title break-all">
-			{{
-				this.sourceItem.folder_linkType.includes('public')
-					? 'Get public link for'
-					: 'Publish'
-			}}
+			{{ isPublicSourceItem ? 'Get public link for' : 'Publish' }}
 			{{ sourceItem.displayName }}
 		</div>
 		@if (publicLink) {

--- a/src/app/file-browser/components/publish/publish.component.spec.ts
+++ b/src/app/file-browser/components/publish/publish.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AccountService } from '@shared/services/account/account.service';
 import { FolderVO, RecordVO } from '@models/index';
 import { FolderResponse } from '@shared/services/api/folder.repo';
-import { Observable } from 'rxjs';
 import { MessageService } from '@shared/services/message/message.service';
 import { EventService } from '@shared/services/event/event.service';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
@@ -33,8 +32,6 @@ const mockApiService = {
 			folderVOs: FolderVO[],
 			destination: FolderVO,
 		): Promise<FolderResponse> => await Promise.resolve(new FolderResponse({})),
-		navigateLean: (folder: FolderVO): Observable<FolderResponse> =>
-			new Observable<FolderResponse>(),
 	},
 	publish: {
 		getInternetArchiveLink: async () => ({
@@ -64,7 +61,9 @@ describe('PublishComponent', () => {
 				{
 					provide: DIALOG_DATA,
 					useValue: {
-						item: { folder_linkType: 'linkType' },
+						// No folder_linkType, like items loaded through the Stela
+						// API, which omits it.
+						item: { type: 'type.folder.generic', displayName: 'Test Item' },
 					},
 				},
 				{ provide: DialogRef, useClass: MockDialogRef },
@@ -92,6 +91,14 @@ describe('PublishComponent', () => {
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	it('should show the publish title when the item has no folder_linkType', () => {
+		const title = fixture.nativeElement.querySelector('.page-title');
+
+		expect(component.isPublicSourceItem).toBeFalse();
+		expect(title.textContent).toContain('Publish');
+		expect(title.textContent).toContain('Test Item');
 	});
 
 	it('should disaple the public to internet archive button if the user does not have the correct access role', () => {

--- a/src/app/file-browser/components/publish/publish.component.ts
+++ b/src/app/file-browser/components/publish/publish.component.ts
@@ -8,7 +8,6 @@ import { PublicLinkPipe } from '@shared/pipes/public-link.pipe';
 import { AccountService } from '@shared/services/account/account.service';
 import { GoogleAnalyticsService } from '@shared/services/google-analytics/google-analytics.service';
 import { EVENTS } from '@shared/services/google-analytics/events';
-import { FolderResponse } from '@shared/services/api/index.repo';
 import { PublicRoutePipe } from '@shared/pipes/public-route.pipe';
 import { Router } from '@angular/router';
 import { PublishIaData } from '@models/publish-ia-vo';
@@ -33,6 +32,7 @@ export class PublishComponent {
 	public linkCopied = false;
 	public iaLinkCopied = false;
 	public isAtleastManager = false;
+	public isPublicSourceItem = false;
 
 	@ViewChild('publicLinkInput', { static: false }) publicLinkInput: ElementRef;
 	@ViewChild('iaLinkInput', { static: false }) iaLinkInput: ElementRef;
@@ -55,7 +55,11 @@ export class PublishComponent {
 		this.isAtleastManager =
 			this.getRole().includes('manager') || this.getRole().includes('owner');
 
-		if (this.sourceItem?.folder_linkType?.includes('public')) {
+		this.isPublicSourceItem =
+			!!this.sourceItem?.type?.includes('public') ||
+			!!this.sourceItem?.folder_linkType?.includes('public');
+
+		if (this.isPublicSourceItem) {
 			this.publicItem = this.sourceItem;
 			this.publicLink = this.linkPipe.transform(this.publicItem);
 			this.checkInternetArchiveLink();
@@ -80,9 +84,9 @@ export class PublishComponent {
 				let tries = 0;
 				while (!this.publicItem && tries < 10) {
 					tries += 1;
-					const publicRootResponse = (await this.api.folder
-						.navigateLean(publicRoot)
-						.toPromise()) as FolderResponse;
+					const publicRootResponse = await this.api.folder.getWithChildren([
+						publicRoot,
+					]);
 					const publicRootFull = publicRootResponse.getFolderVO(true);
 					const publicFolders: FolderVO[] = publicRootFull.ChildItemVOs.filter(
 						(i) => i instanceof FolderVO,


### PR DESCRIPTION
Issue: PER-10476
Subtask: https://permanent.atlassian.net/browse/PER-10679

# Do not merge before #1089 

# Manual test cases — Publish dialog migration and title crash fix

**Setup:** log in on an archive with at least one private folder (with items), one private record, and one already-published item.
**EXPECTED:** only the Publish dialog is affected by this PR — opening it, its title, and the folder publish flow.

---

### Dialog title — private items

1. Open Publish on a private **folder** and keep the browser console open.
   - **EXPECTED:** The title reads "Publish <folder name>" and no `TypeError`s appear in the console. *(Bug fix — the template read `folder_linkType` unguarded, which folders loaded through the Stela API don't have, causing a repeating TypeError on every change detection cycle.)*
2. Open Publish on a private **record**.
   - **EXPECTED:** The title reads "Publish <record name>" with no console errors.

### Dialog title — already-public item

1. Open Publish on an item that is already public.
   - **EXPECTED:** The title reads "Get public link for <name>" and the public link is shown immediately.
2. Click "Copy link".
   - **EXPECTED:** The link is copied and the button changes to "Link copied".

### Publishing a folder

1. Open Publish on a private folder with items and click Publish.
   - **EXPECTED:** The spinner resolves and a public link appears (the dialog polls the Public workspace through the new endpoint to find the copy).
2. Follow the generated link.
   - **EXPECTED:** The public copy opens. *(Known open issue: the copy may appear empty — under investigation with the backend team; if it reproduces, capture the `v2/folder/{id}/children` response.)*

### Publishing a record

1. Open Publish on a private record and click Publish.
   - **EXPECTED:** A public link appears; following it opens the record in the public view.
