### PR TITLE
[PER-10476] [4] Migrate refreshCurrentFolder and remove navigateLean

### DIFF
--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -407,18 +407,6 @@ export class FolderRepo extends BaseRepo {
 		});
 	}
 
-	public navigateLean(folderVO: FolderVO): Observable<FolderResponse> {
-		const data = [
-			{
-				FolderVO: new FolderVO(folderVO),
-			},
-		];
-
-		return this.http.sendRequest<FolderResponse>('/folder/navigateLean', data, {
-			ResponseClass: FolderResponse,
-		});
-	}
-
 	public async post(folderVOs: FolderVO[]): Promise<FolderResponse> {
 		const data = folderVOs.map((folderVO) => ({
 			FolderVO: new FolderVO(folderVO),

--- a/src/app/shared/services/data/data.service.spec.ts
+++ b/src/app/shared/services/data/data.service.spec.ts
@@ -7,8 +7,6 @@ import { DataService } from '@shared/services/data/data.service';
 import { FolderVO, RecordVO } from '@root/app/models';
 import { FolderResponse } from '@shared/services/api/index.repo';
 import { of } from 'rxjs';
-import { HttpTestingController } from '@angular/common/http/testing';
-import { environment } from '@root/environments/environment';
 import { DataStatus } from '@models/data-status.enum';
 
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
@@ -236,9 +234,12 @@ describe('DataService', () => {
 		await service.fetchFullItems([]);
 	});
 
-	it('should refresh the current folder with latest data', (done) => {
+	it('should refresh the current folder with latest data', async () => {
 		const service = TestBed.inject(DataService);
-		const httpMock = TestBed.inject(HttpTestingController);
+		const api = TestBed.inject(ApiService);
+		spyOn(api.folder, 'getWithChildren').and.resolveTo(
+			new FolderResponse(navigateMinData),
+		);
 		const navigateResponse = new FolderResponse(navigateMinData);
 		const currentFolder = navigateResponse.getFolderVO(true) as FolderVO;
 		const childItemCount = currentFolder.ChildItemVOs.length;
@@ -246,16 +247,9 @@ describe('DataService', () => {
 		currentFolder.ChildItemVOs = [];
 		service.setCurrentFolder(currentFolder);
 
-		service
-			.refreshCurrentFolder()
-			.then(() => {
-				expect(currentFolder.ChildItemVOs.length).toBe(childItemCount);
-				done();
-			})
-			.catch(done.fail);
+		await service.refreshCurrentFolder();
 
-		const req = httpMock.expectOne(`${environment.apiUrl}/folder/navigateLean`);
-		req.flush(navigateMinData);
+		expect(currentFolder.ChildItemVOs.length).toBe(childItemCount);
 	});
 
 	it('should add items to thumbRefreshQueue that meet the criteria', (done) => {

--- a/src/app/shared/services/data/data.service.ts
+++ b/src/app/shared/services/data/data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, EventEmitter } from '@angular/core';
-import { map } from 'rxjs/operators';
 import { remove, find, findIndex } from 'lodash';
 
 import { ApiService } from '@shared/services/api/api.service';
@@ -376,27 +375,22 @@ export class DataService {
 	public async refreshCurrentFolder(sortOnly = false) {
 		this.debug('refreshCurrentFolder (sortOnly = %o)', sortOnly);
 
-		return await this.api.folder
-			.navigateLean(this.currentFolder)
-			.pipe(
-				map((response: FolderResponse) => {
-					this.debug('refreshCurrentFolder data fetched', sortOnly);
+		const response: FolderResponse = await this.api.folder.getWithChildren([
+			this.currentFolder,
+		]);
 
-					if (!response.isSuccessful) {
-						throw response;
-					}
+		this.debug('refreshCurrentFolder data fetched', sortOnly);
 
-					return response.getFolderVO(true);
-				}),
-			)
-			.toPromise()
-			.then((updatedFolder: FolderVO) => {
-				this.updateChildItems(this.currentFolder, updatedFolder, sortOnly);
-				this.hideItemsInCurrentFolder();
-				this.debug('refreshCurrentFolder done', sortOnly);
-				this.folderUpdate.emit(this.currentFolder);
-				this.currentHiddenItems = [];
-			});
+		if (!response.isSuccessful) {
+			throw response;
+		}
+
+		const updatedFolder = response.getFolderVO(true);
+		this.updateChildItems(this.currentFolder, updatedFolder, sortOnly);
+		this.hideItemsInCurrentFolder();
+		this.debug('refreshCurrentFolder done', sortOnly);
+		this.folderUpdate.emit(this.currentFolder);
+		this.currentHiddenItems = [];
 	}
 
 	public updateChildItems(


### PR DESCRIPTION
Issue: PER-10476
Subtask: https://permanent.atlassian.net/browse/PER-10680

# Do not merge before #1090 

# Manual test cases — refreshCurrentFolder migration and navigateLean removal

**Setup:** log in on an archive with a folder containing several items.
**EXPECTED:** this PR affects the folder refresh that runs after content operations, and removes the last usage of the v1 `/folder/navigateLean` endpoint.

---

### Folder refresh after content operations

1. Upload a file into a folder.
   - **EXPECTED:** The listing refreshes and shows the new file without a manual reload.
2. Rename an item in the folder.
   - **EXPECTED:** The new name appears after the refresh.
3. Move an item to another folder, then move it back.
   - **EXPECTED:** The listing updates correctly after each move.
4. Delete an item.
   - **EXPECTED:** The item disappears from the listing.
5. Change the sort order of the folder.
   - **EXPECTED:** The list re-sorts, and the order persists after navigating away and back.

### Refresh failure handling

1. With the folder open, go offline (DevTools > Network > Offline) and upload/rename an item, then go back online.
   - **EXPECTED:** An error is surfaced or the operation fails gracefully — no blank listing, no unhandled errors in the console.

### Endpoint removal

1. With the DevTools Network tab open, browse folders, refresh contents (upload/rename), open shares, and use the publish dialog.
   - **EXPECTED:** No request to `/folder/navigateLean` is made anywhere in the app.
