### PR TITLE
[PER-10569] Show downtime banner for scheduled maintenance

### DIFF
--- a/src/app/announcement/data/events.ts
+++ b/src/app/announcement/data/events.ts
@@ -2,6 +2,12 @@ import { AnnouncementEvent } from '../models/announcement-event';
 
 export const ANNOUNCEMENT_EVENTS: AnnouncementEvent[] = [
 	{
+		start: new Date().getTime(),
+		end: new Date('2026-07-28T15:00:00-05:00').getTime(),
+		message:
+			'The Permanent.org platform will be temporarily unavailable on <strong>July 28th, 2026 from approximately 1-3pm Central Time</strong> while we perform routine maintenance. Thank you for your patience.',
+	},
+	{
 		start: new Date('2025-01-29T00:00:00-07:00').getTime(),
 		end: new Date('2025-01-31T03:00:00-07:00').getTime(),
 		message:


### PR DESCRIPTION
Add an announcement event to display a site-wide maintenance banner during the scheduled downtime on July 28th, 1:00-3:00 PM CDT. Reuses the existing time-window-driven Announcement mechanism, so the banner appears and disappears automatically for the window; no feature flag or component changes needed.

Issue: PER-10569

The way I tested this was just to modify the start/end dates locally in the code.

- I changed the start date to be 1 min before the current time, to see that the banner appears.

- Then I modified the end date to be 1 hour in the past, to make sure the banner won't appear after the window is finished.

It is worth mentioning that this banner only appears on a few screens:
<img width="2230" height="1596" alt="image" src="https://github.com/user-attachments/assets/8671a410-ce2f-4c3c-85de-682e828af861" />


For example, it does not appear when you go to an archive's profile:
<img width="2228" height="1878" alt="image" src="https://github.com/user-attachments/assets/b3bf2a6f-49f6-48d3-b4cc-24483422476f" />
