### PR TITLE
[PER-10667] Align public gallery date with detail view

### DIFF
--- a/src/app/file-browser/components/file-list-item/file-list-item.component.spec.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.spec.ts
@@ -389,4 +389,34 @@ describe('FileListItemComponent', () => {
 
 		expect(secondRowDate).toContain('2023-01-01T00:00:00.000Z');
 	});
+
+	it('should base the public-archive date on displayTime when it is set', async () => {
+		component.item.displayTime = '2020-06-10';
+		component.item.displayDT = '2023-01-01T00:00:00.000Z';
+
+		await component.ngOnInit();
+
+		expect(component.date).toContain('2020');
+		expect(component.date).not.toContain('2023');
+	});
+
+	it('should fall back to displayDT for the public-archive date when displayTime is not set', async () => {
+		component.item.displayTime = undefined;
+		component.item.displayDT = '2023-03-15T12:00:00.000Z';
+
+		await component.ngOnInit();
+
+		expect(component.date).toContain('2023');
+	});
+
+	it('should use the interval start for the public-archive date when displayTime is an EDTF interval', async () => {
+		component.item.displayTime = '2020-06-10/2026-06-15';
+		component.item.displayDT = '2023-01-01T00:00:00.000Z';
+
+		await component.ngOnInit();
+
+		expect(component.date).toContain('2020');
+		expect(component.date).not.toContain('2023');
+		expect(component.date).not.toContain('2026');
+	});
 });

--- a/src/app/file-browser/components/file-list-item/file-list-item.component.ts
+++ b/src/app/file-browser/components/file-list-item/file-list-item.component.ts
@@ -260,7 +260,7 @@ export class FileListItemComponent
 
 	async ngOnInit() {
 		this.recordThumbnailUrl = GetThumbnail(this.item);
-		const date = new Date(this.item.displayDT);
+		const date = new Date(this.startDisplayTime);
 		this.date = getFormattedDate(date);
 
 		this.isUnlistedShare = await this.shareLinksService.isUnlistedShare();


### PR DESCRIPTION
The public gallery card rendered its date from displayDT (mapped from the API's displayDate), while the detail sidebar reads displayTime || displayDT. For items where those fields diverge, the gallery showed a different date than the detail panel.

Base the public-archive date on the existing startDisplayTime getter (displayTime with EDTF interval-start handling, falling back to displayDT) so the gallery matches the sidebar's field preference. Add spec coverage for the displayTime, displayDT-fallback, and EDTF-interval cases.

Issue: PER-10667

The dates I have found as being inconsistent with the rest of the app was in the gallery, so I have changed it to displayTime/displayDT:
<img width="2098" height="1858" alt="image" src="https://github.com/user-attachments/assets/a71fe05e-9b03-491b-b213-b265a0551aef" />

The dates in the public folder behave as expected, like in private or shared.
Also, we are not actually supporting a friendly timezone as of now, but we will once the EDTF date will be released.