### PR TITLE
[PER-10476] [5] Replace navigateMin with getWithChildren in folder picker

### DIFF
--- a/src/app/core/components/folder-picker/folder-picker.component.spec.ts
+++ b/src/app/core/components/folder-picker/folder-picker.component.spec.ts
@@ -4,14 +4,44 @@ import { cloneDeep, some } from 'lodash';
 
 import { DataService } from '@shared/services/data/data.service';
 import { ApiService } from '@shared/services/api/api.service';
+import { MessageService } from '@shared/services/message/message.service';
 import { FolderResponse } from '@shared/services/api/index.repo';
 import { SharedModule } from '@shared/shared.module';
 import { FolderVO } from '@root/app/models';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
 import { DataStatus } from '@models/data-status.enum';
-import { of } from 'rxjs';
 import { FolderPickerComponent } from './folder-picker.component';
+
+const buildRootFolderResponse = () =>
+	new FolderResponse({
+		isSuccessful: true,
+		Results: [
+			{
+				data: [
+					{
+						FolderVO: {
+							folderId: 1,
+							folder_linkId: 10,
+							type: 'type.folder.root.root',
+							displayName: 'Root',
+							ChildItemVOs: [
+								{ folder_linkId: 11, type: 'type.folder.root.private' },
+								{ folder_linkId: 12, type: 'type.folder.root.app' },
+								{ folder_linkId: 13, type: 'type.folder.root.vault' },
+							],
+						},
+					},
+				],
+			},
+		],
+	});
+
+const buildErrorFolderResponse = (errorMessage: string) => {
+	const errorResponse = new FolderResponse();
+	errorResponse.Results = [{ message: [errorMessage] }];
+	return errorResponse;
+};
 
 describe('FolderPickerComponent', () => {
 	let component: FolderPickerComponent;
@@ -49,13 +79,16 @@ describe('FolderPickerComponent', () => {
 		const navigateMinExpected = require('@root/test/responses/folder.navigateMin.myFiles.success.json');
 		const myFiles = new FolderResponse(navigateMinExpected).getFolderVO();
 
-		spyOn(api.folder, 'navigate').and.returnValue(
-			of(new FolderResponse(navigateMinExpected)),
-		);
+		// myFiles is type.folder.root.private (not root.root), so setFolder
+		// takes the getWithChildren branch.
+		const getWithChildrenSpy = spyOn(
+			api.folder,
+			'getWithChildren',
+		).and.resolveTo(new FolderResponse(navigateMinExpected));
 
 		await component.setFolder(myFiles);
 
-		expect(api.folder.navigate).toHaveBeenCalledTimes(1);
+		expect(getWithChildrenSpy).toHaveBeenCalledTimes(1);
 		expect(component.currentFolder).toBeTruthy();
 		expect(component.currentFolder.folder_linkId).toEqual(
 			myFiles.folder_linkId,
@@ -64,9 +97,7 @@ describe('FolderPickerComponent', () => {
 		expect(some(component.currentFolder.ChildItemVOs, 'isRecord')).toBeFalsy();
 
 		const getLeanItemsExpected = require('@root/test/responses/folder.getLeanItems.folderPicker.myFiles.success.json');
-		spyOn(api.folder, 'getWithChildren').and.returnValue(
-			Promise.resolve(new FolderResponse(getLeanItemsExpected)),
-		);
+		getWithChildrenSpy.and.resolveTo(new FolderResponse(getLeanItemsExpected));
 
 		await component.loadCurrentFolderChildData();
 
@@ -79,5 +110,51 @@ describe('FolderPickerComponent', () => {
 					childFolder.dataStatus === DataStatus.Placeholder,
 			),
 		).toBeFalsy();
+	});
+
+	it('should load the root folder via getRoot and strip app and vault folders', async () => {
+		const api = TestBed.inject(ApiService) as ApiService;
+		const getRootSpy = spyOn(api.folder, 'getRoot').and.resolveTo(
+			buildRootFolderResponse(),
+		);
+		const getWithChildrenSpy = spyOn(api.folder, 'getWithChildren');
+		const rootFolder = buildRootFolderResponse().getFolderVO();
+
+		await component.setFolder(rootFolder);
+
+		expect(getRootSpy).toHaveBeenCalledTimes(1);
+		expect(getWithChildrenSpy).not.toHaveBeenCalled();
+		expect(component.isRootFolder).toBeTrue();
+		expect(
+			some(component.currentFolder.ChildItemVOs, (item) =>
+				item.type.includes('type.folder.root.app'),
+			),
+		).toBeFalse();
+
+		expect(
+			some(component.currentFolder.ChildItemVOs, (item) =>
+				item.type.includes('type.folder.root.vault'),
+			),
+		).toBeFalse();
+	});
+
+	it('should show an error and leave the current folder unchanged when the response is unsuccessful', async () => {
+		const api = TestBed.inject(ApiService) as ApiService;
+		const message = TestBed.inject(MessageService) as MessageService;
+		spyOn(api.folder, 'getWithChildren').and.resolveTo(
+			buildErrorFolderResponse('Folder not found'),
+		);
+		const showErrorSpy = spyOn(message, 'showError');
+
+		await component.setFolder(
+			new FolderVO({ folderId: 42, type: 'type.folder.private' }),
+		);
+
+		expect(showErrorSpy).toHaveBeenCalledWith({
+			message: 'Folder not found',
+			translate: true,
+		});
+
+		expect(component.currentFolder).toBeFalsy();
 	});
 });

--- a/src/app/core/components/folder-picker/folder-picker.component.ts
+++ b/src/app/core/components/folder-picker/folder-picker.component.ts
@@ -7,6 +7,7 @@ import { FolderResponse } from '@shared/services/api/index.repo';
 import { FolderPickerService } from '@core/services/folder-picker/folder-picker.service';
 import { MessageService } from '@shared/services/message/message.service';
 import { PromptService } from '@shared/services/prompt/prompt.service';
+import { AccountService } from '@shared/services/account/account.service';
 
 export enum FolderPickerOperations {
 	Move = 1,
@@ -46,6 +47,7 @@ export class FolderPickerComponent implements OnDestroy {
 		private message: MessageService,
 		private folderPickerService: FolderPickerService,
 		private prompt: PromptService,
+		private accountService: AccountService,
 	) {
 		this.folderPickerService.registerComponent(this);
 	}
@@ -116,15 +118,33 @@ export class FolderPickerComponent implements OnDestroy {
 	async setFolder(folder: FolderVO) {
 		this.waiting = true;
 		try {
-			const folderResponse = await this.api.folder
-				.navigate(
-					new FolderVO({
-						folder_linkId: folder.folder_linkId,
-						folderId: folder.folderId,
-						archiveNbr: folder.archiveNbr,
-					}),
-				)
-				.toPromise();
+			const rootFolder = this.accountService.getRootFolder();
+			// goToParentFolder reconstructs the root folder with only its ids
+			// (no type), so detect root by type or by identity against the cache.
+			const isRoot =
+				folder.type?.includes('type.folder.root.root') ||
+				(rootFolder &&
+					(folder.folderId === rootFolder.folderId ||
+						folder.folder_linkId === rootFolder.folder_linkId));
+
+			// The root.root folder is a virtual folder that Stela's
+			// getWithChildren does not serve, so keep loading it through getRoot.
+			const folderResponse: FolderResponse = isRoot
+				? await this.api.folder.getRoot()
+				: await this.api.folder.getWithChildren([
+						new FolderVO({
+							folder_linkId: folder.folder_linkId,
+							folderId: folder.folderId,
+							archiveNbr: folder.archiveNbr,
+						}),
+					]);
+
+			// getWithChildren resolves an error-shaped response instead of
+			// rejecting, so surface failures explicitly for the catch below.
+			if (!folderResponse.isSuccessful) {
+				throw folderResponse;
+			}
+
 			this.currentFolder = folderResponse.getFolderVO(true);
 			this.isRootFolder = this.currentFolder.type.includes(
 				'type.folder.root.root',

--- a/src/app/shared/services/api/folder.repo.ts
+++ b/src/app/shared/services/api/folder.repo.ts
@@ -1,6 +1,6 @@
 import { FolderVO, FolderVOData, ItemVO } from '@root/app/models';
 import { BaseResponse, BaseRepo } from '@shared/services/api/base';
-import { firstValueFrom, Observable } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { DataStatus } from '@models/data-status.enum';
 import { ShareLink } from '@root/app/share-links/models/share-link';
 import {
@@ -386,25 +386,6 @@ export class FolderRepo extends BaseRepo {
 			];
 			return errorFolderResponse;
 		}
-	}
-
-	public navigate(folderVO: FolderVO): Observable<FolderResponse> {
-		const response = {
-			...folderVO,
-		};
-		if (folderVO.type === 'type.folder.root.private') {
-			response.displayName = 'Private';
-		}
-
-		const data = [
-			{
-				FolderVO: new FolderVO(response),
-			},
-		];
-
-		return this.http.sendRequest<FolderResponse>('/folder/navigateMin', data, {
-			ResponseClass: FolderResponse,
-		});
 	}
 
 	public async post(folderVOs: FolderVO[]): Promise<FolderResponse> {


### PR DESCRIPTION
Migrate the folder picker off /folder/navigateMin, its last consumer, and remove FolderRepo.navigate. The root.root folder stays on getRoot since Stela does not serve the virtual root.

Issue: PER-10476

# Should not be merged before #1091 

# Manual test cases — Replace navigateMin with getWithChildren

**Setup:** log in on an archive with nested folders and at least one record. The folder picker opens from an item's Move, Copy, and Choose-file actions.
**EXPECTED:** the folder picker now loads folders through the Stela `getWithChildren` endpoint, except the top-level root which still loads through `getRoot`.

---

## Move dialog

1. Select an item and choose Move.
   - **EXPECTED:** The picker opens at the root, listing My Files and Public (not Apps or Vault), and the header shows the root folder name.
2. Click into My Files, then into a subfolder.
   - **EXPECTED:** Each folder's subfolders load and the header name updates.
3. Press Back repeatedly up to the top.
   - **EXPECTED:** The root reloads with My Files and Public — no blank or errored panel.
4. Select a destination folder and confirm the Move.
   - **EXPECTED:** The item moves to the chosen folder and the dialog closes.

## Copy dialog

1. Select an item and choose Copy.
   - **EXPECTED:** The picker opens at the root with the same folders as above.
2. Navigate into a folder, select it, and confirm the Copy.
   - **EXPECTED:** The item is copied to the chosen folder and the dialog closes.

## Choose-file dialog

1. Open the record chooser (Choose file).
   - **EXPECTED:** Both folders and records are listed (records are not stripped).
2. Navigate into a folder and select a record.
   - **EXPECTED:** The record can be selected and confirmed.

## Filtered move

1. Move a folder into the tree.
   - **EXPECTED:** The folder being moved does not appear as a destination option.

## Error handling

1. With the picker open, go offline (DevTools > Network > Offline) and navigate into a folder.
   - **EXPECTED:** An error toast appears — no blank panel and no uncaught error in the console.
